### PR TITLE
Implement a User Switching connector

### DIFF
--- a/classes/class-connector.php
+++ b/classes/class-connector.php
@@ -34,14 +34,11 @@ abstract class Connector {
 	 * Register all context hooks
 	 */
 	public function register() {
-		$class_name = get_called_class();
-		$class = new $class_name;
-
-		foreach ( $class->actions as $action ) {
-			add_action( $action, array( $class, 'callback' ), null, 5 );
+		foreach ( $this->actions as $action ) {
+			add_action( $action, array( $this, 'callback' ), 10, 5 );
 		}
 
-		add_filter( 'wp_stream_action_links_' . $class->name, array( $class, 'action_links' ), 10, 2 );
+		add_filter( 'wp_stream_action_links_' . $this->name, array( $this, 'action_links' ), 10, 2 );
 	}
 
 	/**

--- a/classes/class-connectors.php
+++ b/classes/class-connectors.php
@@ -76,6 +76,7 @@ class Connectors {
 			'edd',
 			'gravityforms',
 			'jetpack',
+			'user-switching',
 			'woocommerce',
 			'wordpress-seo',
 		);

--- a/classes/class-connectors.php
+++ b/classes/class-connectors.php
@@ -178,13 +178,14 @@ class Connectors {
 			);
 		}
 
-		$connectors = $this->term_labels['stream_connector'];
+		$labels = $this->term_labels['stream_connector'];
 
 		/**
 		 * Fires after all connectors have been registered.
 		 *
-		 * @param array $connectors All register connectors labels array
+		 * @param array      $labels     All register connectors labels array
+		 * @param Connectors $connectors The Connectors object
 		 */
-		do_action( 'wp_stream_after_connectors_registration', $connectors );
+		do_action( 'wp_stream_after_connectors_registration', $labels, $this );
 	}
 }

--- a/connectors/class-connector-user-switching.php
+++ b/connectors/class-connector-user-switching.php
@@ -1,0 +1,232 @@
+<?php
+namespace WP_Stream;
+
+class Connector_User_Switching extends Connector {
+
+	/**
+	 * Connector slug
+	 *
+	 * @var string
+	 */
+	public $name = 'user-switching';
+
+	/**
+	 * Actions registered for this connector
+	 *
+	 * @var array
+	 */
+	public $actions = array(
+		'wp_stream_after_connectors_registration',
+		'switch_to_user',
+		'switch_back_user',
+		'switch_off_user',
+	);
+
+	/**
+	 * Check if plugin dependencies are satisfied and add an admin notice if not
+	 *
+	 * @return bool
+	 */
+	public function is_dependency_satisfied() {
+		if ( class_exists( 'user_switching' ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Return translated connector label
+	 *
+	 * @return string Translated connector label
+	 */
+	public function get_label() {
+		return esc_html_x( 'User Switching', 'user-switching', 'stream' );
+	}
+
+	/**
+	 * Return translated action term labels
+	 *
+	 * @return array Action terms label translation
+	 */
+	public function get_action_labels() {
+		return array();
+	}
+
+	/**
+	 * Return translated context labels
+	 *
+	 * @return array Context label translations
+	 */
+	public function get_context_labels() {
+		return array();
+	}
+
+	/**
+	 * Register this connector.
+	 *
+	 * Overrides the default `Connector::register()` method.
+	 *
+	 */
+	public function register() {
+		parent::register();
+
+		add_filter( 'wp_stream_log_data', array( $this, 'log_override' ) );
+	}
+
+	/**
+	 * Override connector log for our own actions
+	 *
+	 * This changes the connector property to the Users connector if the log entry is from
+	 * our User_Switching connector.
+	 *
+	 * @param  array $data The log data.
+	 * @return array The updated log data.
+	 */
+	public function log_override( $data ) {
+		if ( ! is_array( $data ) ) {
+			return $data;
+		}
+
+		if ( 'User_Switching' === $data['connector'] ) {
+			$data['connector'] = 'Users';
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Fired after Stream has instantiated all of its connectors.
+	 *
+	 * This unhooks the Users connector's login and logout actions so they don't appear when a user switches
+	 * user with the User Switching plugin.
+	 *
+	 * @param array      $labels     All registered connector labels
+	 * @param Connectors $connectors The Connectors object instance
+	 */
+	public function callback_wp_stream_after_connectors_registration( array $labels, Connectors $connectors ) {
+
+		if ( ! isset( $_REQUEST['action'] ) ) {
+			return;
+		}
+
+		switch ( $_REQUEST['action'] ) {
+
+			case 'switch_to_user':
+				$this->unhook_user_action( $connectors, 'clear_auth_cookie' );
+				$this->unhook_user_action( $connectors, 'set_logged_in_cookie' );
+				break;
+
+			case 'switch_to_olduser':
+				$this->unhook_user_action( $connectors, 'clear_auth_cookie' );
+				$this->unhook_user_action( $connectors, 'set_logged_in_cookie' );
+				break;
+
+			case 'switch_off':
+				$this->unhook_user_action( $connectors, 'clear_auth_cookie' );
+				break;
+
+		}
+
+	}
+
+	/**
+	 * Fired when a user switches user with the User Switching plugin.
+	 *
+	 * @param int $user_id     The ID of the user being switched to.
+	 * @param int $old_user_id The ID of the user being switched from.
+	 */
+	public function callback_switch_to_user( $user_id, $old_user_id ) {
+
+		$user     = get_userdata( $user_id );
+		$old_user = get_userdata( $old_user_id );
+		$message  = _x(
+			'Switched user to %1$s (%2$s)',
+			'1: User display name, 2: User login',
+			'stream'
+		);
+
+		$this->log(
+			$message,
+			array(
+				'display_name' => $user->display_name,
+				'user_login'   => $user->user_login,
+			),
+			$old_user->ID,
+			'sessions',
+			'switched-to',
+			$old_user->ID
+		);
+
+	}
+
+	/**
+	 * Fired when a user switches back to their previous user account with the User Switching plugin.
+	 *
+	 * @param int       $user_id     The ID of the user being switched back to.
+	 * @param int|false $old_user_id The ID of the user being switched from, or false if the user is switching back
+	 *                               after having been switched off.
+	 */
+	public function callback_switch_back_user( $user_id, $old_user_id ) {
+
+		$user     = get_userdata( $user_id );
+		$old_user = get_userdata( $old_user_id );
+		$message  = _x(
+			'Switched back to %1$s (%2$s)',
+			'1: User display name, 2: User login',
+			'stream'
+		);
+
+		$this->log(
+			$message,
+			array(
+				'display_name' => $user->display_name,
+				'user_login'   => $user->user_login,
+			),
+			$old_user->ID,
+			'sessions',
+			'switched-back',
+			$old_user->ID
+		);
+
+	}
+
+	/**
+	 * Fired when a user switches off with the User Switching plugin.
+	 *
+	 * @param int $old_user_id The ID of the user switching off.
+	 */
+	public function callback_switch_off_user( $old_user_id ) {
+
+		$old_user = get_userdata( $old_user_id );
+		$message  = __(
+			'Switched off',
+			'stream'
+		);
+
+		$this->log(
+			$message,
+			array(),
+			$old_user->ID,
+			'sessions',
+			'switched-off',
+			$old_user->ID
+		);
+
+	}
+
+	/**
+	 * Unhook the requested action from the Users connector.
+	 *
+	 * @param Connectors $connectors The Connectors instance
+	 * @param string     $action     The name of the action to unhook
+	 */
+	protected function unhook_user_action( Connectors $connectors, $action ) {
+		foreach ( $connectors->connectors as $connector ) {
+			if ( 'users' === $connector->name ) {
+				remove_action( $action, array( $connector, 'callback' ) );
+			}
+		}
+	}
+
+}

--- a/connectors/class-connector-user-switching.php
+++ b/connectors/class-connector-user-switching.php
@@ -170,12 +170,17 @@ class Connector_User_Switching extends Connector {
 	public function callback_switch_back_user( $user_id, $old_user_id ) {
 
 		$user     = get_userdata( $user_id );
-		$old_user = get_userdata( $old_user_id );
 		$message  = _x(
 			'Switched back to %1$s (%2$s)',
 			'1: User display name, 2: User login',
 			'stream'
 		);
+
+		if ( $old_user_id ) {
+			$old_user = get_userdata( $old_user_id );
+		} else {
+			$old_user = $user;
+		}
 
 		$this->log(
 			$message,

--- a/connectors/class-connector-users.php
+++ b/connectors/class-connector-users.php
@@ -55,6 +55,9 @@ class Connector_Users extends Connector {
 			'forgot-password' => esc_html__( 'Lost Password', 'stream' ),
 			'login'           => esc_html__( 'Log In', 'stream' ),
 			'logout'          => esc_html__( 'Log Out', 'stream' ),
+			'switched-to'     => esc_html__( 'Switched To', 'stream' ),
+			'switched-back'   => esc_html__( 'Switched Back', 'stream' ),
+			'switched-off'    => esc_html__( 'Switched Off', 'stream' ),
 		);
 	}
 


### PR DESCRIPTION
This adds a new connector which integrates with the [User Switching](https://wordpress.org/plugins/user-switching/) plugin.

Stream works fine with User Switching (see #501), but it's a little sub-optimal. When you switch user, two entries get logged, one for the logout action and one for the login action.

This connector uses the actions that the User Switching plugin fires to more accurately log the actions performed (eg. `Switched user to editor (Editor)`), and also unhooks the default Users connector actions so the logout and login actions aren't logged. The connector also logs its actions under the Users context rather than its own.

New actions that are introduced:

 * Switched User ([`switch_to_user` action](https://github.com/johnbillion/user-switching/blob/1.0.8/user-switching.php#L888-L896))
 * Switched Back ([`switch_back_user` action](https://github.com/johnbillion/user-switching/blob/1.0.8/user-switching.php#L888-L896))
 * Switched Off ([`switch_off` action](https://github.com/johnbillion/user-switching/blob/1.0.8/user-switching.php#L888-L896))

--

I've had to make two small changes Stream's `Connector` and `Connectors` classes in addition to adding the new connector. Currently, it's impossible to unhook a connector's actions due to [the anonymous instance of each connector which gets instantiated inside itself](https://github.com/xwp/stream/blob/master/classes/class-connector.php#L37-L42). There's no need for this, so I've switched to using `$this`.

In addition, I've added `$this` as a parameter to the `wp_stream_after_connectors_registration` action so a connector can use it to unhook actions attached to any of its connectors. This is necessary because the `connectors` property on the global `$wp_stream` object hasn't been populated at this point.