### PR TITLE
Fix order status log for WooCommerce >= 2.2

### DIFF
--- a/connectors/class-connector-woocommerce.php
+++ b/connectors/class-connector-woocommerce.php
@@ -54,6 +54,8 @@ class Connector_Woocommerce extends Connector {
 
 	private $settings = array();
 
+	private $plugin_version = null;
+
 	public function register() {
 		parent::register();
 
@@ -72,6 +74,7 @@ class Connector_Woocommerce extends Connector {
 		global $woocommerce;
 
 		if ( class_exists( 'WooCommerce' ) && version_compare( $woocommerce->version, self::PLUGIN_MIN_VERSION, '>=' ) ) {
+			$this->plugin_version = $woocommerce->version;
 			return true;
 		}
 
@@ -413,12 +416,19 @@ class Connector_Woocommerce extends Connector {
 			return;
 		}
 
-		$old_status = wp_stream_is_vip() ? wpcom_vip_get_term_by( 'slug', $old, 'shop_order_status' ) : get_term_by( 'slug', $old, 'shop_order_status' );
-		$new_status = wp_stream_is_vip() ? wpcom_vip_get_term_by( 'slug', $new, 'shop_order_status' ) : get_term_by( 'slug', $new, 'shop_order_status' );
-
 		// Don't track new statuses
-		if ( ! $old_status ) {
+		if ( empty( $old ) ) {
 			return;
+		}
+
+		if ( version_compare( $this->plugin_version, '2.2', '>=' ) ) {
+			$old_status_name = strtolower( wc_get_order_status_name( $old ) );
+			$new_status_name = strtolower( wc_get_order_status_name( $new ) );
+		} else {
+			$old_status = wp_stream_is_vip() ? wpcom_vip_get_term_by( 'slug', $old, 'shop_order_status' ) : get_term_by( 'slug', $old, 'shop_order_status' );
+			$new_status = wp_stream_is_vip() ? wpcom_vip_get_term_by( 'slug', $new, 'shop_order_status' ) : get_term_by( 'slug', $new, 'shop_order_status' );
+			$new_status_name = strtolower( $new_status->name );
+			$old_status_name = strtolower( $old_status->name );
 		}
 
 		$message = esc_html_x(
@@ -430,8 +440,6 @@ class Connector_Woocommerce extends Connector {
 		$order           = new \WC_Order( $order_id );
 		$order_title     = esc_html__( 'Order number', 'stream' ) . ' ' . esc_html( $order->get_order_number() );
 		$order_type_name = esc_html__( 'order', 'stream' );
-		$new_status_name = strtolower( $new_status->name );
-		$old_status_name = strtolower( $old_status->name );
 
 		$this->log(
 			$message,


### PR DESCRIPTION
Per https://woocommerce.wordpress.com/2014/08/07/wc-2-2-order-statuses-plugin-compatibility/ WooCommerce switched from using a taxonomy for shop_order_status to using post_status.
