### PR TITLE
Fix shipping methods for WooCommerce connector

### DIFF
--- a/connectors/class-connector-woocommerce.php
+++ b/connectors/class-connector-woocommerce.php
@@ -751,7 +751,7 @@ class Connector_Woocommerce extends Connector {
 			$shipping_method_settings = array();
 			$shipping_methods         = $woocommerce->shipping();
 
-			foreach ( $shipping_methods->shipping_methods as $section_key => $shipping_method ) {
+			foreach ( $shipping_methods->get_shipping_methods() as $section_key => $shipping_method ) {
 				$title = $shipping_method->title;
 				$key   = $shipping_method->plugin_id . $shipping_method->id . '_settings';
 


### PR DESCRIPTION
`shipping_methods` is `null` by default and will throw a error if isn't array, better to use `get_shipping_methods` method (or check that `shipping_methods` is a array before using it as a array)