### PR TITLE
Gravity Forms connector update - bugfix/issue-771

### DIFF
--- a/connectors/class-connector-gravityforms.php
+++ b/connectors/class-connector-gravityforms.php
@@ -1,7 +1,9 @@
 <?php
+
 namespace WP_Stream;
 
 class Connector_GravityForms extends Connector {
+
 	/**
 	 * Connector slug
 	 *
@@ -22,6 +24,7 @@ class Connector_GravityForms extends Connector {
 	 * @var array
 	 */
 	public $actions = array(
+
 		'gform_after_save_form',
 		'gform_pre_confirmation_save',
 		'gform_pre_notification_save',
@@ -48,6 +51,7 @@ class Connector_GravityForms extends Connector {
 		'update_site_option',
 		'add_site_option',
 		'delete_site_option',
+
 	);
 
 	/**
@@ -70,11 +74,13 @@ class Connector_GravityForms extends Connector {
 	 * @return bool
 	 */
 	public function is_dependency_satisfied() {
+
 		if ( class_exists( 'GFForms' ) && version_compare( \GFCommon::$version, self::PLUGIN_MIN_VERSION, '>=' ) ) {
 			return true;
 		}
 
 		return false;
+
 	}
 
 	/**
@@ -83,7 +89,9 @@ class Connector_GravityForms extends Connector {
 	 * @return string Translated connector label
 	 */
 	public function get_label() {
+
 		return esc_html_x( 'Gravity Forms', 'gravityforms', 'stream' );
+
 	}
 
 	/**
@@ -92,6 +100,7 @@ class Connector_GravityForms extends Connector {
 	 * @return array Action label translations
 	 */
 	public function get_action_labels() {
+
 		return array(
 			'created'       => esc_html_x( 'Created', 'gravityforms', 'stream' ),
 			'updated'       => esc_html_x( 'Updated', 'gravityforms', 'stream' ),
@@ -106,6 +115,7 @@ class Connector_GravityForms extends Connector {
 			'deactivated'   => esc_html_x( 'Deactivated', 'gravityforms', 'stream' ),
 			'views_deleted' => esc_html_x( 'Views Reset', 'gravityforms', 'stream' ),
 		);
+
 	}
 
 	/**
@@ -114,6 +124,7 @@ class Connector_GravityForms extends Connector {
 	 * @return array Context label translations
 	 */
 	public function get_context_labels() {
+
 		return array(
 			'forms'    => esc_html_x( 'Forms', 'gravityforms', 'stream' ),
 			'settings' => esc_html_x( 'Settings', 'gravityforms', 'stream' ),
@@ -121,6 +132,7 @@ class Connector_GravityForms extends Connector {
 			'entries'  => esc_html_x( 'Entries', 'gravityforms', 'stream' ),
 			'notes'    => esc_html_x( 'Notes', 'gravityforms', 'stream' ),
 		);
+
 	}
 
 	/**
@@ -134,6 +146,7 @@ class Connector_GravityForms extends Connector {
 	 * @return array             Action links
 	 */
 	public function action_links( $links, $record ) {
+
 		if ( 'forms' === $record->context ) {
 			$links[ esc_html__( 'Edit', 'stream' ) ] = add_query_arg(
 				array(
@@ -172,32 +185,41 @@ class Connector_GravityForms extends Connector {
 		}
 
 		return $links;
+
 	}
 
 	public function register() {
+
 		parent::register();
 
 		$this->options = array(
-			'rg_gforms_disable_css'         => array(
+			'rg_gforms_disable_css' => array(
 				'label' => esc_html_x( 'Output CSS', 'gravityforms', 'stream' ),
 			),
-			'rg_gforms_enable_html5'        => array(
+
+			'rg_gforms_enable_html5' => array(
 				'label' => esc_html_x( 'Output HTML5', 'gravityforms', 'stream' ),
 			),
-			'gform_enable_noconflict'       => array(
+
+			'gform_enable_noconflict' => array(
 				'label' => esc_html_x( 'No-Conflict Mode', 'gravityforms', 'stream' ),
 			),
-			'rg_gforms_currency'            => array(
+
+			'rg_gforms_currency' => array(
 				'label' => esc_html_x( 'Currency', 'gravityforms', 'stream' ),
 			),
-			'rg_gforms_captcha_public_key'  => array(
+
+			'rg_gforms_captcha_public_key' => array(
 				'label' => esc_html_x( 'reCAPTCHA Public Key', 'gravityforms', 'stream' ),
 			),
+
 			'rg_gforms_captcha_private_key' => array(
 				'label' => esc_html_x( 'reCAPTCHA Private Key', 'gravityforms', 'stream' ),
 			),
-			'rg_gforms_key'                 => null,
+
+			'rg_gforms_key' => null,
 		);
+
 	}
 
 	/**
@@ -205,8 +227,10 @@ class Connector_GravityForms extends Connector {
 	 *
 	 * @param array $form
 	 * @param bool $is_new
+	 * @return void
 	 */
 	public function callback_gform_after_save_form( $form, $is_new ) {
+
 		$title = $form['title'];
 		$id    = $form['id'];
 
@@ -225,6 +249,7 @@ class Connector_GravityForms extends Connector {
 			'forms',
 			$is_new ? 'created' : 'updated'
 		);
+
 	}
 
 	/**
@@ -233,10 +258,10 @@ class Connector_GravityForms extends Connector {
 	 * @param array $confirmation
 	 * @param array $form
 	 * @param bool $is_new
-	 *
 	 * @return array
 	 */
 	public function callback_gform_pre_confirmation_save( $confirmation, $form, $is_new = true ) {
+
 		if ( ! isset( $is_new ) ) {
 			$is_new = false;
 		}
@@ -258,6 +283,7 @@ class Connector_GravityForms extends Connector {
 		);
 
 		return $confirmation;
+
 	}
 
 	/**
@@ -266,10 +292,10 @@ class Connector_GravityForms extends Connector {
 	 * @param array $notification
 	 * @param array $form
 	 * @param bool $is_new
-	 *
 	 * @return array
 	 */
 	public function callback_gform_pre_notification_save( $notification, $form, $is_new = true ) {
+
 		if ( ! isset( $is_new ) ) {
 			$is_new = false;
 		}
@@ -291,6 +317,7 @@ class Connector_GravityForms extends Connector {
 		);
 
 		return $notification;
+
 	}
 
 	/**
@@ -298,8 +325,10 @@ class Connector_GravityForms extends Connector {
 	 *
 	 * @param array $notification
 	 * @param array $form
+	 * @return void
 	 */
 	public function callback_gform_pre_notification_deleted( $notification, $form ) {
+
 		$this->log(
 			sprintf(
 				__( '"%1$s" notification deleted from "%2$s"', 'stream' ),
@@ -314,6 +343,7 @@ class Connector_GravityForms extends Connector {
 			'forms',
 			'updated'
 		);
+
 	}
 
 	/**
@@ -321,8 +351,10 @@ class Connector_GravityForms extends Connector {
 	 *
 	 * @param array $confirmation
 	 * @param array $form
+	 * @return void
 	 */
 	public function callback_gform_pre_confirmation_deleted( $confirmation, $form ) {
+
 		$this->log(
 			sprintf(
 				__( '"%1$s" confirmation deleted from "%2$s"', 'stream' ),
@@ -337,6 +369,7 @@ class Connector_GravityForms extends Connector {
 			'forms',
 			'updated'
 		);
+
 	}
 
 	/**
@@ -345,8 +378,10 @@ class Connector_GravityForms extends Connector {
 	 * @param array $confirmation
 	 * @param array $form
 	 * @param bool $is_active
+	 * @return void
 	 */
 	public function callback_gform_confirmation_status( $confirmation, $form, $is_active ) {
+
 		$this->log(
 			sprintf(
 				__( '"%1$s" confirmation %2$s from "%3$s"', 'stream' ),
@@ -363,6 +398,7 @@ class Connector_GravityForms extends Connector {
 			'forms',
 			'updated'
 		);
+
 	}
 
 	/**
@@ -371,8 +407,10 @@ class Connector_GravityForms extends Connector {
 	 * @param array $notification
 	 * @param array $form
 	 * @param bool $is_active
+	 * @return void
 	 */
 	public function callback_gform_notification_status( $notification, $form, $is_active ) {
+
 		$this->log(
 			sprintf(
 				__( '"%1$s" notification %2$s from "%3$s"', 'stream' ),
@@ -389,6 +427,7 @@ class Connector_GravityForms extends Connector {
 			'forms',
 			'updated'
 		);
+
 	}
 
 	public function callback_update_option( $option, $old, $new ) {
@@ -416,6 +455,7 @@ class Connector_GravityForms extends Connector {
 	}
 
 	public function check( $option, $old_value, $new_value ) {
+
 		if ( ! array_key_exists( $option, $this->options ) ) {
 			return;
 		}
@@ -435,9 +475,11 @@ class Connector_GravityForms extends Connector {
 				isset( $data['action'] ) ? $data['action'] : 'updated'
 			);
 		}
+
 	}
 
 	public function check_rg_gforms_key( $old_value, $new_value ) {
+
 		$is_update = ( $new_value && strlen( $new_value ) );
 		$option    = 'rg_gforms_key';
 
@@ -451,6 +493,7 @@ class Connector_GravityForms extends Connector {
 			'settings',
 			$is_update ? 'updated' : 'deleted'
 		);
+
 	}
 
 	public function callback_gform_post_export_entries( $form, $start_date, $end_date, $fields ) {
@@ -492,6 +535,7 @@ class Connector_GravityForms extends Connector {
 	}
 
 	public function callback_gform_export_separator( $dummy, $form_id ) {
+
 		$form = $this->get_form( $form_id );
 
 		$this->log(
@@ -506,9 +550,11 @@ class Connector_GravityForms extends Connector {
 		);
 
 		return $dummy;
+
 	}
 
 	public function callback_gform_export_options( $dummy, $forms ) {
+
 		$ids    = wp_list_pluck( $forms, 'id' );
 		$titles = wp_list_pluck( $forms, 'title' );
 
@@ -525,9 +571,11 @@ class Connector_GravityForms extends Connector {
 		);
 
 		return $dummy;
+
 	}
 
 	public function callback_gform_delete_lead( $lead_id ) {
+
 		$lead = $this->get_lead( $lead_id );
 		$form = $this->get_form( $lead['form_id'] );
 
@@ -542,9 +590,11 @@ class Connector_GravityForms extends Connector {
 			'entries',
 			'deleted'
 		);
+
 	}
 
 	public function callback_gform_post_note_added( $note_id, $lead_id, $user_id, $user_name, $note, $note_type ) {
+
 		$lead = \GFFormsModel::get_lead( $lead_id );
 		$form = $this->get_form( $lead['form_id'] );
 
@@ -560,9 +610,11 @@ class Connector_GravityForms extends Connector {
 			'notes',
 			'added'
 		);
+
 	}
 
 	public function callback_gform_pre_note_deleted( $note_id, $lead_id ) {
+
 		$lead = $this->get_lead( $lead_id );
 		$form = $this->get_form( $lead['form_id'] );
 
@@ -578,9 +630,11 @@ class Connector_GravityForms extends Connector {
 			'notes',
 			'deleted'
 		);
+
 	}
 
 	public function callback_gform_update_status( $lead_id, $status, $prev = '' ) {
+
 		$lead = $this->get_lead( $lead_id );
 		$form = $this->get_form( $lead['form_id'] );
 
@@ -617,9 +671,11 @@ class Connector_GravityForms extends Connector {
 			'entries',
 			$status
 		);
+
 	}
 
 	public function callback_gform_update_is_read( $lead_id, $status ) {
+
 		$lead = $this->get_lead( $lead_id );
 		$form = $this->get_form( $lead['form_id'] );
 
@@ -640,9 +696,11 @@ class Connector_GravityForms extends Connector {
 			'entries',
 			'updated'
 		);
+
 	}
 
 	public function callback_gform_update_is_starred( $lead_id, $status ) {
+
 		$lead = $this->get_lead( $lead_id );
 		$form = $this->get_form( $lead['form_id'] );
 
@@ -663,6 +721,7 @@ class Connector_GravityForms extends Connector {
 			'entries',
 			'updated'
 		);
+
 	}
 
 	public function callback_gform_before_delete_form( $form_id ) {
@@ -696,11 +755,13 @@ class Connector_GravityForms extends Connector {
 	/**
 	 * Track status change of forms
 	 *
-	 * @param integer $form_id
+	 * @param int $form_id
 	 * @param string $action
+	 * @return void
 	 */
 	public function log_form_action( $form_id, $action ) {
-		$form    = $this->get_form( $form_id );
+
+		$form = $this->get_form( $form_id );
 
 		if ( empty( $form ) ) {
 			return;
@@ -730,13 +791,31 @@ class Connector_GravityForms extends Connector {
 			'forms',
 			$action
 		);
+
 	}
 
+	/**
+	 * Helper function to get a single entry
+	 *
+	 * @param  int $lead_id Lead ID
+	 * @return array
+	 */
 	private function get_lead( $lead_id ) {
+
 		return \GFFormsModel::get_lead( $lead_id );
+
 	}
 
+	/**
+	 * Helper function to get a single form
+	 *
+	 * @param  int $form_id Form ID
+	 * @return array
+	 */
 	private function get_form( $form_id ) {
+
 		return \GFFormsModel::get_form_meta( $form_id );
+
 	}
+
 }

--- a/connectors/class-connector-gravityforms.php
+++ b/connectors/class-connector-gravityforms.php
@@ -36,7 +36,7 @@ class Connector_GravityForms extends Connector {
 		'gform_post_form_deactivated',
 		'gform_post_form_duplicated',
 		'gform_post_form_views_deleted',
-		'gform_export_lines', // Export entries
+		'gform_post_export_entries', // Export entries
 		'gform_export_form', // Export forms
 		'gform_import_form_xml_options', // Import
 		'gform_delete_lead',
@@ -454,6 +454,23 @@ class Connector_GravityForms extends Connector {
 			'settings',
 			$is_update ? 'updated' : 'deleted'
 		);
+	}
+
+	public function callback_gform_post_export_entries( $form, $start_date, $end_date, $fields ) {
+
+		$this->log(
+			__( '"%s" form entries exported', 'stream' ),
+			array(
+				'form_title' => $form[ 'title' ],
+				'form_id'    => $form[ 'id' ],
+				'start_date' => empty( $start_date ) ? null : $start_date,
+				'end_date'   => empty( $end_date )   ? null : $end_date
+			),
+			$form[ 'id' ],
+			'export',
+			'exported'
+		);
+
 	}
 
 	public function callback_gform_export_separator( $dummy, $form_id ) {

--- a/connectors/class-connector-gravityforms.php
+++ b/connectors/class-connector-gravityforms.php
@@ -14,7 +14,7 @@ class Connector_GravityForms extends Connector {
 	 *
 	 * @const string
 	 */
-	const PLUGIN_MIN_VERSION = '1.9.13.29';
+	const PLUGIN_MIN_VERSION = '1.9.14';
 
 	/**
 	 * Actions registered for this connector

--- a/connectors/class-connector-gravityforms.php
+++ b/connectors/class-connector-gravityforms.php
@@ -36,8 +36,7 @@ class Connector_GravityForms extends Connector {
 		'gform_post_form_deactivated',
 		'gform_post_form_duplicated',
 		'gform_post_form_views_deleted',
-		'gform_post_export_entries', // Export entries
-		'gform_import_form_xml_options', // Import
+		'gform_post_export_entries',
 		'gform_delete_lead',
 		'gform_post_note_added',
 		'gform_pre_note_deleted',
@@ -484,18 +483,6 @@ class Connector_GravityForms extends Connector {
 			$form_id,
 			'export',
 			'exported'
-		);
-
-		return $dummy;
-	}
-
-	public function callback_gform_import_form_xml_options( $dummy ) {
-		$this->log(
-			__( 'Import process started', 'stream' ),
-			array(),
-			null,
-			'export',
-			'imported'
 		);
 
 		return $dummy;

--- a/connectors/class-connector-gravityforms.php
+++ b/connectors/class-connector-gravityforms.php
@@ -528,7 +528,7 @@ class Connector_GravityForms extends Connector {
 	}
 
 	public function callback_gform_delete_lead( $lead_id ) {
-		$lead = \GFFormsModel::get_lead( $lead_id );
+		$lead = $this->get_lead( $lead_id );
 		$form = $this->get_form( $lead['form_id'] );
 
 		$this->log(
@@ -563,7 +563,7 @@ class Connector_GravityForms extends Connector {
 	}
 
 	public function callback_gform_pre_note_deleted( $note_id, $lead_id ) {
-		$lead = \GFFormsModel::get_lead( $lead_id );
+		$lead = $this->get_lead( $lead_id );
 		$form = $this->get_form( $lead['form_id'] );
 
 		$this->log(
@@ -581,7 +581,7 @@ class Connector_GravityForms extends Connector {
 	}
 
 	public function callback_gform_update_status( $lead_id, $status, $prev = '' ) {
-		$lead = \GFFormsModel::get_lead( $lead_id );
+		$lead = $this->get_lead( $lead_id );
 		$form = $this->get_form( $lead['form_id'] );
 
 		if ( 'active' === $status && 'trash' === $prev ) {
@@ -620,7 +620,7 @@ class Connector_GravityForms extends Connector {
 	}
 
 	public function callback_gform_update_is_read( $lead_id, $status ) {
-		$lead = \GFFormsModel::get_lead( $lead_id );
+		$lead = $this->get_lead( $lead_id );
 		$form = $this->get_form( $lead['form_id'] );
 
 		$this->log(
@@ -643,7 +643,7 @@ class Connector_GravityForms extends Connector {
 	}
 
 	public function callback_gform_update_is_starred( $lead_id, $status ) {
-		$lead = \GFFormsModel::get_lead( $lead_id );
+		$lead = $this->get_lead( $lead_id );
 		$form = $this->get_form( $lead['form_id'] );
 
 		$this->log(
@@ -730,6 +730,10 @@ class Connector_GravityForms extends Connector {
 			'forms',
 			$action
 		);
+	}
+
+	private function get_lead( $lead_id ) {
+		return \GFFormsModel::get_lead( $lead_id );
 	}
 
 	private function get_form( $form_id ) {

--- a/connectors/class-connector-gravityforms.php
+++ b/connectors/class-connector-gravityforms.php
@@ -782,7 +782,7 @@ class Connector_GravityForms extends Connector {
 				__( 'Form #%1$d ("%2$s") %3$s', 'stream' ),
 				$form_id,
 				$form[ 'title' ],
-				strtolower( $actions[ $action ] ),
+				strtolower( $actions[ $action ] )
 			),
 
 			array(

--- a/connectors/class-connector-gravityforms.php
+++ b/connectors/class-connector-gravityforms.php
@@ -37,6 +37,7 @@ class Connector_GravityForms extends Connector {
 		'gform_post_form_duplicated',
 		'gform_post_form_views_deleted',
 		'gform_post_export_entries',
+		'gform_forms_post_import',
 		'gform_delete_lead',
 		'gform_post_note_added',
 		'gform_pre_note_deleted',
@@ -467,6 +468,27 @@ class Connector_GravityForms extends Connector {
 			$form[ 'id' ],
 			'export',
 			'exported'
+		);
+
+	}
+
+	public function callback_gform_forms_post_import( $forms ) {
+
+		$forms_total  = count( $forms );
+		$forms_label  = ( 1 === $forms_total ) ? 'form' : 'forms';
+		$forms_ids    = wp_list_pluck( $forms, 'id' );
+		$forms_titles = wp_list_pluck( $forms, 'title' );
+
+		$this->log(
+			__( '%d ' . $forms_label . ' imported', 'stream' ),
+			array(
+				'count'  => $forms_total,
+				'ids'    => $forms_ids,
+				'titles' => $forms_titles
+			),
+			null,
+			'export',
+			'imported'
 		);
 
 	}

--- a/connectors/class-connector-gravityforms.php
+++ b/connectors/class-connector-gravityforms.php
@@ -724,32 +724,88 @@ class Connector_GravityForms extends Connector {
 
 	}
 
+	/**
+	 * Callback fired when a form is deleted
+	 *
+	 * @param  int $form_id Form ID
+	 * @return void
+	 */
 	public function callback_gform_before_delete_form( $form_id ) {
+
 		$this->log_form_action( $form_id, 'deleted' );
+
 	}
 
+	/**
+	 * Callback fired when a form is trashed
+	 *
+	 * @param  int $form_id Form ID
+	 * @return void
+	 */
 	public function callback_gform_post_form_trashed( $form_id ) {
+
 		$this->log_form_action( $form_id, 'trashed' );
+
 	}
 
+	/**
+	 * Callback fired when a form is restored
+	 *
+	 * @param  int $form_id Form ID
+	 * @return void
+	 */
 	public function callback_gform_post_form_restored( $form_id ) {
+
 		$this->log_form_action( $form_id, 'untrashed' );
+
 	}
 
+	/**
+	 * Callback fired when a form is activated
+	 *
+	 * @param  int $form_id Form ID
+	 * @return void
+	 */
 	public function callback_gform_post_form_activated( $form_id ) {
+
 		$this->log_form_action( $form_id, 'activated' );
+
 	}
 
+	/**
+	 * Callback fired when a form is deactivated
+	 *
+	 * @param  int $form_id Form ID
+	 * @return void
+	 */
 	public function callback_gform_post_form_deactivated( $form_id ) {
+
 		$this->log_form_action( $form_id, 'deactivated' );
+
 	}
 
+	/**
+	 * Callback fired when a form is duplicated
+	 *
+	 * @param  int $form_id Form ID
+	 * @return void
+	 */
 	public function callback_gform_post_form_duplicated( $form_id ) {
+
 		$this->log_form_action( $form_id, 'duplicated' );
+
 	}
 
+	/**
+	 * Callback fired when a form's views are reset
+	 *
+	 * @param  int $form_id Form ID
+	 * @return void
+	 */
 	public function callback_gform_post_form_views_deleted( $form_id ) {
+
 		$this->log_form_action( $form_id, 'views_deleted' );
+
 	}
 
 	/**

--- a/connectors/class-connector-gravityforms.php
+++ b/connectors/class-connector-gravityforms.php
@@ -114,6 +114,8 @@ class Connector_GravityForms extends Connector {
 			'activated'     => esc_html_x( 'Activated', 'gravityforms', 'stream' ),
 			'deactivated'   => esc_html_x( 'Deactivated', 'gravityforms', 'stream' ),
 			'views_deleted' => esc_html_x( 'Views Reset', 'gravityforms', 'stream' ),
+			'starred'       => esc_html_x( 'Starred', 'gravityforms', 'stream' ),
+			'unstarred'     => esc_html_x( 'Unstarred', 'gravityforms', 'stream' ),
 		);
 
 	}
@@ -697,10 +699,10 @@ class Connector_GravityForms extends Connector {
 			),
 
 			array(
-				'lead_id'    => $lead_id,
-				'form_title' => $form[ 'title' ],
-				'form_id'    => $form[ 'id' ],
-				'status'     => $status,
+				'lead_id'     => $lead_id,
+				'lead_status' => $status,
+				'form_id'     => $form[ 'id' ],
+				'form_title'  => $form[ 'title' ],
 			),
 
 			$lead_id,
@@ -722,6 +724,7 @@ class Connector_GravityForms extends Connector {
 		$lead   = $this->get_lead( $lead_id );
 		$form   = $this->get_form( $lead[ 'form_id' ] );
 		$status = ( ! empty( $status ) ) ? esc_html__( 'starred', 'stream' ) : esc_html__( 'unstarred', 'stream' );
+		$action = $status;
 
 		$this->log(
 			sprintf(
@@ -733,15 +736,15 @@ class Connector_GravityForms extends Connector {
 			),
 
 			array(
-				'lead_id'    => $lead_id,
-				'form_title' => $form[ 'title' ],
-				'form_id'    => $form[ 'id' ],
-				'status'     => $status,
+				'lead_id'     => $lead_id,
+				'lead_status' => $status,
+				'form_id'     => $form[ 'id' ],
+				'form_title'  => $form[ 'title' ],
 			),
 
 			$lead_id,
 			'entries',
-			'updated'
+			$action
 		);
 
 	}

--- a/connectors/class-connector-gravityforms.php
+++ b/connectors/class-connector-gravityforms.php
@@ -779,15 +779,19 @@ class Connector_GravityForms extends Connector {
 
 		$this->log(
 			sprintf(
-				__( '"%1$s" form %2$s', 'stream' ),
-				$form['title'],
-				$actions[ $action ]
+				__( 'Form #%1$d ("%2$s") %3$s', 'stream' ),
+				$form_id,
+				$form[ 'title' ],
+				strtolower( $actions[ $action ] ),
 			),
+
 			array(
-				'form_title' => $form['title'],
-				'form_id'    => $form_id,
+				'form_id'     => $form_id,
+				'form_title'  => $form[ 'title' ],
+				'form_status' => strtolower( $action )
 			),
-			$form['id'],
+
+			$form[ 'id' ],
 			'forms',
 			$action
 		);

--- a/connectors/class-connector-gravityforms.php
+++ b/connectors/class-connector-gravityforms.php
@@ -27,8 +27,6 @@ class Connector_GravityForms extends Connector {
 		'gform_pre_notification_save',
 		'gform_pre_notification_deleted',
 		'gform_pre_confirmation_deleted',
-		'gform_notification_status',
-		'gform_confirmation_status',
 		'gform_before_delete_form',
 		'gform_post_form_trashed',
 		'gform_post_form_restored',

--- a/connectors/class-connector-gravityforms.php
+++ b/connectors/class-connector-gravityforms.php
@@ -733,8 +733,6 @@ class Connector_GravityForms extends Connector {
 	}
 
 	private function get_form( $form_id ) {
-		$form = \GFFormsModel::get_form_meta_by_id( $form_id );
-
-		return reset( $form );
+		return \GFFormsModel::get_form_meta( $form_id );
 	}
 }

--- a/connectors/class-connector-gravityforms.php
+++ b/connectors/class-connector-gravityforms.php
@@ -37,7 +37,6 @@ class Connector_GravityForms extends Connector {
 		'gform_post_form_duplicated',
 		'gform_post_form_views_deleted',
 		'gform_post_export_entries', // Export entries
-		'gform_export_form', // Export forms
 		'gform_import_form_xml_options', // Import
 		'gform_delete_lead',
 		'gform_post_note_added',

--- a/connectors/class-connector-gravityforms.php
+++ b/connectors/class-connector-gravityforms.php
@@ -231,8 +231,8 @@ class Connector_GravityForms extends Connector {
 	 */
 	public function callback_gform_after_save_form( $form, $is_new ) {
 
-		$title = $form['title'];
-		$id    = $form['id'];
+		$title = $form[ 'title' ];
+		$id    = $form[ 'id' ];
 
 		$this->log(
 			sprintf(
@@ -271,13 +271,13 @@ class Connector_GravityForms extends Connector {
 				__( '"%1$s" confirmation %2$s for "%3$s"', 'stream' ),
 				$confirmation['name'],
 				$is_new ? esc_html__( 'created', 'stream' ) : esc_html__( 'updated', 'stream' ),
-				$form['title']
+				$form[ 'title' ]
 			),
 			array(
 				'is_new'  => $is_new,
-				'form_id' => $form['id'],
+				'form_id' => $form[ 'id' ],
 			),
-			$form['id'],
+			$form[ 'id' ],
 			'forms',
 			'updated'
 		);
@@ -305,13 +305,13 @@ class Connector_GravityForms extends Connector {
 				__( '"%1$s" notification %2$s for "%3$s"', 'stream' ),
 				$notification['name'],
 				$is_new ? esc_html__( 'created', 'stream' ) : esc_html__( 'updated', 'stream' ),
-				$form['title']
+				$form[ 'title' ]
 			),
 			array(
 				'is_update' => $is_new,
-				'form_id'   => $form['id'],
+				'form_id'   => $form[ 'id' ],
 			),
-			$form['id'],
+			$form[ 'id' ],
 			'forms',
 			'updated'
 		);
@@ -333,13 +333,13 @@ class Connector_GravityForms extends Connector {
 			sprintf(
 				__( '"%1$s" notification deleted from "%2$s"', 'stream' ),
 				$notification['name'],
-				$form['title']
+				$form[ 'title' ]
 			),
 			array(
-				'form_id'      => $form['id'],
+				'form_id'      => $form[ 'id' ],
 				'notification' => $notification,
 			),
-			$form['id'],
+			$form[ 'id' ],
 			'forms',
 			'updated'
 		);
@@ -359,13 +359,13 @@ class Connector_GravityForms extends Connector {
 			sprintf(
 				__( '"%1$s" confirmation deleted from "%2$s"', 'stream' ),
 				$confirmation['name'],
-				$form['title']
+				$form[ 'title' ]
 			),
 			array(
-				'form_id'      => $form['id'],
+				'form_id'      => $form[ 'id' ],
 				'confirmation' => $confirmation,
 			),
-			$form['id'],
+			$form[ 'id' ],
 			'forms',
 			'updated'
 		);
@@ -387,10 +387,10 @@ class Connector_GravityForms extends Connector {
 				__( '"%1$s" confirmation %2$s from "%3$s"', 'stream' ),
 				$confirmation['name'],
 				$is_active ? esc_html__( 'activated', 'stream' ) : esc_html__( 'deactivated', 'stream' ),
-				$form['title']
+				$form[ 'title' ]
 			),
 			array(
-				'form_id'      => $form['id'],
+				'form_id'      => $form[ 'id' ],
 				'confirmation' => $confirmation,
 				'is_active'    => $is_active,
 			),
@@ -416,14 +416,14 @@ class Connector_GravityForms extends Connector {
 				__( '"%1$s" notification %2$s from "%3$s"', 'stream' ),
 				$notification['name'],
 				$is_active ? esc_html__( 'activated', 'stream' ) : esc_html__( 'deactivated', 'stream' ),
-				$form['title']
+				$form[ 'title' ]
 			),
 			array(
-				'form_id'      => $form['id'],
+				'form_id'      => $form[ 'id' ],
 				'notification' => $notification,
 				'is_active'    => $is_active,
 			),
-			$form['id'],
+			$form[ 'id' ],
 			'forms',
 			'updated'
 		);
@@ -541,7 +541,7 @@ class Connector_GravityForms extends Connector {
 		$this->log(
 			__( '"%s" form exported', 'stream' ),
 			array(
-				'form_title' => $form['title'],
+				'form_title' => $form[ 'title' ],
 				'form_id'    => $form_id,
 			),
 			$form_id,
@@ -577,14 +577,14 @@ class Connector_GravityForms extends Connector {
 	public function callback_gform_delete_lead( $lead_id ) {
 
 		$lead = $this->get_lead( $lead_id );
-		$form = $this->get_form( $lead['form_id'] );
+		$form = $this->get_form( $lead[ 'form_id' ] );
 
 		$this->log(
 			__( 'Lead #%1$d from "%2$s" deleted', 'stream' ),
 			array(
 				'lead_id'    => $lead_id,
-				'form_title' => $form['title'],
-				'form_id'    => $form['id'],
+				'form_title' => $form[ 'title' ],
+				'form_id'    => $form[ 'id' ],
 			),
 			$lead_id,
 			'entries',
@@ -596,15 +596,15 @@ class Connector_GravityForms extends Connector {
 	public function callback_gform_post_note_added( $note_id, $lead_id, $user_id, $user_name, $note, $note_type ) {
 
 		$lead = \GFFormsModel::get_lead( $lead_id );
-		$form = $this->get_form( $lead['form_id'] );
+		$form = $this->get_form( $lead[ 'form_id' ] );
 
 		$this->log(
 			__( 'Note #%1$d added to lead #%2$d on "%3$s" form', 'stream' ),
 			array(
 				'note_id'    => $note_id,
 				'lead_id'    => $lead_id,
-				'form_title' => $form['title'],
-				'form_id'    => $form['id'],
+				'form_title' => $form[ 'title' ],
+				'form_id'    => $form[ 'id' ],
 			),
 			$note_id,
 			'notes',
@@ -616,15 +616,15 @@ class Connector_GravityForms extends Connector {
 	public function callback_gform_pre_note_deleted( $note_id, $lead_id ) {
 
 		$lead = $this->get_lead( $lead_id );
-		$form = $this->get_form( $lead['form_id'] );
+		$form = $this->get_form( $lead[ 'form_id' ] );
 
 		$this->log(
 			__( 'Note #%1$d deleted from lead #%2$d on "%3$s" form', 'stream' ),
 			array(
 				'note_id'    => $note_id,
 				'lead_id'    => $lead_id,
-				'form_title' => $form['title'],
-				'form_id'    => $form['id'],
+				'form_title' => $form[ 'title' ],
+				'form_id'    => $form[ 'id' ],
 			),
 			$note_id,
 			'notes',
@@ -636,7 +636,7 @@ class Connector_GravityForms extends Connector {
 	public function callback_gform_update_status( $lead_id, $status, $prev = '' ) {
 
 		$lead = $this->get_lead( $lead_id );
-		$form = $this->get_form( $lead['form_id'] );
+		$form = $this->get_form( $lead[ 'form_id' ] );
 
 		if ( 'active' === $status && 'trash' === $prev ) {
 			$status = 'restore';
@@ -658,12 +658,12 @@ class Connector_GravityForms extends Connector {
 				__( 'Lead #%1$d %2$s on "%3$s" form', 'stream' ),
 				$lead_id,
 				$actions[ $status ],
-				$form['title']
+				$form[ 'title' ]
 			),
 			array(
 				'lead_id'    => $lead_id,
-				'form_title' => $form['title'],
-				'form_id'    => $form['id'],
+				'form_title' => $form[ 'title' ],
+				'form_id'    => $form[ 'id' ],
 				'status'     => $status,
 				'prev'       => $prev,
 			),
@@ -674,24 +674,35 @@ class Connector_GravityForms extends Connector {
 
 	}
 
+	/**
+	 * Callback fired when an entry is read/unread
+	 *
+	 * @param  int $lead_id
+	 * @param  int $status
+	 * @return void
+	 */
 	public function callback_gform_update_is_read( $lead_id, $status ) {
 
-		$lead = $this->get_lead( $lead_id );
-		$form = $this->get_form( $lead['form_id'] );
+		$lead   = $this->get_lead( $lead_id );
+		$form   = $this->get_form( $lead[ 'form_id' ] );
+		$status = ( ! empty( $status ) ) ? esc_html__( 'read', 'stream' ) : esc_html__( 'unread', 'stream' );
 
 		$this->log(
 			sprintf(
-				__( 'Lead #%1$d marked as %2$s on "%3$s" form', 'stream' ),
+				__( 'Entry #%1$d marked as %2$s on form #%3$d ("%4$s")', 'stream' ),
 				$lead_id,
-				$status ? esc_html__( 'read', 'stream' ) : esc_html__( 'unread', 'stream' ),
-				$form['title']
+				$status,
+				$form[ 'id' ],
+				$form[ 'title' ]
 			),
+
 			array(
 				'lead_id'    => $lead_id,
-				'form_title' => $form['title'],
-				'form_id'    => $form['id'],
+				'form_title' => $form[ 'title' ],
+				'form_id'    => $form[ 'id' ],
 				'status'     => $status,
 			),
+
 			$lead_id,
 			'entries',
 			'updated'
@@ -699,24 +710,35 @@ class Connector_GravityForms extends Connector {
 
 	}
 
+	/**
+	 * Callback fired when an entry is starred/unstarred
+	 *
+	 * @param  int $lead_id
+	 * @param  int $status
+	 * @return void
+	 */
 	public function callback_gform_update_is_starred( $lead_id, $status ) {
 
-		$lead = $this->get_lead( $lead_id );
-		$form = $this->get_form( $lead['form_id'] );
+		$lead   = $this->get_lead( $lead_id );
+		$form   = $this->get_form( $lead[ 'form_id' ] );
+		$status = ( ! empty( $status ) ) ? esc_html__( 'starred', 'stream' ) : esc_html__( 'unstarred', 'stream' );
 
 		$this->log(
 			sprintf(
-				__( 'Lead #%1$d %2$s on "%3$s" form', 'stream' ),
+				__( 'Entry #%1$d %2$s on form #%3$d ("%4$s")', 'stream' ),
 				$lead_id,
-				$status ? esc_html__( 'starred', 'stream' ) : esc_html__( 'unstarred', 'stream' ),
-				$form['title']
+				$status,
+				$form[ 'id' ],
+				$form[ 'title' ]
 			),
+
 			array(
 				'lead_id'    => $lead_id,
-				'form_title' => $form['title'],
-				'form_id'    => $form['id'],
+				'form_title' => $form[ 'title' ],
+				'form_id'    => $form[ 'id' ],
 				'status'     => $status,
 			),
+
 			$lead_id,
 			'entries',
 			'updated'

--- a/connectors/class-connector-gravityforms.php
+++ b/connectors/class-connector-gravityforms.php
@@ -14,7 +14,7 @@ class Connector_GravityForms extends Connector {
 	 *
 	 * @const string
 	 */
-	const PLUGIN_MIN_VERSION = '1.8.8';
+	const PLUGIN_MIN_VERSION = '1.9.13.29';
 
 	/**
 	 * Actions registered for this connector


### PR DESCRIPTION
This PR extends #779 with some more fixes. (also see #771)

FYI: All of the current GF export/import tracking functionality is broken in Stream. There's no longer a way to track form exports (and this was causing a bug - see below), and the actions for exporting entries and importing forms has changed. This commit fixes export/import tracking.

I also bumped `PLUGIN_MIN_VERSION` due to the new `gform_forms_post_import` action introduced in `1.9.13.29` (latest stable release.)

I discovered a bug in the current version. The `gform_export_form` line (which is actually a filter, not action) was causing the Gravity Forms .json export file to be empty. After removing that line, exports are working fine.