### PR TITLE
Only load scripts when on the correct admin pages

### DIFF
--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -334,24 +334,24 @@ class Admin {
 	 * @return void
 	 */
 	public function admin_enqueue_scripts( $hook ) {
-		wp_register_script( 'select2', $this->plugin->locations['url'] . 'ui/lib/select2/select2.js', array( 'jquery' ), '3.5.2', true );
-		wp_register_style( 'select2', $this->plugin->locations['url'] . 'ui/lib/select2/select2.css', array(), '3.5.2' );
-		wp_register_script( 'timeago', $this->plugin->locations['url'] . 'ui/lib/timeago/jquery.timeago.js', array(), '1.4.1', true );
-
-		$locale    = strtolower( substr( get_locale(), 0, 2 ) );
-		$file_tmpl = 'ui/lib/timeago/locales/jquery.timeago.%s.js';
-
-		if ( file_exists( $this->plugin->locations['dir'] . sprintf( $file_tmpl, $locale ) ) ) {
-			wp_register_script( 'timeago-locale', $this->plugin->locations['url'] . sprintf( $file_tmpl, $locale ), array( 'timeago' ), '1' );
-		} else {
-			wp_register_script( 'timeago-locale', $this->plugin->locations['url'] . sprintf( $file_tmpl, 'en' ), array( 'timeago' ), '1' );
-		}
-
-		wp_enqueue_style( 'wp-stream-admin', $this->plugin->locations['url'] . 'ui/css/admin.css', array(), $this->plugin->get_version() );
-
 		$script_screens = array( 'plugins.php' );
 
 		if ( in_array( $hook, $this->screen_id ) || in_array( $hook, $script_screens ) ) {
+			wp_register_script( 'select2', $this->plugin->locations['url'] . 'ui/lib/select2/select2.js', array( 'jquery' ), '3.5.2', true );
+			wp_register_style( 'select2', $this->plugin->locations['url'] . 'ui/lib/select2/select2.css', array(), '3.5.2' );
+			wp_register_script( 'timeago', $this->plugin->locations['url'] . 'ui/lib/timeago/jquery.timeago.js', array(), '1.4.1', true );
+
+			$locale    = strtolower( substr( get_locale(), 0, 2 ) );
+			$file_tmpl = 'ui/lib/timeago/locales/jquery.timeago.%s.js';
+
+			if ( file_exists( $this->plugin->locations['dir'] . sprintf( $file_tmpl, $locale ) ) ) {
+				wp_register_script( 'timeago-locale', $this->plugin->locations['url'] . sprintf( $file_tmpl, $locale ), array( 'timeago' ), '1' );
+			} else {
+				wp_register_script( 'timeago-locale', $this->plugin->locations['url'] . sprintf( $file_tmpl, 'en' ), array( 'timeago' ), '1' );
+			}
+
+			wp_enqueue_style( 'wp-stream-admin', $this->plugin->locations['url'] . 'ui/css/admin.css', array(), $this->plugin->get_version() );
+
 			wp_enqueue_script( 'select2' );
 			wp_enqueue_style( 'select2' );
 


### PR DESCRIPTION
Some plugins clash with the Select2 library and since the scripts are not needed on other pages then Stream admin pages we should not load them.

I am not sure if I overlooked something on this change, so it would be nice if a second pair of eyes checks this.

Would love to get some feedback in before I dig in and fix the test :)