### PR TITLE
Bugfix: #836 Custom Roles not tracking

### DIFF
--- a/classes/class-install.php
+++ b/classes/class-install.php
@@ -399,7 +399,7 @@ class Install {
 			blog_id bigint(20) unsigned NOT NULL DEFAULT '1',
 			object_id bigint(20) unsigned NULL,
 			user_id bigint(20) unsigned NOT NULL DEFAULT '0',
-			user_role varchar(20) NOT NULL DEFAULT '',
+			user_role varchar(50) NOT NULL DEFAULT '',
 			summary longtext NOT NULL,
 			created datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
 			connector varchar(100) NOT NULL,

--- a/classes/class-install.php
+++ b/classes/class-install.php
@@ -337,6 +337,7 @@ class Install {
 		$db_update_versions = array(
 			'3.0.0' /* @version 3.0.0 Drop the stream_context table, changes to stream table */,
 			'3.0.2' /* @version 3.0.2 Fix uppercase values in stream table, connector column */,
+			'3.0.8' /* @version 3.0.8 Increase size of user role IDs, user_roll column */,
 		);
 
 		/**

--- a/classes/class-install.php
+++ b/classes/class-install.php
@@ -76,8 +76,6 @@ class Install {
 	 * @return void
 	 */
 	public function check() {
-		global $wpdb;
-
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
 			return;
 		}
@@ -97,15 +95,16 @@ class Install {
 		if ( ! $update ) {
 			$this->update_required = true;
 			$this->success_db      = $this->update( $this->db_version, $this->plugin->get_version(), array( 'type' => 'auto' ) );
-		} elseif ( 'update_and_continue' === $update ) {
+		}
+
+		if ( 'update_and_continue' === $update ) {
 			$this->success_db = $this->update( $this->db_version, $this->plugin->get_version(), array( 'type' => 'user' ) );
 		}
 
 		$versions = $this->db_update_versions();
 
-		if ( version_compare( end( $versions ), $this->db_version, '>' ) ) {
+		if ( ! $this->success_db && version_compare( end( $versions ), $this->db_version, '>' ) ) {
 			add_action( 'all_admin_notices', array( $this, 'update_notice_hook' ) );
-
 			return;
 		}
 

--- a/includes/db-updates.php
+++ b/includes/db-updates.php
@@ -9,7 +9,7 @@
  *
  * @return string
  */
-function wp_stream_update_308( $db_version, $current_version ) {
+function wp_stream_auto_update_308( $db_version, $current_version ) {
 	$plugin = wp_stream_get_instance();
 	$plugin->install->install( $current_version );
 

--- a/includes/db-updates.php
+++ b/includes/db-updates.php
@@ -9,7 +9,7 @@
  *
  * @return string
  */
-function wp_stream_auto_update_308( $db_version, $current_version ) {
+function wp_stream_update_auto_308( $db_version, $current_version ) {
 	$plugin = wp_stream_get_instance();
 	$plugin->install->install( $current_version );
 

--- a/includes/db-updates.php
+++ b/includes/db-updates.php
@@ -1,5 +1,22 @@
 <?php
 /**
+ * Version 3.0.8
+ *
+ * Force update for older versions to call \dbdelta in install() method to fix column widths.
+ *
+ * @param string $db_version
+ * @param string $current_version
+ *
+ * @return string
+ */
+function wp_stream_update_308( $db_version, $current_version ) {
+	$plugin = wp_stream_get_instance();
+	$plugin->install->install( $current_version );
+
+	return $current_version;
+}
+
+/**
  * Version 3.0.2
  *
  * @param string $db_version

--- a/tests/tests/test-class-log.php
+++ b/tests/tests/test-class-log.php
@@ -1,0 +1,68 @@
+<?php
+namespace WP_Stream;
+
+class Test_Log extends WP_StreamTestCase {
+
+	public function setUp() {
+		parent::setUp();
+
+		$admin_role = get_role( 'administrator' );
+
+		/**
+		 * Add user roles for testing.
+		 */
+		$role = 'this_longish_user_role_slug_to_be_logged_in_stream';
+		$long = get_role( $role );
+		if ( ! $long ) {
+			$long = add_role(
+				$role,
+				'This longish user_role slug to be logged in stream',
+				(array) $admin_role->capabilities
+			);
+		}
+
+		$role = 'this_is_a_really_long_user_role_slug_that_will_not_be_logged_in_stream';
+		$extra_long = get_role( $role );
+		if ( ! $extra_long ) {
+			$extra_long = add_role(
+				$role,
+				'This is a really long user_role slug that will not be logged in stream',
+				(array) $admin_role->capabilities
+			);
+		}
+
+		/**
+		 * Add users for testing and assign roles.
+		 */
+		$user_id = wp_create_user( 'test1', 'password', 'test1@example.com' );
+		wp_update_user( array( 'ID' => $user_id, 'role' => $long->name ) );
+
+		$user_id = wp_create_user( 'test2', 'password', 'test2@example.com' );
+		wp_update_user( array( 'ID' => $user_id, 'role' => $extra_long->name ) );
+	}
+
+	public function test_field_lengths() {
+
+		$user1 = get_user_by( 'slug', 'test1' );
+		$user2 = get_user_by( 'slug', 'test2' );
+
+		// Test user_role length (<=50)
+		$result = $this->plugin->log->log( 'test_connector', 'Test user_role 1', array(), 0, 'settings', 'test', $user1->ID );
+		$this->assertNotEmpty( $result );
+		$record = $this->plugin->db->query( array( 'search' => $result, 'search_field' => 'ID' ) );
+		$this->assertEquals( $result, $record[0]->ID );
+
+		// Test user_role length (>50)
+		$result = $this->plugin->log->log( 'test_connector', 'Test user_role 2', array(), 0, 'settings', 'test', $user2->ID );
+		$this->assertEmpty( $result );
+
+		// Test connector length
+
+		// Test context length
+
+		// Test action length
+
+		// Test IP length
+		
+	}
+}

--- a/tests/tests/test-class-plugin.php
+++ b/tests/tests/test-class-plugin.php
@@ -33,6 +33,16 @@ class Test_Plugin extends WP_StreamTestCase {
 	public function test_i18n() {
 		global $l10n;
 
+		/**
+		 * Make sure we get the correct MO file during tests.
+		 * WP looks in develop installation where MO file is not found.
+		 */
+		add_filter( 'load_textdomain_mofile', function( $mofile ) {
+			$locale = get_locale();
+			$mofile = sprintf( '%s/languages/stream-%s.mo', $this->plugin->locations['dir'], $locale );
+			return $mofile;
+		} );
+
 		$this->plugin->i18n();
 		$this->assertArrayHasKey( 'stream', $l10n );
 	}


### PR DESCRIPTION
Addresses https://github.com/xwp/stream/issues/836 where longer custom user rolls are not getting entries into the database.

The column size of 20 characters does not pass string validation for user rolls with longer lengths and causes a WP_Error and in turn a `wp_stream_record_insert_error`.