### PR TITLE
Remove border-bottom from inactive nav tabs

### DIFF
--- a/ui/css/admin.css
+++ b/ui/css/admin.css
@@ -205,12 +205,6 @@
 
 /* Settings */
 
-.wp_stream_settings .nav-tab-wrapper a:not(.nav-tab-active),
-.wp_stream_network_settings .nav-tab-wrapper a:not(.nav-tab-active)
-.wp_stream_default_settings .nav-tab-wrapper a:not(.nav-tab-active) {
-	border-bottom: 1px solid #ccc;
-}
-
 .wp_stream_settings .select2-container,
 .wp_stream_network_settings .select2-container,
 .wp_stream_default_settings .select2-container {


### PR DESCRIPTION
A border is added to the inactive tabs on the settings page causing the tabs to display incorrectly.

![pasted_image_08_03_16_20_04](https://cloud.githubusercontent.com/assets/4179791/13612745/6bedc4ba-e569-11e5-99fc-247a3b741be7.jpg)