### PR TITLE
Exclude problematic builds from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,10 @@ after_script:
     - $DEV_LIB_PATH/travis.after_script.sh
 
 sudo: false
+
+matrix:
+  exclude:
+    - php: 7.0
+      env: WP_VERSION=3.9 WP_MULTISITE=0
+    - php: 7.0
+      env: WP_VERSION=3.9 WP_MULTISITE=1

--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -218,7 +218,7 @@ class Admin {
 
 			$notice = compact( 'message', 'is_error' );
 
-			if ( ! in_array( $notice, $this->notices ) ) {
+			if ( ! in_array( $notice, $this->notices, true ) ) {
 				$this->notices[] = $notice;
 			}
 		}
@@ -351,7 +351,7 @@ class Admin {
 
 		$script_screens = array( 'plugins.php' );
 
-		if ( in_array( $hook, $this->screen_id ) || in_array( $hook, $script_screens ) ) {
+		if ( in_array( $hook, $this->screen_id, true ) || in_array( $hook, $script_screens, true ) ) {
 			wp_enqueue_script( 'wp-stream-select2' );
 			wp_enqueue_style( 'wp-stream-select2' );
 
@@ -762,7 +762,7 @@ class Admin {
 	 * @return bool
 	 */
 	private function role_can_view( $role ) {
-		if ( in_array( $role, $this->plugin->settings->options['general_role_access'] ) ) {
+		if ( in_array( $role, $this->plugin->settings->options['general_role_access'], true ) ) {
 			return true;
 		}
 
@@ -803,7 +803,7 @@ class Admin {
 		$stream_view_caps = array( $this->view_cap );
 
 		foreach ( $caps as $cap ) {
-			if ( in_array( $cap, $stream_view_caps ) ) {
+			if ( in_array( $cap, $stream_view_caps, true ) ) {
 				foreach ( $roles as $role ) {
 					if ( $this->role_can_view( $role ) ) {
 						$allcaps[ $cap ] = true;
@@ -831,7 +831,7 @@ class Admin {
 	public function filter_role_caps( $allcaps, $cap, $role ) {
 		$stream_view_caps = array( $this->view_cap );
 
-		if ( in_array( $cap, $stream_view_caps ) && $this->role_can_view( $role ) ) {
+		if ( in_array( $cap, $stream_view_caps, true ) && $this->role_can_view( $role ) ) {
 			$allcaps[ $cap ] = true;
 		}
 

--- a/classes/class-connector.php
+++ b/classes/class-connector.php
@@ -200,9 +200,9 @@ abstract class Connector {
 		$result = array_fill_keys( $result, null );
 
 		foreach ( $result as $key => $val ) {
-			if ( in_array( $key, $unique_keys_old ) ) {
+			if ( in_array( $key, $unique_keys_old, true ) ) {
 				$result[ $key ] = false; // Removed
-			} elseif ( in_array( $key, $unique_keys_new ) ) {
+			} elseif ( in_array( $key, $unique_keys_new, true ) ) {
 				$result[ $key ] = true; // Added
 			} elseif ( $deep ) { // Changed, find what changed, only if we're allowed to explore a new level
 				if ( is_array( $old_value[ $key ] ) && is_array( $new_value[ $key ] ) ) {

--- a/classes/class-connectors.php
+++ b/classes/class-connectors.php
@@ -143,12 +143,12 @@ class Connectors {
 			}
 
 			// Store connector label
-			if ( ! in_array( $connector->name, $this->term_labels['stream_connector'] ) ) {
+			if ( ! in_array( $connector->name, $this->term_labels['stream_connector'], true ) ) {
 				$this->term_labels['stream_connector'][ $connector->name ] = $connector->get_label();
 			}
 
 			$connector_name = $connector->name;
-			$is_excluded    = in_array( $connector_name, $excluded_connectors );
+			$is_excluded    = in_array( $connector_name, $excluded_connectors, true );
 
 			/**
 			 * Allows excluded connectors to be overridden and registered.

--- a/classes/class-db.php
+++ b/classes/class-db.php
@@ -182,7 +182,7 @@ class DB {
 
 		// Sanitize column
 		$allowed_columns = array( 'ID', 'site_id', 'blog_id', 'object_id', 'user_id', 'user_role', 'created', 'summary', 'connector', 'context', 'action', 'ip' );
-		if ( ! in_array( $column, $allowed_columns ) ) {
+		if ( ! in_array( $column, $allowed_columns, true ) ) {
 			return array();
 		}
 

--- a/classes/class-network.php
+++ b/classes/class-network.php
@@ -257,7 +257,7 @@ class Network {
 					continue;
 				}
 
-				if ( in_array( $field['name'], $hidden_options[ $section_key ] ) ) {
+				if ( in_array( $field['name'], $hidden_options[ $section_key ], true ) ) {
 					unset( $fields[ $section_key ]['fields'][ $key ] );
 				}
 			}
@@ -319,7 +319,7 @@ class Network {
 			$this->default_settings_page_slug,
 		);
 
-		if ( ! isset( $_GET['action'] ) || ! in_array( $_GET['action'], $allowed_referers ) ) {
+		if ( ! isset( $_GET['action'] ) || ! in_array( $_GET['action'], $allowed_referers, true ) ) {
 			return;
 		}
 

--- a/classes/class-query.php
+++ b/classes/class-query.php
@@ -128,7 +128,7 @@ class Query {
 
 			// Sanitize field
 			$allowed_fields = array( 'ID', 'site_id', 'blog_id', 'object_id', 'user_id', 'user_role', 'created', 'summary', 'connector', 'context', 'action', 'ip' );
-			if ( in_array( $field, $allowed_fields ) ) {
+			if ( in_array( $field, $allowed_fields, true ) ) {
 				$where .= $wpdb->prepare( " AND $wpdb->stream.{$field} LIKE %s", "%{$args['search']}%" ); // @codingStandardsIgnoreLine can't prepare column name
 			}
 		}
@@ -252,7 +252,7 @@ class Query {
 		$orderby   = esc_sql( $args['orderby'] );
 		$orderable = array( 'ID', 'site_id', 'blog_id', 'object_id', 'user_id', 'user_role', 'summary', 'created', 'connector', 'context', 'action' );
 
-		if ( in_array( $orderby, $orderable ) ) {
+		if ( in_array( $orderby, $orderable, true ) ) {
 			$orderby = sprintf( '%s.%s', $wpdb->stream, $orderby );
 		} elseif ( 'meta_value_num' === $orderby && ! empty( $args['meta_key'] ) ) {
 			$orderby = "CAST($wpdb->streammeta.meta_value AS SIGNED)";
@@ -314,7 +314,7 @@ class Query {
 		$this->found_records = absint( $wpdb->get_var( 'SELECT FOUND_ROWS()' ) );
 
 		// Add meta to the records, when applicable
-		if ( empty( $fields ) || in_array( 'meta', $fields ) ) {
+		if ( empty( $fields ) || in_array( 'meta', $fields, true ) ) {
 			$results = $this->add_record_meta( $results );
 		}
 

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -614,7 +614,7 @@ class Settings {
 							esc_attr( $section ),
 							esc_attr( $name ),
 							esc_attr( $value ),
-							checked( in_array( $value, $current_value ), true, false )
+							checked( in_array( $value, $current_value, true ), true, false )
 						),
 						esc_html( $label )
 					);

--- a/connectors/class-connector-bbpress.php
+++ b/connectors/class-connector-bbpress.php
@@ -181,7 +181,7 @@ class Connector_bbPress extends Connector {
 			$data['connector']     = $this->name;
 			$data['context']       = 'settings';
 			$data['action']        = 'updated';
-		} elseif ( 'posts' === $data['connector'] && in_array( $data['context'], array( 'forum', 'topic', 'reply' ) ) ) {
+		} elseif ( 'posts' === $data['connector'] && in_array( $data['context'], array( 'forum', 'topic', 'reply' ), true ) ) {
 			if ( 'reply' === $data['context'] ) {
 				if ( 'updated' === $data['action'] ) {
 					$data['message'] = esc_html__( 'Replied on "%1$s"', 'stream' );
@@ -194,7 +194,7 @@ class Connector_bbPress extends Connector {
 			}
 
 			$data['connector'] = $this->name;
-		} elseif ( 'taxonomies' === $data['connector'] && in_array( $data['context'], array( 'topic-tag' ) ) ) {
+		} elseif ( 'taxonomies' === $data['connector'] && in_array( $data['context'], array( 'topic-tag' ), true ) ) {
 			$data['connector'] = $this->name;
 		}
 

--- a/connectors/class-connector-buddypress.php
+++ b/connectors/class-connector-buddypress.php
@@ -157,7 +157,7 @@ class Connector_BuddyPress extends Connector {
 	 * @return array Action links
 	 */
 	public function action_links( $links, $record ) {
-		if ( in_array( $record->context, array( 'components' ) ) ) {
+		if ( in_array( $record->context, array( 'components' ), true ) ) {
 			$option_key = $record->get_meta( 'option_key', true );
 
 			if ( 'bp-active-components' === $option_key ) {
@@ -182,14 +182,14 @@ class Connector_BuddyPress extends Connector {
 					$links[ esc_html__( 'View', 'stream' ) ]      = get_permalink( $page_id );
 				}
 			}
-		} elseif ( in_array( $record->context, array( 'settings' ) ) ) {
+		} elseif ( in_array( $record->context, array( 'settings' ), true ) ) {
 			$links[ esc_html__( 'Edit setting', 'stream' ) ] = add_query_arg(
 				array(
 					'page' => $record->get_meta( 'page', true ),
 				),
 				admin_url( 'admin.php' )
 			);
-		} elseif ( in_array( $record->context, array( 'groups' ) ) ) {
+		} elseif ( in_array( $record->context, array( 'groups' ), true ) ) {
 			$group_id = $record->get_meta( 'id', true );
 			$group    = \groups_get_group( array( 'group_id' => $group_id ) );
 
@@ -204,7 +204,7 @@ class Connector_BuddyPress extends Connector {
 				$links[ esc_html__( 'View group', 'stream' ) ] = $visit_url;
 				$links[ esc_html__( 'Delete group', 'stream' ) ] = $delete_url;
 			}
-		} elseif ( in_array( $record->context, array( 'activity' ) ) ) {
+		} elseif ( in_array( $record->context, array( 'activity' ), true ) ) {
 			$activity_id = $record->get_meta( 'id', true );
 			$activities = \bp_activity_get( array( 'in' => $activity_id, 'spam' => 'all' ) );
 			if ( ! empty( $activities['activities'] ) ) {
@@ -225,7 +225,7 @@ class Connector_BuddyPress extends Connector {
 				}
 				$links[ esc_html__( 'Delete', 'stream' ) ] = $delete_url;
 			}
-		} elseif ( in_array( $record->context, array( 'profile_fields' ) ) ) {
+		} elseif ( in_array( $record->context, array( 'profile_fields' ), true ) ) {
 			$field_id = $record->get_meta( 'field_id', true );
 			$group_id = $record->get_meta( 'group_id', true );
 

--- a/connectors/class-connector-comments.php
+++ b/connectors/class-connector-comments.php
@@ -243,7 +243,7 @@ class Connector_Comments extends Connector {
 	 * @param object $comment
 	 */
 	public function callback_wp_insert_comment( $comment_id, $comment ) {
-		if ( in_array( $comment->comment_type, $this->get_ignored_comment_types() ) ) {
+		if ( in_array( $comment->comment_type, $this->get_ignored_comment_types(), true ) ) {
 			return;
 		}
 
@@ -311,7 +311,7 @@ class Connector_Comments extends Connector {
 	public function callback_edit_comment( $comment_id ) {
 		$comment = get_comment( $comment_id );
 
-		if ( in_array( $comment->comment_type, $this->get_ignored_comment_types() ) ) {
+		if ( in_array( $comment->comment_type, $this->get_ignored_comment_types(), true ) ) {
 			return;
 		}
 
@@ -375,7 +375,7 @@ class Connector_Comments extends Connector {
 	public function callback_delete_comment( $comment_id ) {
 		$comment = get_comment( $comment_id );
 
-		if ( in_array( $comment->comment_type, $this->get_ignored_comment_types() ) ) {
+		if ( in_array( $comment->comment_type, $this->get_ignored_comment_types(), true ) ) {
 			return;
 		}
 
@@ -413,7 +413,7 @@ class Connector_Comments extends Connector {
 	public function callback_trash_comment( $comment_id ) {
 		$comment = get_comment( $comment_id );
 
-		if ( in_array( $comment->comment_type, $this->get_ignored_comment_types() ) ) {
+		if ( in_array( $comment->comment_type, $this->get_ignored_comment_types(), true ) ) {
 			return;
 		}
 
@@ -447,7 +447,7 @@ class Connector_Comments extends Connector {
 	public function callback_untrash_comment( $comment_id ) {
 		$comment = get_comment( $comment_id );
 
-		if ( in_array( $comment->comment_type, $this->get_ignored_comment_types() ) ) {
+		if ( in_array( $comment->comment_type, $this->get_ignored_comment_types(), true ) ) {
 			return;
 		}
 
@@ -481,7 +481,7 @@ class Connector_Comments extends Connector {
 	public function callback_spam_comment( $comment_id ) {
 		$comment = get_comment( $comment_id );
 
-		if ( in_array( $comment->comment_type, $this->get_ignored_comment_types() ) ) {
+		if ( in_array( $comment->comment_type, $this->get_ignored_comment_types(), true ) ) {
 			return;
 		}
 
@@ -515,7 +515,7 @@ class Connector_Comments extends Connector {
 	public function callback_unspam_comment( $comment_id ) {
 		$comment = get_comment( $comment_id );
 
-		if ( in_array( $comment->comment_type, $this->get_ignored_comment_types() ) ) {
+		if ( in_array( $comment->comment_type, $this->get_ignored_comment_types(), true ) ) {
 			return;
 		}
 
@@ -549,7 +549,7 @@ class Connector_Comments extends Connector {
 	 * @param object $comment
 	 */
 	public function callback_transition_comment_status( $new_status, $old_status, $comment ) {
-		if ( in_array( $comment->comment_type, $this->get_ignored_comment_types() ) ) {
+		if ( in_array( $comment->comment_type, $this->get_ignored_comment_types(), true ) ) {
 			return;
 		}
 
@@ -591,7 +591,7 @@ class Connector_Comments extends Connector {
 		$comment_id = $wpdb->last_result[0]->comment_ID;
 		$comment    = get_comment( $comment_id );
 
-		if ( in_array( $comment->comment_type, $this->get_ignored_comment_types() ) ) {
+		if ( in_array( $comment->comment_type, $this->get_ignored_comment_types(), true ) ) {
 			return;
 		}
 

--- a/connectors/class-connector-edd.php
+++ b/connectors/class-connector-edd.php
@@ -147,10 +147,10 @@ class Connector_EDD extends Connector {
 	 * @return array             Action links
 	 */
 	public function action_links( $links, $record ) {
-		if ( in_array( $record->context, array( 'downloads' ) ) ) {
+		if ( in_array( $record->context, array( 'downloads' ), true ) ) {
 			$posts_connector = new Connector_Posts();
 			$links = $posts_connector->action_links( $links, $record );
-		} elseif ( in_array( $record->context, array( 'discounts' ) ) ) {
+		} elseif ( in_array( $record->context, array( 'discounts' ), true ) ) {
 			$post_type_label = get_post_type_labels( get_post_type_object( 'edd_discount' ) )->singular_name;
 			$base            = admin_url( 'edit.php?post_type=download&page=edd-discounts' );
 
@@ -179,7 +179,7 @@ class Connector_EDD extends Connector {
 					$base
 				);
 			}
-		} elseif ( in_array( $record->context, array( 'download_category', 'download_tag' ) ) ) {
+		} elseif ( in_array( $record->context, array( 'download_category', 'download_tag' ), true ) ) {
 			$tax_label = get_taxonomy_labels( get_taxonomy( $record->context ) )->singular_name;
 			$links[ sprintf( esc_html__( 'Edit %s', 'stream' ), $tax_label ) ] = get_edit_term_link( $record->object_id, $record->get_meta( 'taxonomy', true ) );
 		} elseif ( 'api_keys' === $record->context ) {
@@ -451,7 +451,7 @@ class Connector_EDD extends Connector {
 	}
 
 	public function meta( $object_id, $key, $value, $is_add = false ) {
-		if ( ! in_array( $key, $this->user_meta ) ) {
+		if ( ! in_array( $key, $this->user_meta, true ) ) {
 			return false;
 		}
 

--- a/connectors/class-connector-installer.php
+++ b/connectors/class-connector-installer.php
@@ -131,7 +131,7 @@ class Connector_Installer extends Connector {
 		$type   = $extra['type'];
 		$action = $extra['action'];
 
-		if ( ! in_array( $type, array( 'plugin', 'theme' ) ) ) {
+		if ( ! in_array( $type, array( 'plugin', 'theme' ), true ) ) {
 			return false;
 		}
 

--- a/connectors/class-connector-jetpack.php
+++ b/connectors/class-connector-jetpack.php
@@ -328,7 +328,7 @@ class Connector_Jetpack extends Connector {
 		$action  = null;
 		$meta    = array();
 
-		if ( in_array( $method, array( 'activate', 'deactivate' ) ) && ! is_null( $data ) ) {
+		if ( in_array( $method, array( 'activate', 'deactivate' ), true ) && ! is_null( $data ) ) {
 			$module_slug = $data;
 			$module      = \Jetpack::get_module( $module_slug );
 			$module_name = $module['name'];
@@ -340,7 +340,7 @@ class Connector_Jetpack extends Connector {
 				$module_name,
 				( 'activated' === $action ) ? esc_html__( 'activated', 'stream' ) : esc_html__( 'deactivated', 'stream' )
 			);
-		} elseif ( in_array( $method, array( 'authorize', 'unlink' ) ) && ! is_null( $data ) ) {
+		} elseif ( in_array( $method, array( 'authorize', 'unlink' ), true ) && ! is_null( $data ) ) {
 			$user_id = intval( $data );
 
 			if ( empty( $user_id ) ) {
@@ -359,7 +359,7 @@ class Connector_Jetpack extends Connector {
 				( 'unlink' === $action ) ? esc_html__( 'unlinked', 'stream' ) : esc_html__( 'linked', 'stream' ),
 				( 'unlink' === $action ) ? esc_html__( 'from', 'stream' ) : esc_html__( 'to', 'stream' )
 			);
-		} elseif ( in_array( $method, array( 'register', 'disconnect', 'subsiteregister', 'subsitedisconnect' ) ) ) {
+		} elseif ( in_array( $method, array( 'register', 'disconnect', 'subsiteregister', 'subsitedisconnect' ), true ) ) {
 			$context      = 'blogs';
 			$action       = str_replace( 'subsite', '', $method );
 			$is_multisite = ( 0 === strpos( $method, 'subsite' ) );

--- a/connectors/class-connector-menus.php
+++ b/connectors/class-connector-menus.php
@@ -82,7 +82,7 @@ class Connector_Menus extends Connector {
 			$menus    = wp_get_nav_menus();
 			$menu_ids = wp_list_pluck( $menus, 'term_id' );
 
-			if ( in_array( $record->object_id, $menu_ids ) ) {
+			if ( in_array( $record->object_id, $menu_ids, true ) ) {
 				$links[ esc_html__( 'Edit Menu', 'stream' ) ] = admin_url( 'nav-menus.php?action=edit&menu=' . $record->object_id );
 			}
 		}

--- a/connectors/class-connector-posts.php
+++ b/connectors/class-connector-posts.php
@@ -361,9 +361,8 @@ class Connector_Posts extends Connector {
 		$order    = ( $previous ) ? 'DESC' : 'ASC';
 
 		global $wpdb;
-
+		// @codingStandardsIgnoreStart
 		$revision_id = $wpdb->get_var( // db call okay
-// @codingStandardsIgnoreStart
 			$wpdb->prepare(
 				"SELECT p.ID
 				FROM $wpdb->posts AS p
@@ -375,9 +374,9 @@ class Connector_Posts extends Connector {
 				$revision->post_date,
 				$revision->post_parent
 			)
-// @codingStandardsIgnoreEnd
-// prepare okay
 		);
+		// @codingStandardsIgnoreEnd
+		// prepare okay
 
 		$revision_id = absint( $revision_id );
 

--- a/connectors/class-connector-posts.php
+++ b/connectors/class-connector-posts.php
@@ -363,7 +363,7 @@ class Connector_Posts extends Connector {
 		global $wpdb;
 
 		$revision_id = $wpdb->get_var( // db call okay
-			// @codingStandardsIgnoreStart
+// @codingStandardsIgnoreStart
 			$wpdb->prepare(
 				"SELECT p.ID
 				FROM $wpdb->posts AS p
@@ -375,7 +375,8 @@ class Connector_Posts extends Connector {
 				$revision->post_date,
 				$revision->post_parent
 			)
-			// @codingStandardsIgnoreEnd prepare okay
+// @codingStandardsIgnoreEnd
+// prepare okay
 		);
 
 		$revision_id = absint( $revision_id );

--- a/connectors/class-connector-posts.php
+++ b/connectors/class-connector-posts.php
@@ -146,7 +146,7 @@ class Connector_Posts extends Connector {
 	 * @param \WP_Post $post
 	 */
 	public function callback_transition_post_status( $new, $old, $post ) {
-		if ( in_array( $post->post_type, $this->get_excluded_post_types() ) ) {
+		if ( in_array( $post->post_type, $this->get_excluded_post_types(), true ) ) {
 			return;
 		}
 

--- a/connectors/class-connector-posts.php
+++ b/connectors/class-connector-posts.php
@@ -150,7 +150,7 @@ class Connector_Posts extends Connector {
 			return;
 		}
 
-		if ( in_array( $new, array( 'auto-draft', 'inherit' ) ) ) {
+		if ( in_array( $new, array( 'auto-draft', 'inherit' ), true ) ) {
 			return;
 		} elseif ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return;
@@ -282,7 +282,7 @@ class Connector_Posts extends Connector {
 		$post = get_post( $post_id );
 
 		// We check if post is an instance of WP_Post as it doesn't always resolve in unit testing
-		if ( ! ( $post instanceof \WP_Post ) || in_array( $post->post_type, $this->get_excluded_post_types() )  ) {
+		if ( ! ( $post instanceof \WP_Post ) || in_array( $post->post_type, $this->get_excluded_post_types(), true )  ) {
 			return;
 		}
 

--- a/connectors/class-connector-settings.php
+++ b/connectors/class-connector-settings.php
@@ -446,7 +446,7 @@ class Connector_Settings extends Connector {
 					);
 				},
 				'applicable'   => function( $submenu, $record ) {
-					return $record->context === 'wp_stream';
+					return 'wp_stream' === $record->context;
 				},
 			),
 			'background_header' => array(

--- a/connectors/class-connector-settings.php
+++ b/connectors/class-connector-settings.php
@@ -287,7 +287,7 @@ class Connector_Settings extends Connector {
 
 		if ( isset( $contexts[ $option_name ] ) ) {
 			foreach ( $contexts[ $option_name ] as $context => $keys ) {
-				if ( in_array( $key, $keys ) ) {
+				if ( in_array( $key, $keys, true ) ) {
 					return $context;
 				}
 			}
@@ -313,7 +313,7 @@ class Connector_Settings extends Connector {
 		);
 
 		if ( isset( $ignored[ $option_name ] ) ) {
-			return in_array( $key, $ignored[ $option_name ] );
+			return in_array( $key, $ignored[ $option_name ], true );
 		}
 
 		return false;
@@ -458,7 +458,7 @@ class Connector_Settings extends Connector {
 					return add_query_arg( 'page', $rule['submenu_slug']( $record ), admin_url( $rule['menu_slug'] ) );
 				},
 				'applicable'   => function( $submenu, $record ) {
-					return in_array( $record->context, array( 'custom_header', 'custom_background' ) );
+					return in_array( $record->context, array( 'custom_header', 'custom_background' ), true );
 				},
 			),
 			'general' => array(
@@ -490,7 +490,7 @@ class Connector_Settings extends Connector {
 			),
 		);
 
-		if ( 'settings' !== $record->context && in_array( $record->context, array_keys( $context_labels ) ) ) {
+		if ( 'settings' !== $record->context && in_array( $record->context, array_keys( $context_labels ), true ) ) {
 			global $submenu;
 
 			$applicable_rules = array_filter(
@@ -644,7 +644,7 @@ class Connector_Settings extends Connector {
 		);
 
 		foreach ( $options as $key => $opts ) {
-			if ( in_array( $option, $opts ) ) {
+			if ( in_array( $option, $opts, true ) ) {
 				$context = $key;
 				break;
 			}

--- a/connectors/class-connector-taxonomies.php
+++ b/connectors/class-connector-taxonomies.php
@@ -140,7 +140,7 @@ class Connector_Taxonomies extends Connector {
 	 * @param string $taxonomy
 	 */
 	public function callback_created_term( $term_id, $tt_id, $taxonomy ) {
-		if ( in_array( $taxonomy, $this->get_excluded_taxonomies() ) ) {
+		if ( in_array( $taxonomy, $this->get_excluded_taxonomies(), true ) ) {
 			return;
 		}
 
@@ -173,7 +173,7 @@ class Connector_Taxonomies extends Connector {
 	 * @param object $deleted_term
 	 */
 	public function callback_delete_term( $term_id, $tt_id, $taxonomy, $deleted_term ) {
-		if ( in_array( $taxonomy, $this->get_excluded_taxonomies() ) ) {
+		if ( in_array( $taxonomy, $this->get_excluded_taxonomies(), true ) ) {
 			return;
 		}
 
@@ -209,7 +209,7 @@ class Connector_Taxonomies extends Connector {
 	}
 
 	public function callback_edited_term( $term_id, $tt_id, $taxonomy ) {
-		if ( in_array( $taxonomy, $this->get_excluded_taxonomies() ) ) {
+		if ( in_array( $taxonomy, $this->get_excluded_taxonomies(), true ) ) {
 			return;
 		}
 

--- a/connectors/class-connector-users.php
+++ b/connectors/class-connector-users.php
@@ -116,7 +116,7 @@ class Connector_Users extends Connector {
 		$labels = array();
 
 		foreach ( $roles as $role => $label ) {
-			if ( in_array( $role, (array) $user->roles ) ) {
+			if ( in_array( $role, (array) $user->roles, true ) ) {
 				$labels[] = translate_user_role( $label );
 			}
 		}

--- a/connectors/class-connector-widgets.php
+++ b/connectors/class-connector-widgets.php
@@ -183,7 +183,7 @@ class Connector_Widgets extends Connector {
 			$sidebar_id = '';
 
 			foreach ( $old as $old_sidebar_id => $old_widget_ids ) {
-				if ( in_array( $widget_id, $old_widget_ids ) ) {
+				if ( in_array( $widget_id, $old_widget_ids, true ) ) {
 					$sidebar_id = $old_sidebar_id;
 					break;
 				}
@@ -234,7 +234,7 @@ class Connector_Widgets extends Connector {
 			$sidebar_id = '';
 
 			foreach ( $new as $new_sidebar_id => $new_widget_ids ) {
-				if ( in_array( $widget_id, $new_widget_ids ) ) {
+				if ( in_array( $widget_id, $new_widget_ids, true ) ) {
 					$sidebar_id = $new_sidebar_id;
 					break;
 				}
@@ -288,7 +288,7 @@ class Connector_Widgets extends Connector {
 			$sidebar_id = '';
 
 			foreach ( $old as $old_sidebar_id => $old_widget_ids ) {
-				if ( in_array( $widget_id, $old_widget_ids ) ) {
+				if ( in_array( $widget_id, $old_widget_ids, true ) ) {
 					$sidebar_id = $old_sidebar_id;
 					break;
 				}
@@ -341,7 +341,7 @@ class Connector_Widgets extends Connector {
 			$sidebar_id = '';
 
 			foreach ( $new as $new_sidebar_id => $new_widget_ids ) {
-				if ( in_array( $widget_id, $new_widget_ids ) ) {
+				if ( in_array( $widget_id, $new_widget_ids, true ) ) {
 					$sidebar_id = $new_sidebar_id;
 					break;
 				}
@@ -441,7 +441,7 @@ class Connector_Widgets extends Connector {
 				// Now find the sidebar that the widget was originally located in, as long it is not wp_inactive_widgets
 				$old_sidebar_id = null;
 				foreach ( $old as $sidebar_id => $old_widget_ids ) {
-					if ( in_array( $widget_id, $old_widget_ids ) ) {
+					if ( in_array( $widget_id, $old_widget_ids, true ) ) {
 						$old_sidebar_id = $sidebar_id;
 						break;
 					}
@@ -804,7 +804,7 @@ class Connector_Widgets extends Connector {
 		unset( $sidebars_widgets['array_version'] );
 
 		foreach ( $sidebars_widgets as $sidebar_id => $widget_ids ) {
-			if ( in_array( $widget_id, $widget_ids ) ) {
+			if ( in_array( $widget_id, $widget_ids, true ) ) {
 				return $sidebar_id;
 			}
 		}

--- a/connectors/class-connector-woocommerce.php
+++ b/connectors/class-connector-woocommerce.php
@@ -209,7 +209,7 @@ class Connector_Woocommerce extends Connector {
 	 * @return array Action links
 	 */
 	public function action_links( $links, $record ) {
-		if ( in_array( $record->context, $this->post_types ) && get_post( $record->object_id ) ) {
+		if ( in_array( $record->context, $this->post_types, true ) && get_post( $record->object_id ) ) {
 			if ( $link = get_edit_post_link( $record->object_id ) ) {
 				$posts_connector = new Connector_Posts();
 				$post_type_name = $posts_connector->get_post_type_name( get_post_type( $record->object_id ) );
@@ -293,7 +293,7 @@ class Connector_Woocommerce extends Connector {
 		}
 
 		// Don't track minor status change actions
-		if ( in_array( wp_stream_filter_input( INPUT_GET, 'action' ), array( 'mark_processing', 'mark_on-hold', 'mark_completed' ) ) || defined( 'DOING_AJAX' ) ) {
+		if ( in_array( wp_stream_filter_input( INPUT_GET, 'action' ), array( 'mark_processing', 'mark_on-hold', 'mark_completed' ), true ) || defined( 'DOING_AJAX' ) ) {
 			return;
 		}
 
@@ -302,7 +302,7 @@ class Connector_Woocommerce extends Connector {
 			return;
 		}
 
-		if ( in_array( $new, array( 'auto-draft', 'draft', 'inherit' ) ) ) {
+		if ( in_array( $new, array( 'auto-draft', 'draft', 'inherit' ), true ) ) {
 			return;
 		} elseif ( 'auto-draft' === $old && 'publish' === $new ) {
 			$message = esc_html_x(
@@ -612,9 +612,9 @@ class Connector_Woocommerce extends Connector {
 			}
 
 			// Change connector::posts records
-			if ( 'posts' === $record['connector'] && in_array( $record['context'], $this->post_types ) ) {
+			if ( 'posts' === $record['connector'] && in_array( $record['context'], $this->post_types, true ) ) {
 				$recordarr[ $key ]['connector'] = $this->name;
-			} elseif ( 'taxonomies' === $record['connector'] && in_array( $record['context'], $this->taxonomies ) ) {
+			} elseif ( 'taxonomies' === $record['connector'] && in_array( $record['context'], $this->taxonomies, true ) ) {
 				$recordarr[ $key ]['connector'] = $this->name;
 			} elseif ( 'settings' === $record['connector'] ) {
 				$option = isset( $record['meta']['option_key'] ) ? $record['meta']['option_key'] : false;
@@ -703,7 +703,7 @@ class Connector_Woocommerce extends Connector {
 					$_fields = array_filter(
 						$page->get_settings( $section_key ),
 						function( $item ) {
-							return isset( $item['id'] ) && ( ! in_array( $item['type'], array( 'title', 'sectionend' ) ) );
+							return isset( $item['id'] ) && ( ! in_array( $item['type'], array( 'title', 'sectionend' ), true ) );
 						}
 					);
 

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -49,7 +49,7 @@ class WP_StreamTestCase extends \WP_UnitTestCase {
 			$priority = isset( $test[3] ) ? $test[3] : 10;
 
 			//Default function call
-			$function_call = ( in_array( $function_call, array( 'has_action', 'has_filter' ) ) ) ? $function_call : 'has_action';
+			$function_call = ( in_array( $function_call, array( 'has_action', 'has_filter' ), true ) ) ? $function_call : 'has_action';
 
 			//Run assertion here
 			$this->assertEquals(


### PR DESCRIPTION
Excludes WordPress 3.9 from being tested in conjunction with PHP7.

Errors are being caused because WordPress 3.9 still contains old constructors that are now deprecated. These deprecations are causing errors preventing the build from passing.

Closes #816