### PR TITLE
Gravity forms connector update

### DIFF
--- a/connectors/class-connector-gravityforms.php
+++ b/connectors/class-connector-gravityforms.php
@@ -1,9 +1,7 @@
 <?php
-
 namespace WP_Stream;
 
 class Connector_GravityForms extends Connector {
-
 	/**
 	 * Connector slug
 	 *

--- a/connectors/class-connector-gravityforms.php
+++ b/connectors/class-connector-gravityforms.php
@@ -180,31 +180,25 @@ class Connector_GravityForms extends Connector {
 		parent::register();
 
 		$this->options = array(
-			'rg_gforms_disable_css' => array(
+			'rg_gforms_disable_css'        => array(
 				'label' => esc_html_x( 'Output CSS', 'gravityforms', 'stream' ),
 			),
-
-			'rg_gforms_enable_html5' => array(
+			'rg_gforms_enable_html5'       => array(
 				'label' => esc_html_x( 'Output HTML5', 'gravityforms', 'stream' ),
 			),
-
-			'gform_enable_noconflict' => array(
+			'gform_enable_noconflict'      => array(
 				'label' => esc_html_x( 'No-Conflict Mode', 'gravityforms', 'stream' ),
 			),
-
-			'rg_gforms_currency' => array(
+			'rg_gforms_currency'           => array(
 				'label' => esc_html_x( 'Currency', 'gravityforms', 'stream' ),
 			),
-
-			'rg_gforms_captcha_public_key' => array(
+			'rg_gforms_captcha_public_key'  => array(
 				'label' => esc_html_x( 'reCAPTCHA Public Key', 'gravityforms', 'stream' ),
 			),
-
 			'rg_gforms_captcha_private_key' => array(
 				'label' => esc_html_x( 'reCAPTCHA Private Key', 'gravityforms', 'stream' ),
 			),
-
-			'rg_gforms_key' => null,
+			'rg_gforms_key'                 => null,
 		);
 	}
 

--- a/connectors/class-connector-gravityforms.php
+++ b/connectors/class-connector-gravityforms.php
@@ -25,22 +25,23 @@ class Connector_GravityForms extends Connector {
 		'gform_after_save_form',
 		'gform_pre_confirmation_save',
 		'gform_pre_notification_save',
-		'gform_notification_delete',
-		'gform_confirmation_delete',
+		'gform_pre_notification_deleted',
+		'gform_pre_confirmation_deleted',
 		'gform_notification_status',
 		'gform_confirmation_status',
-		'gform_form_status_change',
-		'gform_form_reset_views',
 		'gform_before_delete_form',
 		'gform_post_form_trashed',
-		'gform_form_restore',
-		'gform_form_duplicate',
-		'gform_export_separator', // Export entries
-		'gform_export_options', // Export forms
+		'gform_post_form_restored',
+		'gform_post_form_activated',
+		'gform_post_form_deactivated',
+		'gform_post_form_duplicated',
+		'gform_post_form_views_deleted',
+		'gform_export_lines', // Export entries
+		'gform_export_form', // Export forms
 		'gform_import_form_xml_options', // Import
 		'gform_delete_lead',
-		'gform_insert_note',
-		'gform_delete_note',
+		'gform_post_note_added',
+		'gform_pre_note_deleted',
 		'gform_update_status',
 		'gform_update_is_read',
 		'gform_update_is_starred',
@@ -95,15 +96,18 @@ class Connector_GravityForms extends Connector {
 	 */
 	public function get_action_labels() {
 		return array(
-			'created'    => esc_html_x( 'Created', 'gravityforms', 'stream' ),
-			'updated'    => esc_html_x( 'Updated', 'gravityforms', 'stream' ),
-			'exported'   => esc_html_x( 'Exported', 'gravityforms', 'stream' ),
-			'imported'   => esc_html_x( 'Imported', 'gravityforms', 'stream' ),
-			'added'      => esc_html_x( 'Added', 'gravityforms', 'stream' ),
-			'deleted'    => esc_html_x( 'Deleted', 'gravityforms', 'stream' ),
-			'trashed'    => esc_html_x( 'Trashed', 'gravityforms', 'stream' ),
-			'untrashed'  => esc_html_x( 'Restored', 'gravityforms', 'stream' ),
-			'duplicated' => esc_html_x( 'Duplicated', 'gravityforms', 'stream' ),
+			'created'       => esc_html_x( 'Created', 'gravityforms', 'stream' ),
+			'updated'       => esc_html_x( 'Updated', 'gravityforms', 'stream' ),
+			'exported'      => esc_html_x( 'Exported', 'gravityforms', 'stream' ),
+			'imported'      => esc_html_x( 'Imported', 'gravityforms', 'stream' ),
+			'added'         => esc_html_x( 'Added', 'gravityforms', 'stream' ),
+			'deleted'       => esc_html_x( 'Deleted', 'gravityforms', 'stream' ),
+			'trashed'       => esc_html_x( 'Trashed', 'gravityforms', 'stream' ),
+			'untrashed'     => esc_html_x( 'Restored', 'gravityforms', 'stream' ),
+			'duplicated'    => esc_html_x( 'Duplicated', 'gravityforms', 'stream' ),
+			'activated'     => esc_html_x( 'Activated', 'gravityforms', 'stream' ),
+			'deactivated'   => esc_html_x( 'Deactivated', 'gravityforms', 'stream' ),
+			'views_deleted' => esc_html_x( 'Views Reset', 'gravityforms', 'stream' ),
 		);
 	}
 
@@ -298,7 +302,7 @@ class Connector_GravityForms extends Connector {
 	 * @param array $notification
 	 * @param array $form
 	 */
-	public function callback_gform_notification_delete( $notification, $form ) {
+	public function callback_gform_pre_notification_deleted( $notification, $form ) {
 		$this->log(
 			sprintf(
 				__( '"%1$s" notification deleted from "%2$s"', 'stream' ),
@@ -321,7 +325,7 @@ class Connector_GravityForms extends Connector {
 	 * @param array $confirmation
 	 * @param array $form
 	 */
-	public function callback_gform_confirmation_delete( $confirmation, $form ) {
+	public function callback_gform_pre_confirmation_deleted( $confirmation, $form ) {
 		$this->log(
 			sprintf(
 				__( '"%1$s" confirmation deleted from "%2$s"', 'stream' ),
@@ -365,26 +369,6 @@ class Connector_GravityForms extends Connector {
 	}
 
 	/**
-	 * Track status change of confirmations
-	 *
-	 * @param integer $id
-	 */
-	public function callback_gform_form_reset_views( $id ) {
-		$form = $this->get_form( $id );
-
-		$this->log(
-			__( '"%s" form views reset', 'stream' ),
-			array(
-				'title'   => $form['title'],
-				'form_id' => $form['id'],
-			),
-			$form['id'],
-			'forms',
-			'updated'
-		);
-	}
-
-	/**
 	 * Track status change of notifications
 	 *
 	 * @param array $notification
@@ -407,37 +391,6 @@ class Connector_GravityForms extends Connector {
 			$form['id'],
 			'forms',
 			'updated'
-		);
-	}
-
-	/**
-	 * Track status change of forms
-	 *
-	 * @param integer $id
-	 * @param string $action
-	 */
-	public function callback_gform_form_status_change( $id, $action ) {
-		$form    = $this->get_form( $id );
-		$actions = array(
-			'activated'   => esc_html__( 'Activated', 'stream' ),
-			'deactivated' => esc_html__( 'Deactivated', 'stream' ),
-			'trashed'     => esc_html__( 'Trashed', 'stream' ),
-			'untrashed'   => esc_html__( 'Restored', 'stream' ),
-		);
-
-		$this->log(
-			sprintf(
-				__( '"%1$s" form %2$s', 'stream' ),
-				$form['title'],
-				$actions[ $action ]
-			),
-			array(
-				'form_title' => $form['title'],
-				'form_id'    => $id,
-			),
-			$form['id'],
-			'forms',
-			$action
 		);
 	}
 
@@ -551,39 +504,6 @@ class Connector_GravityForms extends Connector {
 		return $dummy;
 	}
 
-	public function callback_gform_before_delete_form( $id ) {
-		$form = $this->get_form( $id );
-
-		$this->log(
-			__( '"%s" form deleted', 'stream' ),
-			array(
-				'form_title' => $form['title'],
-				'form_id'    => $id,
-			),
-			$form['id'],
-			'forms',
-			'deleted'
-		);
-	}
-
-	public function callback_gform_form_duplicate( $id, $new_id ) {
-		$form = $this->get_form( $id );
-		$new  = $this->get_form( $new_id );
-
-		$this->log(
-			__( '"%1$s" form created as duplicate from "%2$s"', 'stream' ),
-			array(
-				'new_form_title' => $new['title'],
-				'form_title'     => $form['title'],
-				'form_id'        => $id,
-				'new_id'         => $new_id,
-			),
-			$new_id,
-			'forms',
-			'duplicated'
-		);
-	}
-
 	public function callback_gform_delete_lead( $lead_id ) {
 		$lead = \GFFormsModel::get_lead( $lead_id );
 		$form = $this->get_form( $lead['form_id'] );
@@ -601,7 +521,7 @@ class Connector_GravityForms extends Connector {
 		);
 	}
 
-	public function callback_gform_insert_note( $note_id, $lead_id, $user_id, $user_name, $note, $note_type ) {
+	public function callback_gform_post_note_added( $note_id, $lead_id, $user_id, $user_name, $note, $note_type ) {
 		$lead = \GFFormsModel::get_lead( $lead_id );
 		$form = $this->get_form( $lead['form_id'] );
 
@@ -619,7 +539,7 @@ class Connector_GravityForms extends Connector {
 		);
 	}
 
-	public function callback_gform_delete_note( $note_id, $lead_id ) {
+	public function callback_gform_pre_note_deleted( $note_id, $lead_id ) {
 		$lead = \GFFormsModel::get_lead( $lead_id );
 		$form = $this->get_form( $lead['form_id'] );
 
@@ -722,18 +642,70 @@ class Connector_GravityForms extends Connector {
 		);
 	}
 
-	public function callback_gform_post_form_trashed( $id ) {
-		$form = $this->get_form( $id );
+	public function callback_gform_before_delete_form( $form_id ) {
+		$this->log_form_action( $form_id, 'deleted' );
+	}
+
+	public function callback_gform_post_form_trashed( $form_id ) {
+		$this->log_form_action( $form_id, 'trashed' );
+	}
+
+	public function callback_gform_post_form_restored( $form_id ) {
+		$this->log_form_action( $form_id, 'untrashed' );
+	}
+
+	public function callback_gform_post_form_activated( $form_id ) {
+		$this->log_form_action( $form_id, 'activated' );
+	}
+
+	public function callback_gform_post_form_deactivated( $form_id ) {
+		$this->log_form_action( $form_id, 'deactivated' );
+	}
+
+	public function callback_gform_post_form_duplicated( $form_id ) {
+		$this->log_form_action( $form_id, 'duplicated' );
+	}
+
+	public function callback_gform_post_form_views_deleted( $form_id ) {
+		$this->log_form_action( $form_id, 'views_deleted' );
+	}
+
+	/**
+	 * Track status change of forms
+	 *
+	 * @param integer $form_id
+	 * @param string $action
+	 */
+	public function log_form_action( $form_id, $action ) {
+		$form    = $this->get_form( $form_id );
+
+		if ( empty( $form ) ) {
+			return;
+		}
+
+		$actions = array(
+			'activated'     => esc_html__( 'Activated', 'stream' ),
+			'deactivated'   => esc_html__( 'Deactivated', 'stream' ),
+			'trashed'       => esc_html__( 'Trashed', 'stream' ),
+			'untrashed'     => esc_html__( 'Restored', 'stream' ),
+			'duplicated'    => esc_html__( 'Duplicated', 'stream' ),
+			'deleted'       => esc_html__( 'Deleted', 'stream' ),
+			'views_deleted' => esc_html__( 'Views Reset', 'stream' ),
+		);
 
 		$this->log(
-			__( '"%s" form trashed', 'stream' ),
+			sprintf(
+				__( '"%1$s" form %2$s', 'stream' ),
+				$form['title'],
+				$actions[ $action ]
+			),
 			array(
 				'form_title' => $form['title'],
-				'form_id'    => $id,
+				'form_id'    => $form_id,
 			),
 			$form['id'],
 			'forms',
-			'trashed'
+			$action
 		);
 	}
 

--- a/connectors/class-connector-gravityforms.php
+++ b/connectors/class-connector-gravityforms.php
@@ -24,7 +24,6 @@ class Connector_GravityForms extends Connector {
 	 * @var array
 	 */
 	public $actions = array(
-
 		'gform_after_save_form',
 		'gform_pre_confirmation_save',
 		'gform_pre_notification_save',
@@ -51,7 +50,6 @@ class Connector_GravityForms extends Connector {
 		'update_site_option',
 		'add_site_option',
 		'delete_site_option',
-
 	);
 
 	/**
@@ -74,13 +72,11 @@ class Connector_GravityForms extends Connector {
 	 * @return bool
 	 */
 	public function is_dependency_satisfied() {
-
 		if ( class_exists( 'GFForms' ) && version_compare( \GFCommon::$version, self::PLUGIN_MIN_VERSION, '>=' ) ) {
 			return true;
 		}
 
 		return false;
-
 	}
 
 	/**
@@ -89,9 +85,7 @@ class Connector_GravityForms extends Connector {
 	 * @return string Translated connector label
 	 */
 	public function get_label() {
-
 		return esc_html_x( 'Gravity Forms', 'gravityforms', 'stream' );
-
 	}
 
 	/**
@@ -100,7 +94,6 @@ class Connector_GravityForms extends Connector {
 	 * @return array Action label translations
 	 */
 	public function get_action_labels() {
-
 		return array(
 			'created'       => esc_html_x( 'Created', 'gravityforms', 'stream' ),
 			'updated'       => esc_html_x( 'Updated', 'gravityforms', 'stream' ),
@@ -117,7 +110,6 @@ class Connector_GravityForms extends Connector {
 			'starred'       => esc_html_x( 'Starred', 'gravityforms', 'stream' ),
 			'unstarred'     => esc_html_x( 'Unstarred', 'gravityforms', 'stream' ),
 		);
-
 	}
 
 	/**
@@ -126,7 +118,6 @@ class Connector_GravityForms extends Connector {
 	 * @return array Context label translations
 	 */
 	public function get_context_labels() {
-
 		return array(
 			'forms'    => esc_html_x( 'Forms', 'gravityforms', 'stream' ),
 			'settings' => esc_html_x( 'Settings', 'gravityforms', 'stream' ),
@@ -134,7 +125,6 @@ class Connector_GravityForms extends Connector {
 			'entries'  => esc_html_x( 'Entries', 'gravityforms', 'stream' ),
 			'notes'    => esc_html_x( 'Notes', 'gravityforms', 'stream' ),
 		);
-
 	}
 
 	/**
@@ -148,7 +138,6 @@ class Connector_GravityForms extends Connector {
 	 * @return array             Action links
 	 */
 	public function action_links( $links, $record ) {
-
 		if ( 'forms' === $record->context ) {
 			$links[ esc_html__( 'Edit', 'stream' ) ] = add_query_arg(
 				array(
@@ -187,11 +176,9 @@ class Connector_GravityForms extends Connector {
 		}
 
 		return $links;
-
 	}
 
 	public function register() {
-
 		parent::register();
 
 		$this->options = array(
@@ -221,7 +208,6 @@ class Connector_GravityForms extends Connector {
 
 			'rg_gforms_key' => null,
 		);
-
 	}
 
 	/**
@@ -232,9 +218,8 @@ class Connector_GravityForms extends Connector {
 	 * @return void
 	 */
 	public function callback_gform_after_save_form( $form, $is_new ) {
-
-		$title = $form[ 'title' ];
-		$id    = $form[ 'id' ];
+		$title = $form['title'];
+		$id    = $form['id'];
 
 		$this->log(
 			sprintf(
@@ -251,7 +236,6 @@ class Connector_GravityForms extends Connector {
 			'forms',
 			$is_new ? 'created' : 'updated'
 		);
-
 	}
 
 	/**
@@ -263,7 +247,6 @@ class Connector_GravityForms extends Connector {
 	 * @return array
 	 */
 	public function callback_gform_pre_confirmation_save( $confirmation, $form, $is_new = true ) {
-
 		if ( ! isset( $is_new ) ) {
 			$is_new = false;
 		}
@@ -273,19 +256,18 @@ class Connector_GravityForms extends Connector {
 				__( '"%1$s" confirmation %2$s for "%3$s"', 'stream' ),
 				$confirmation['name'],
 				$is_new ? esc_html__( 'created', 'stream' ) : esc_html__( 'updated', 'stream' ),
-				$form[ 'title' ]
+				$form['title']
 			),
 			array(
 				'is_new'  => $is_new,
-				'form_id' => $form[ 'id' ],
+				'form_id' => $form['id'],
 			),
-			$form[ 'id' ],
+			$form['id'],
 			'forms',
 			'updated'
 		);
 
 		return $confirmation;
-
 	}
 
 	/**
@@ -297,7 +279,6 @@ class Connector_GravityForms extends Connector {
 	 * @return array
 	 */
 	public function callback_gform_pre_notification_save( $notification, $form, $is_new = true ) {
-
 		if ( ! isset( $is_new ) ) {
 			$is_new = false;
 		}
@@ -307,19 +288,18 @@ class Connector_GravityForms extends Connector {
 				__( '"%1$s" notification %2$s for "%3$s"', 'stream' ),
 				$notification['name'],
 				$is_new ? esc_html__( 'created', 'stream' ) : esc_html__( 'updated', 'stream' ),
-				$form[ 'title' ]
+				$form['title']
 			),
 			array(
 				'is_update' => $is_new,
-				'form_id'   => $form[ 'id' ],
+				'form_id'   => $form['id'],
 			),
-			$form[ 'id' ],
+			$form['id'],
 			'forms',
 			'updated'
 		);
 
 		return $notification;
-
 	}
 
 	/**
@@ -330,22 +310,20 @@ class Connector_GravityForms extends Connector {
 	 * @return void
 	 */
 	public function callback_gform_pre_notification_deleted( $notification, $form ) {
-
 		$this->log(
 			sprintf(
 				__( '"%1$s" notification deleted from "%2$s"', 'stream' ),
 				$notification['name'],
-				$form[ 'title' ]
+				$form['title']
 			),
 			array(
-				'form_id'      => $form[ 'id' ],
+				'form_id'      => $form['id'],
 				'notification' => $notification,
 			),
-			$form[ 'id' ],
+			$form['id'],
 			'forms',
 			'updated'
 		);
-
 	}
 
 	/**
@@ -356,22 +334,20 @@ class Connector_GravityForms extends Connector {
 	 * @return void
 	 */
 	public function callback_gform_pre_confirmation_deleted( $confirmation, $form ) {
-
 		$this->log(
 			sprintf(
 				__( '"%1$s" confirmation deleted from "%2$s"', 'stream' ),
 				$confirmation['name'],
-				$form[ 'title' ]
+				$form['title']
 			),
 			array(
-				'form_id'      => $form[ 'id' ],
+				'form_id'      => $form['id'],
 				'confirmation' => $confirmation,
 			),
-			$form[ 'id' ],
+			$form['id'],
 			'forms',
 			'updated'
 		);
-
 	}
 
 	/**
@@ -383,16 +359,15 @@ class Connector_GravityForms extends Connector {
 	 * @return void
 	 */
 	public function callback_gform_confirmation_status( $confirmation, $form, $is_active ) {
-
 		$this->log(
 			sprintf(
 				__( '"%1$s" confirmation %2$s from "%3$s"', 'stream' ),
 				$confirmation['name'],
 				$is_active ? esc_html__( 'activated', 'stream' ) : esc_html__( 'deactivated', 'stream' ),
-				$form[ 'title' ]
+				$form['title']
 			),
 			array(
-				'form_id'      => $form[ 'id' ],
+				'form_id'      => $form['id'],
 				'confirmation' => $confirmation,
 				'is_active'    => $is_active,
 			),
@@ -400,7 +375,6 @@ class Connector_GravityForms extends Connector {
 			'forms',
 			'updated'
 		);
-
 	}
 
 	/**
@@ -412,24 +386,22 @@ class Connector_GravityForms extends Connector {
 	 * @return void
 	 */
 	public function callback_gform_notification_status( $notification, $form, $is_active ) {
-
 		$this->log(
 			sprintf(
 				__( '"%1$s" notification %2$s from "%3$s"', 'stream' ),
 				$notification['name'],
 				$is_active ? esc_html__( 'activated', 'stream' ) : esc_html__( 'deactivated', 'stream' ),
-				$form[ 'title' ]
+				$form['title']
 			),
 			array(
-				'form_id'      => $form[ 'id' ],
+				'form_id'      => $form['id'],
 				'notification' => $notification,
 				'is_active'    => $is_active,
 			),
-			$form[ 'id' ],
+			$form['id'],
 			'forms',
 			'updated'
 		);
-
 	}
 
 	public function callback_update_option( $option, $old, $new ) {
@@ -457,7 +429,6 @@ class Connector_GravityForms extends Connector {
 	}
 
 	public function check( $option, $old_value, $new_value ) {
-
 		if ( ! array_key_exists( $option, $this->options ) ) {
 			return;
 		}
@@ -477,11 +448,9 @@ class Connector_GravityForms extends Connector {
 				isset( $data['action'] ) ? $data['action'] : 'updated'
 			);
 		}
-
 	}
 
 	public function check_rg_gforms_key( $old_value, $new_value ) {
-
 		$is_update = ( $new_value && strlen( $new_value ) );
 		$option    = 'rg_gforms_key';
 
@@ -495,28 +464,25 @@ class Connector_GravityForms extends Connector {
 			'settings',
 			$is_update ? 'updated' : 'deleted'
 		);
-
 	}
 
 	public function callback_gform_post_export_entries( $form, $start_date, $end_date, $fields ) {
-
+		unset( $fields );
 		$this->log(
 			__( '"%s" form entries exported', 'stream' ),
 			array(
-				'form_title' => $form[ 'title' ],
-				'form_id'    => $form[ 'id' ],
+				'form_title' => $form['title'],
+				'form_id'    => $form['id'],
 				'start_date' => empty( $start_date ) ? null : $start_date,
-				'end_date'   => empty( $end_date )   ? null : $end_date
+				'end_date'   => empty( $end_date )   ? null : $end_date,
 			),
-			$form[ 'id' ],
+			$form['id'],
 			'export',
 			'exported'
 		);
-
 	}
 
 	public function callback_gform_forms_post_import( $forms ) {
-
 		$forms_total  = count( $forms );
 		$forms_label  = ( 1 === $forms_total ) ? 'form' : 'forms';
 		$forms_ids    = wp_list_pluck( $forms, 'id' );
@@ -527,23 +493,21 @@ class Connector_GravityForms extends Connector {
 			array(
 				'count'  => $forms_total,
 				'ids'    => $forms_ids,
-				'titles' => $forms_titles
+				'titles' => $forms_titles,
 			),
 			null,
 			'export',
 			'imported'
 		);
-
 	}
 
 	public function callback_gform_export_separator( $dummy, $form_id ) {
-
 		$form = $this->get_form( $form_id );
 
 		$this->log(
 			__( '"%s" form exported', 'stream' ),
 			array(
-				'form_title' => $form[ 'title' ],
+				'form_title' => $form['title'],
 				'form_id'    => $form_id,
 			),
 			$form_id,
@@ -552,11 +516,9 @@ class Connector_GravityForms extends Connector {
 		);
 
 		return $dummy;
-
 	}
 
 	public function callback_gform_export_options( $dummy, $forms ) {
-
 		$ids    = wp_list_pluck( $forms, 'id' );
 		$titles = wp_list_pluck( $forms, 'title' );
 
@@ -573,72 +535,69 @@ class Connector_GravityForms extends Connector {
 		);
 
 		return $dummy;
-
 	}
 
 	public function callback_gform_delete_lead( $lead_id ) {
-
 		$lead = $this->get_lead( $lead_id );
-		$form = $this->get_form( $lead[ 'form_id' ] );
+		$form = $this->get_form( $lead['form_id'] );
 
 		$this->log(
 			__( 'Lead #%1$d from "%2$s" deleted', 'stream' ),
 			array(
 				'lead_id'    => $lead_id,
-				'form_title' => $form[ 'title' ],
-				'form_id'    => $form[ 'id' ],
+				'form_title' => $form['title'],
+				'form_id'    => $form['id'],
 			),
 			$lead_id,
 			'entries',
 			'deleted'
 		);
-
 	}
 
 	public function callback_gform_post_note_added( $note_id, $lead_id, $user_id, $user_name, $note, $note_type ) {
+		unset( $user_id );
+		unset( $user_name );
+		unset( $note );
+		unset( $note_type );
 
 		$lead = \GFFormsModel::get_lead( $lead_id );
-		$form = $this->get_form( $lead[ 'form_id' ] );
+		$form = $this->get_form( $lead['form_id'] );
 
 		$this->log(
 			__( 'Note #%1$d added to lead #%2$d on "%3$s" form', 'stream' ),
 			array(
 				'note_id'    => $note_id,
 				'lead_id'    => $lead_id,
-				'form_title' => $form[ 'title' ],
-				'form_id'    => $form[ 'id' ],
+				'form_title' => $form['title'],
+				'form_id'    => $form['id'],
 			),
 			$note_id,
 			'notes',
 			'added'
 		);
-
 	}
 
 	public function callback_gform_pre_note_deleted( $note_id, $lead_id ) {
-
 		$lead = $this->get_lead( $lead_id );
-		$form = $this->get_form( $lead[ 'form_id' ] );
+		$form = $this->get_form( $lead['form_id'] );
 
 		$this->log(
 			__( 'Note #%1$d deleted from lead #%2$d on "%3$s" form', 'stream' ),
 			array(
 				'note_id'    => $note_id,
 				'lead_id'    => $lead_id,
-				'form_title' => $form[ 'title' ],
-				'form_id'    => $form[ 'id' ],
+				'form_title' => $form['title'],
+				'form_id'    => $form['id'],
 			),
 			$note_id,
 			'notes',
 			'deleted'
 		);
-
 	}
 
 	public function callback_gform_update_status( $lead_id, $status, $prev = '' ) {
-
 		$lead = $this->get_lead( $lead_id );
-		$form = $this->get_form( $lead[ 'form_id' ] );
+		$form = $this->get_form( $lead['form_id'] );
 
 		if ( 'active' === $status && 'trash' === $prev ) {
 			$status = 'restore';
@@ -660,12 +619,12 @@ class Connector_GravityForms extends Connector {
 				__( 'Lead #%1$d %2$s on "%3$s" form', 'stream' ),
 				$lead_id,
 				$actions[ $status ],
-				$form[ 'title' ]
+				$form['title']
 			),
 			array(
 				'lead_id'    => $lead_id,
-				'form_title' => $form[ 'title' ],
-				'form_id'    => $form[ 'id' ],
+				'form_title' => $form['title'],
+				'form_id'    => $form['id'],
 				'status'     => $status,
 				'prev'       => $prev,
 			),
@@ -673,7 +632,6 @@ class Connector_GravityForms extends Connector {
 			'entries',
 			$status
 		);
-
 	}
 
 	/**
@@ -684,9 +642,8 @@ class Connector_GravityForms extends Connector {
 	 * @return void
 	 */
 	public function callback_gform_update_is_read( $lead_id, $status ) {
-
 		$lead   = $this->get_lead( $lead_id );
-		$form   = $this->get_form( $lead[ 'form_id' ] );
+		$form   = $this->get_form( $lead['form_id'] );
 		$status = ( ! empty( $status ) ) ? esc_html__( 'read', 'stream' ) : esc_html__( 'unread', 'stream' );
 
 		$this->log(
@@ -694,22 +651,19 @@ class Connector_GravityForms extends Connector {
 				__( 'Entry #%1$d marked as %2$s on form #%3$d ("%4$s")', 'stream' ),
 				$lead_id,
 				$status,
-				$form[ 'id' ],
-				$form[ 'title' ]
+				$form['id'],
+				$form['title']
 			),
-
 			array(
 				'lead_id'     => $lead_id,
 				'lead_status' => $status,
-				'form_id'     => $form[ 'id' ],
-				'form_title'  => $form[ 'title' ],
+				'form_id'     => $form['id'],
+				'form_title'  => $form['title'],
 			),
-
 			$lead_id,
 			'entries',
 			'updated'
 		);
-
 	}
 
 	/**
@@ -720,9 +674,8 @@ class Connector_GravityForms extends Connector {
 	 * @return void
 	 */
 	public function callback_gform_update_is_starred( $lead_id, $status ) {
-
 		$lead   = $this->get_lead( $lead_id );
-		$form   = $this->get_form( $lead[ 'form_id' ] );
+		$form   = $this->get_form( $lead['form_id'] );
 		$status = ( ! empty( $status ) ) ? esc_html__( 'starred', 'stream' ) : esc_html__( 'unstarred', 'stream' );
 		$action = $status;
 
@@ -731,22 +684,19 @@ class Connector_GravityForms extends Connector {
 				__( 'Entry #%1$d %2$s on form #%3$d ("%4$s")', 'stream' ),
 				$lead_id,
 				$status,
-				$form[ 'id' ],
-				$form[ 'title' ]
+				$form['id'],
+				$form['title']
 			),
-
 			array(
 				'lead_id'     => $lead_id,
 				'lead_status' => $status,
-				'form_id'     => $form[ 'id' ],
-				'form_title'  => $form[ 'title' ],
+				'form_id'     => $form['id'],
+				'form_title'  => $form['title'],
 			),
-
 			$lead_id,
 			'entries',
 			$action
 		);
-
 	}
 
 	/**
@@ -756,9 +706,7 @@ class Connector_GravityForms extends Connector {
 	 * @return void
 	 */
 	public function callback_gform_before_delete_form( $form_id ) {
-
 		$this->log_form_action( $form_id, 'deleted' );
-
 	}
 
 	/**
@@ -768,9 +716,7 @@ class Connector_GravityForms extends Connector {
 	 * @return void
 	 */
 	public function callback_gform_post_form_trashed( $form_id ) {
-
 		$this->log_form_action( $form_id, 'trashed' );
-
 	}
 
 	/**
@@ -780,9 +726,7 @@ class Connector_GravityForms extends Connector {
 	 * @return void
 	 */
 	public function callback_gform_post_form_restored( $form_id ) {
-
 		$this->log_form_action( $form_id, 'untrashed' );
-
 	}
 
 	/**
@@ -792,9 +736,7 @@ class Connector_GravityForms extends Connector {
 	 * @return void
 	 */
 	public function callback_gform_post_form_activated( $form_id ) {
-
 		$this->log_form_action( $form_id, 'activated' );
-
 	}
 
 	/**
@@ -804,9 +746,7 @@ class Connector_GravityForms extends Connector {
 	 * @return void
 	 */
 	public function callback_gform_post_form_deactivated( $form_id ) {
-
 		$this->log_form_action( $form_id, 'deactivated' );
-
 	}
 
 	/**
@@ -816,9 +756,7 @@ class Connector_GravityForms extends Connector {
 	 * @return void
 	 */
 	public function callback_gform_post_form_duplicated( $form_id ) {
-
 		$this->log_form_action( $form_id, 'duplicated' );
-
 	}
 
 	/**
@@ -828,9 +766,7 @@ class Connector_GravityForms extends Connector {
 	 * @return void
 	 */
 	public function callback_gform_post_form_views_deleted( $form_id ) {
-
 		$this->log_form_action( $form_id, 'views_deleted' );
-
 	}
 
 	/**
@@ -841,7 +777,6 @@ class Connector_GravityForms extends Connector {
 	 * @return void
 	 */
 	public function log_form_action( $form_id, $action ) {
-
 		$form = $this->get_form( $form_id );
 
 		if ( empty( $form ) ) {
@@ -862,21 +797,18 @@ class Connector_GravityForms extends Connector {
 			sprintf(
 				__( 'Form #%1$d ("%2$s") %3$s', 'stream' ),
 				$form_id,
-				$form[ 'title' ],
+				$form['title'],
 				strtolower( $actions[ $action ] )
 			),
-
 			array(
 				'form_id'     => $form_id,
-				'form_title'  => $form[ 'title' ],
-				'form_status' => strtolower( $action )
+				'form_title'  => $form['title'],
+				'form_status' => strtolower( $action ),
 			),
-
-			$form[ 'id' ],
+			$form['id'],
 			'forms',
 			$action
 		);
-
 	}
 
 	/**
@@ -886,9 +818,7 @@ class Connector_GravityForms extends Connector {
 	 * @return array
 	 */
 	private function get_lead( $lead_id ) {
-
 		return \GFFormsModel::get_lead( $lead_id );
-
 	}
 
 	/**
@@ -898,9 +828,6 @@ class Connector_GravityForms extends Connector {
 	 * @return array
 	 */
 	private function get_form( $form_id ) {
-
 		return \GFFormsModel::get_form_meta( $form_id );
-
 	}
-
 }


### PR DESCRIPTION
This updates the Stream Gravity Forms connector to work with the renamed actions in Gravity Forms.

Needs testing:
- Deleting notification
- Deleting confirmation
- Resetting a form's views
- Deleting / Restoring a form
- Activating / Deactivating a form
- Duplicating a form
- Exporting a form / forms
- Exporting entries

@rob Could you please test and review these changes?