### PR TITLE
Initialize admin class during cron jobs

### DIFF
--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -101,6 +101,8 @@ class Plugin {
 		if ( is_admin() || ( defined( 'WP_STREAM_DEV_DEBUG' ) && WP_STREAM_DEV_DEBUG ) ) {
 			$this->admin   = new Admin( $this );
 			$this->install = new Install( $this );
+		} else if ( defined( 'DOING_CRON' ) && DOING_CRON ) {
+			$this->admin = new Admin( $this );
 		}
 
 		// Load WP-CLI command


### PR DESCRIPTION
The cron job wasn't running because the admin class wasn't initialized outside of the backend. This fix initializes the admin class during cron jobs if it wasn't already initialized with the `WP_STREAM_DEV_DEBUG` constant.

Fixes #830 