### PR TITLE
Stream 3: Fix \WP_Stream\List_Table namespace so live updates work correctly

### DIFF
--- a/classes/class-live-update.php
+++ b/classes/class-live-update.php
@@ -176,7 +176,7 @@ class Live_Update {
 		$enable_stream_update = ( 'off' !== $this->plugin->admin->get_user_meta( get_current_user_id(), $this->user_meta_key ) );
 
 		// Register list table
-		$this->list_table = new WP_Stream_List_Table( array( 'screen' => 'toplevel_page_' . $this->plugin->admin->records_page_slug ) );
+		$this->list_table = new List_Table( $this->plugin, array( 'screen' => 'toplevel_page_' . $this->plugin->admin->records_page_slug ) );
 		$this->list_table->prepare_items();
 
 		$total_items = isset( $this->list_table->_pagination_args['total_items'] ) ? $this->list_table->_pagination_args['total_items'] : null;


### PR DESCRIPTION
*(Reposting from #735 to issue PR against `develop` branch instead of `master`)*

On a fresh Stream 3 install, live updates fail silently with the following error:

    PHP Fatal error:  Class 'WP_Stream\\WP_Stream_List_Table' not found in /[...]/wp-content/plugins/stream/classes/class-live-update.php on line 179

Due to PHP's namespaces, this needs to be `\WP_Stream\List_Table` or just `List_Table`, not `WP_Stream_List_Table`. This commit fixes this so live updates work correctly again like they should.