### PR TITLE
Use the correct label for events relating to taxonomies which are registered after initial loading.

### DIFF
--- a/connectors/class-connector-taxonomies.php
+++ b/connectors/class-connector-taxonomies.php
@@ -123,7 +123,7 @@ class Connector_Taxonomies extends Connector {
 		unset( $object_type );
 
 		$taxonomy_obj = (object) $args;
-		$label        = get_taxonomy_labels( $taxonomy_obj )->name;
+		$label        = get_taxonomy_labels( $taxonomy_obj )->singular_name;
 
 		$this->context_labels[ $taxonomy ] = $label;
 


### PR DESCRIPTION
Given a custom taxonomy which is registered after Stream initialises, the plural label is incorrectly used to build the event summary.

This results in a summary such as `"Foo" features updated` instead of `"Foo" feature updated` when the term is updated.