### PR TITLE
Create add new alert inline on alerts listing page.

### DIFF
--- a/alerts/class-alert-trigger-action.php
+++ b/alerts/class-alert-trigger-action.php
@@ -60,9 +60,9 @@ class Alert_Trigger_Action extends Alert_Trigger {
 	 * @param Alert          $alert The Alert being worked on.
 	 * @return void
 	 */
-	public function add_fields( $form, $alert ) {
+	public function add_fields( $form, $alert = array() ) {
 		$value = '';
-		if ( ! empty( $alert->alert_meta['trigger_action'] ) ) {
+		if ( is_object( $alert ) && ! empty( $alert->alert_meta['trigger_action'] ) ) {
 			$value = $alert->alert_meta['trigger_action'];
 		}
 

--- a/alerts/class-alert-trigger-author.php
+++ b/alerts/class-alert-trigger-author.php
@@ -52,9 +52,9 @@ class Alert_Trigger_Author extends Alert_Trigger {
 	 * @param Alert          $alert The Alert being worked on.
 	 * @return void
 	 */
-	public function add_fields( $form, $alert ) {
+	public function add_fields( $form, $alert = array() ) {
 		$value = '';
-		if ( ! empty( $alert->alert_meta['trigger_author'] ) ) {
+		if ( is_object( $alert ) && ! empty( $alert->alert_meta['trigger_author'] ) ) {
 			$value = $alert->alert_meta['trigger_author'];
 		}
 

--- a/alerts/class-alert-trigger-context.php
+++ b/alerts/class-alert-trigger-context.php
@@ -55,9 +55,9 @@ class Alert_Trigger_Context extends Alert_Trigger {
 	 * @param Alert          $alert The Alert being worked on.
 	 * @return void
 	 */
-	public function add_fields( $form, $alert ) {
+	public function add_fields( $form, $alert = array() ) {
 		$connector = '';
-		if ( ! empty( $alert->alert_meta['trigger_connector'] ) ) {
+		if ( is_object( $alert ) && ! empty( $alert->alert_meta['trigger_connector'] ) ) {
 			$connector = $alert->alert_meta['trigger_connector'];
 		}
 

--- a/alerts/class-alert-type-highlight.php
+++ b/alerts/class-alert-type-highlight.php
@@ -77,6 +77,8 @@ class Alert_Type_Highlight extends Alert_Type {
 				add_filter( 'wp_stream_action_links_' . $connector->name, array( $this, 'action_link_remove_highlight' ), 10, 2 );
 			}
 		}
+
+		add_filter( 'wp_stream_alerts_save_meta', array( $this, 'add_alert_meta' ), 10, 2 );
 	}
 
 	/**
@@ -117,7 +119,23 @@ class Alert_Type_Highlight extends Alert_Type {
 			'value'   => $options['color'],
 		) );
 	}
+	/**
+	 * Displays a settings form for the alert type
+	 *
+	 * @param Alert $alert Alert object for the currently displayed alert.
+	 * @return void
+	 */
+	public function display_new_fields() {
+		$form = new Form_Generator;
 
+		echo '<p>' . esc_html__( 'Color', 'stream' ) . ':</p>';
+		echo $form->render_field( 'select', array( // Xss ok.
+			'name'    => 'wp_stream_highlight_color',
+			'title'   => esc_attr( __( 'Highlight Color', 'stream' ) ),
+			'options' => $this->get_highlight_options(),
+			'value'   => '',
+		) );
+	}
 	/**
 	 * Lists available color options for alerts.
 	 *
@@ -268,5 +286,25 @@ class Alert_Type_Highlight extends Alert_Type {
 			wp_add_inline_script( self::SCRIPT_HANDLE, 'streamAlertTypeHighlight.init();', 'after' );
 			wp_enqueue_script( self::SCRIPT_HANDLE );
 		}
+	}
+
+	/**
+	 * Add alert meta if this is a highlight alert
+	 *
+	 * @param array  $alert_meta The metadata to be inserted for this alert.
+	 * @param string $alert_type The type of alert being added or updated.
+	 *
+	 * @return mixed
+	 */
+	public function add_alert_meta( $alert_meta, $alert_type ) {
+		if ( $this->slug === $alert_type ) {
+			$color = wp_stream_filter_input( INPUT_POST, 'wp_stream_highlight_color' );
+			if ( empty( $color ) ) {
+				$alert_meta['color'] = 'yellow';
+			} else {
+				$alert_meta['color'] = $color;
+			}
+		}
+		return $alert_meta;
 	}
 }

--- a/alerts/class-alert-type-iftt.php
+++ b/alerts/class-alert-type-iftt.php
@@ -64,6 +64,20 @@ class Alert_Type_IFTT extends Alert_Type {
 	public $slug = 'iftt';
 
 	/**
+	 * Class Constructor
+	 *
+	 * @param Plugin $plugin Plugin object.
+	 * @return void
+	 */
+	public function __construct( $plugin ) {
+		parent::__construct( $plugin );
+		$this->plugin = $plugin;
+		if ( ! is_admin() ) {
+			return;
+		}
+		add_filter( 'wp_stream_alerts_save_meta', array( $this, 'add_alert_meta' ), 10, 2 );
+	}
+		/**
 	 * Record that the Alert was triggered by a Record.
 	 *
 	 * In self::post_class() this value is checked so we can determine
@@ -107,7 +121,28 @@ class Alert_Type_IFTT extends Alert_Type {
 			'value'   => $options['event_name'],
 		) );
 	}
+	/**
+	 * Displays a settings form for the alert type
+	 *
+	 * @param Alert $alert Alert object for the currently displayed alert.
+	 * @return void
+	 */
+	public function display_new_fields() {
+		$form = new Form_Generator;
 
+		echo '<p>' . esc_html__( 'IFTT Maker Key', 'stream' ) . ':</p>';
+		echo $form->render_field( 'text', array( // Xss ok.
+			'name'    => 'wp_stream_iftt_maker_key',
+			'title'   => esc_attr( __( 'Maker Key', 'stream' ) ),
+			'value'   => '',
+		) );
+		echo '<p>' . esc_html__( 'IFTT Event Name', 'stream' ) . ':</p>';
+		echo $form->render_field( 'text', array( // Xss ok.
+			'name'    => 'wp_stream_iftt_event_name',
+			'title'   => esc_attr( __( 'Event Name', 'stream' ) ),
+			'value'   => '',
+		) );
+	}
 	/**
 	 * Validates and saves form settings for later use.
 	 *
@@ -242,5 +277,26 @@ class Alert_Type_IFTT extends Alert_Type {
 			return false;
 		}
 		return true;
+	}
+	/**
+	 * Add alert meta if this is a highlight alert
+	 *
+	 * @param array  $alert_meta The metadata to be inserted for this alert.
+	 * @param string $alert_type The type of alert being added or updated.
+	 *
+	 * @return mixed
+	 */
+	public function add_alert_meta( $alert_meta, $alert_type ) {
+		if ( $this->slug === $alert_type ) {
+			$maker_key = wp_stream_filter_input( INPUT_POST, 'wp_stream_iftt_maker_key' );
+			if ( ! empty( $maker_key ) ) {
+				$alert_meta['maker_key'] = $maker_key;
+			}
+			$event_name = wp_stream_filter_input( INPUT_POST, 'wp_stream_iftt_event_name' );
+			if ( ! empty( $event_name ) ) {
+				$alert_meta['$event_name'] = $event_name;
+			}
+		}
+		return $alert_meta;
 	}
 }

--- a/alerts/class-alert-type-menu-alert.php
+++ b/alerts/class-alert-type-menu-alert.php
@@ -72,7 +72,23 @@ class Alert_Type_Menu_Alert extends Alert_Type {
 
 		echo $form->render_all(); // Xss ok.
 	}
+	/**
+	 * Displays a settings form for the alert type
+	 *
+	 * @param Alert $alert Alert object for the currently displayed alert.
+	 * @return void
+	 */
+	public function display_new_fields() {
+		$form = new Form_Generator;
+		$form->add_field( 'checkbox', array(
+			'name'  => 'wp_stream_menu_alert_clear_immediate',
+			'text'  => esc_attr( __( 'Clear alerts after seen.', 'stream' ) ),
+			'value' => '',
+			'title' => __( 'Menu Bar', 'stream' ),
+		) );
 
+		echo $form->render_all(); // Xss ok.
+	}
 	/**
 	 * Validates and saves form settings for later use.
 	 *

--- a/classes/class-alert-type.php
+++ b/classes/class-alert-type.php
@@ -59,6 +59,13 @@ abstract class Alert_Type {
 	}
 
 	/**
+	 * Display blank settings form for configuration of new individual alerts
+	 */
+	public function display_new_fields() {
+		return;
+	}
+
+	/**
 	 * Process settings form for configuration of individual alerts
 	 *
 	 * @param Alert $alert Alert currently being worked on.

--- a/classes/class-alerts-list.php
+++ b/classes/class-alerts-list.php
@@ -34,12 +34,14 @@ class Alerts_List {
 
 		// @todo Make more specific
 		if ( is_admin() ) {
-				add_filter( 'request', array( $this, 'parse_request' ), 10, 2 );
+			add_filter( 'request', array( $this, 'parse_request' ), 10, 2 );
 		}
 		add_filter( 'views_edit-wp_stream_alerts', array( $this, 'manage_views' ) );
 
 		add_filter( 'manage_wp_stream_alerts_posts_columns', array( $this, 'manage_columns' ) );
 		add_action( 'manage_wp_stream_alerts_posts_custom_column', array( $this, 'column_data' ), 10, 2 );
+
+		add_action( 'in_admin_footer', array( $this, 'add_new_form' ) );
 
 	}
 
@@ -187,5 +189,26 @@ class Alerts_List {
 			$status = true;
 		}
 		return $status;
+	}
+
+	/**
+	 * Add a new hidden form to use for creating new alerts.
+	 */
+	public function add_new_form() {
+		$screen = get_current_screen();
+		if ( 'edit-wp_stream_alerts' === $screen->id ) {
+			?>
+			<div id="new-alert-triggers">
+				<?php
+				$this->plugin->alerts->display_triggers_box();
+				?>
+			</div>
+			<div id="new-alert-notifications">
+				<?php
+				$this->plugin->alerts->display_notification_box();
+				?>
+			</div>
+			<?php
+		}
 	}
 }

--- a/classes/class-alerts-list.php
+++ b/classes/class-alerts-list.php
@@ -41,8 +41,6 @@ class Alerts_List {
 		add_filter( 'manage_wp_stream_alerts_posts_columns', array( $this, 'manage_columns' ) );
 		add_action( 'manage_wp_stream_alerts_posts_custom_column', array( $this, 'column_data' ), 10, 2 );
 
-		add_action( 'in_admin_footer', array( $this, 'add_new_form' ) );
-
 	}
 
 	/**
@@ -189,26 +187,5 @@ class Alerts_List {
 			$status = true;
 		}
 		return $status;
-	}
-
-	/**
-	 * Add a new hidden form to use for creating new alerts.
-	 */
-	public function add_new_form() {
-		$screen = get_current_screen();
-		if ( 'edit-wp_stream_alerts' === $screen->id ) {
-			?>
-			<div id="new-alert-triggers">
-				<?php
-				$this->plugin->alerts->display_triggers_box();
-				?>
-			</div>
-			<div id="new-alert-notifications">
-				<?php
-				$this->plugin->alerts->display_notification_box();
-				?>
-			</div>
-			<?php
-		}
 	}
 }

--- a/classes/class-alerts.php
+++ b/classes/class-alerts.php
@@ -83,6 +83,7 @@ class Alerts {
 		add_action( 'wp_ajax_load_alert_preview', array( $this, 'display_preview_box_ajax' ) );
 		add_action( 'wp_ajax_update_actions', array( $this, 'update_actions' ) );
 		add_action( 'wp_ajax_save_new_alert', array( $this, 'save_new_alert' ) );
+		add_action( 'wp_ajax_get_new_alert_triggers_notifications', array( $this, 'get_new_alert_triggers_notifications' ) );
 
 		$this->load_alert_types();
 		$this->load_alert_triggers();
@@ -870,5 +871,23 @@ class Alerts {
 		$alert_meta = apply_filters( 'wp_stream_alerts_save_meta', $alert_meta, $alert_type );
 		add_post_meta( $post_id, 'alert_meta', $alert_meta );
 		wp_send_json_success( array( 'success' => true ) );
+	}
+
+	/**
+	 *
+	 */
+	function get_new_alert_triggers_notifications() {
+		ob_start();
+		?>
+<fieldset class="inline-edit-col-left">
+	<legend class="inline-edit-legend">Add New Alert</legend>
+	<?php $GLOBALS['wp_stream']->alerts->display_triggers_box(); ?>
+</fieldset>
+<fieldset class="inline-edit-col-right">
+	<?php $GLOBALS['wp_stream']->alerts->display_notification_box(); ?>
+</fieldset>
+	<?php
+		$html = ob_get_clean();
+		wp_send_json_success( array( 'success' => true, 'html' => $html ) );
 	}
 }

--- a/classes/class-form-generator.php
+++ b/classes/class-form-generator.php
@@ -116,7 +116,7 @@ class Form_Generator {
 
 				$multiple = ( $args['multiple'] ) ? 'multiple ' : '';
 				$output = sprintf(
-					'<select name="%1$s" id="%1$s" class="select2-select %2$s" %3$s%4$s/>',
+					'<select name="%1$s" id="%1$s" class="select2-select %2$s" %3$s%4$s>',
 					esc_attr( $args['name'] ),
 					esc_attr( $args['classes'] ),
 					$this->prepare_data_attributes_string( $args['data'] ),

--- a/ui/css/admin.css
+++ b/ui/css/admin.css
@@ -625,7 +625,12 @@
 #wp_stream_alerts_preview td.summary.column-summary .row-actions {
 	display: none;
 }
-
+body.post-type-wp_stream_alerts .select2-results__option .parent {
+	font-weight: bold;
+}
+body.post-type-wp_stream_alerts .select2-results__option .child {
+	padding-left: 8px;
+}
 /* Extensions */
 
 .post-type-stream_notification .view-switch {

--- a/ui/js/alerts.js
+++ b/ui/js/alerts.js
@@ -190,7 +190,7 @@ jQuery( function( $ ) {
 			'wp_stream_trigger_author':  $('#wp_stream_trigger_author').val(),
 			'wp_stream_trigger_context': $('#wp_stream_trigger_connector_or_context').val(),
 			'wp_stream_trigger_action':  $('#wp_stream_trigger_action').val(),
-			'wp_stream_alert_type':      $('#wp_stream_alert_type').val(),
+			'wp_stream_alert_type':      $('#wp_stream_alert_type').val()
 		};
 		$('#wp_stream_alert_type_form :input').each( function(){
 			var alert_type_data_id = $(this).attr('id');

--- a/ui/js/alerts.js
+++ b/ui/js/alerts.js
@@ -1,80 +1,82 @@
 /* globals jQuery, streamAlerts, JSON */
 jQuery( function( $ ) {
-	$( '.select2-select.connector_or_context' ).each( function( k, el ) {
-		$( el ).select2({
-			allowClear: true,
-			placeholder: streamAlerts.anyContext,
-			templateResult: function( item ) {
-				if ( 'undefined' === typeof item.id ) {
-					return item.text;
-				}
-				if ( -1 === item.id.indexOf( '-' ) ) {
-					return $( '<span class="parent">' + item.text + '</span>' );
-				} else {
-					return $( '<span class="child">' + item.text + '</span>' );
-				}
-			},
-			matcher: function( params, data ) {
-				var match = $.extend( true, {}, data );
+	var setupSelectTwo = function setupSelectTwo() {
+		$('#the-list .select2-select.connector_or_context').each(function (k, el) {
+			$(el).select2({
+				allowClear: true,
+				placeholder: streamAlerts.anyContext,
+				templateResult: function (item) {
+					if ('undefined' === typeof item.id) {
+						return item.text;
+					}
+					if (-1 === item.id.indexOf('-')) {
+						return $('<span class="parent">' + item.text + '</span>');
+					} else {
+						return $('<span class="child">' + item.text + '</span>');
+					}
+				},
+				matcher: function (params, data) {
+					var match = $.extend(true, {}, data);
 
-				if ( null == params.term || '' === $.trim( params.term ) ) {
-					return match;
-				}
+					if (null == params.term || '' === $.trim(params.term)) {
+						return match;
+					}
 
-				var term = params.term.toLowerCase();
+					var term = params.term.toLowerCase();
 
-				match.id = match.id.replace( 'blogs', 'sites' );
-				if ( match.id.toLowerCase().indexOf( term ) >= 0 ) {
-					return match;
-				}
+					match.id = match.id.replace('blogs', 'sites');
+					if (match.id.toLowerCase().indexOf(term) >= 0) {
+						return match;
+					}
 
-				if ( match.children ) {
-					for ( var i = match.children.length - 1; i >= 0; i-- ) {
-						var child = match.children[i];
+					if (match.children) {
+						for (var i = match.children.length - 1; i >= 0; i--) {
+							var child = match.children[i];
 
-						// Remove term from results if it doesn't match.
-						if ( -1 === child.id.toLowerCase().indexOf( term ) ) {
-							match.children.splice( i, 1 );
+							// Remove term from results if it doesn't match.
+							if (-1 === child.id.toLowerCase().indexOf(term)) {
+								match.children.splice(i, 1);
+							}
+						}
+
+						if (match.children.length > 0) {
+							return match;
 						}
 					}
 
-					if ( match.children.length > 0 ) {
-						return match;
-					}
+					return null;
 				}
+			}).change(function () {
+				var value = $(this).val();
+				if (value) {
+					var parts = value.split('-');
+					$(this).siblings('.connector').val(parts[0]);
+					$(this).siblings('.context').val(parts[1]);
+					$(this).removeAttr('name');
+				}
+			});
 
-				return null;
+			var parts = [
+				$(el).siblings('.connector').val(),
+				$(el).siblings('.context').val()
+			];
+			if ('' === parts[1]) {
+				parts.splice(1, 1);
 			}
-		}).change( function() {
-			var value = $( this ).val();
-			if ( value ) {
-				var parts = value.split( '-' );
-				$( this ).siblings( '.connector' ).val( parts[0] );
-				$( this ).siblings( '.context' ).val( parts[1] );
-				$( this ).removeAttr( 'name' );
-			}
+			$(el).val(parts.join('-')).trigger('change');
 		});
 
-		var parts = [
-			$( el ).siblings( '.connector' ).val(),
-			$( el ).siblings( '.context' ).val()
-		];
-		if ( '' === parts[1] ) {
-			parts.splice( 1, 1 );
-		}
-		$( el ).val( parts.join( '-' ) ).trigger( 'change' );
-	});
-
-	$( '.select2-select:not(.connector_or_context)' ).each( function() {
-		var element_id_split = $( this ).attr( 'id').split( '_' );
-		var select_name = element_id_split[ element_id_split.length - 1 ].charAt(0).toUpperCase() +
-			element_id_split[ element_id_split.length - 1 ].slice(1);
-		$( this ).select2( {
-			allowClear: true,
-			placeholder: streamAlerts.any + ' ' + select_name
+		$('#the-list .select2-select:not(.connector_or_context)').each(function () {
+			var element_id_split = $(this).attr('id').split('_');
+			var select_name = element_id_split[element_id_split.length - 1].charAt(0).toUpperCase() +
+				element_id_split[element_id_split.length - 1].slice(1);
+			$(this).select2({
+				allowClear: true,
+				placeholder: streamAlerts.any + ' ' + select_name
+			});
 		});
-	});
-
+	};
+	setupSelectTwo();
 	var $alertSettingSelect = $( '#wp_stream_alert_type' ),
 		$alertSettingForm   = $( '#wp_stream_alert_type_form' );
 
@@ -82,22 +84,21 @@ jQuery( function( $ ) {
 		var data = {
 			'action'     : 'load_alerts_settings',
 			'alert_type' : alert_type,
-			'post_id'    : $( '#post_ID' ).val()
+			// 'post_id'    : $( '#post_ID' ).val()
 		};
 
 		$( '#wp_stream_alerts_triggers input.wp_stream_ajax_forward' ).each( function() {
 			data[ $( this ).attr( 'name' ) ] = $( this ).val();
 		} );
-
 		$.post( window.ajaxurl, data, function( response ) {
-			$alertSettingForm.html( response.data.html );
+			$( '#wp_stream_alert_type_form' ).html( response.data.html );
 		});
 	};
 
 	var $alertTriggersSelect = $( '#wp_stream_alerts_triggers select.wp_stream_ajax_forward' ),
 		$alertPreviewTable   = $( '#wp_stream_alerts_preview .inside' );
-
-	$alertTriggersSelect.change( function() {
+	$( 'body' ).on('change', '#wp_stream_trigger_connector_or_context', function() {
+	//$alertTriggersSelect.change( function() {
 		loadAlertPreview();
 		if ( 'wp_stream_trigger_connector_or_context' === $(this).attr('id') ) {
 			var connector = $(this).val();
@@ -150,4 +151,59 @@ jQuery( function( $ ) {
 	$alertSettingSelect.change( function() {
 		loadAlertSettings( $( this ).val() );
 	});
+	//$('.new-alert-box').hide();
+	var new_alert_triggers = $('#new-alert-triggers').clone( true );
+	var new_alert_notifications = $('#new-alert-notifications').clone( true );
+	$( 'tbody#the-list' ).prepend( '<tr id="add-new-alert" class="inline-edit-row inline-edit-row-page inline-edit-page quick-edit-row quick-edit-row-page inline-edit-page inline-editor" style=""><td colspan="5" class="colspanchange"><fieldset class="inline-edit-col-left"><legend class="inline-edit-legend">Add New Alert</legend>'+new_alert_triggers[0].innerHTML+'</fieldset><fieldset class="inline-edit-col-right">'+new_alert_notifications[0].innerHTML+'</fieldset><p class="submit inline-edit-save"> <button type="button" class="button-secondary cancel alignleft">Cancel</button> <input type="hidden" id="_inline_edit" name="_inline_edit" value="3550d271fe"> <button type="button" class="button-primary save alignright">Update</button> <span class="spinner"></span> <input type="hidden" name="post_view" value="list"> <input type="hidden" name="screen" value="edit-page"> <span class="error" style="display:none"></span> <br class="clear"></p></td></tr>');
+	$('#new-alert-triggers').remove();
+	$('#new-alert-notifications').remove();
+	$('#add-new-alert').hide();
+
+	$( 'a.page-title-action' ).on( 'click', function( e ) {
+		e.preventDefault();
+		if ( ! $( '#add-new-alert' ).is( ':visible' ) ) {
+			var add_new_alert = $( '#add-new-alert' );
+			add_new_alert.show();
+			var current_bg_color = add_new_alert.css( 'background-color' );
+
+			// Color taken from /wp-admin/css/forms.css
+			// #pass-strength-result.strong
+			add_new_alert.css( 'background-color', '#C1E1B9' );
+			setTimeout(function () {
+				add_new_alert.css( 'background-color', current_bg_color );
+			}, 250);
+			setupSelectTwo();
+			$( '#wp_stream_alert_type' ).change( function () {
+				loadAlertSettings( $( this ).val() );
+			});
+			$( '#add-new-alert .button-secondary.cancel' ).on( 'click', function () {
+				$( '#add-new-alert' ).hide();
+			});
+			$( '#add-new-alert .button-primary.save' ).on( 'click', save_new_alert );
+		}
+	});
+	var save_new_alert = function save_new_alert( e ) {
+		e.preventDefault();
+
+		var data = {
+			'action':          'save_new_alert',
+			'wp_stream_trigger_author':  $('#wp_stream_trigger_author').val(),
+			'wp_stream_trigger_context': $('#wp_stream_trigger_connector_or_context').val(),
+			'wp_stream_trigger_action':  $('#wp_stream_trigger_action').val(),
+			'wp_stream_alert_type':      $('#wp_stream_alert_type').val(),
+		};
+		$('#wp_stream_alert_type_form :input').each( function(){
+			var alert_type_data_id = $(this).attr('id');
+			if ( $(this).val() ) {
+				data[alert_type_data_id] = $(this).val();
+			}
+		});
+
+		$.post( window.ajaxurl, data, function( response ) {
+			if ( true === response.success ) {
+				$( '#add-new-alert' ).css( 'background-color', '#C1E1B9' );
+				location.reload();
+			}
+		});
+	};
 });


### PR DESCRIPTION
This is a rough (working) draft for adding new alerts on the alerts listing page instead of using a new post page. A lot of the existing functions relied on the fact that the post object was already present but in this case we need to create it so some functions had to be changed and some new ones added to show the form fields. 

Here is a quick demo:
http://i.imgur.com/BPzvtBX.gifv

This is still a bit sloppy: the form fields could be brought in via AJAX (right now hidden form fields are brought in from the footer), the new alert could be added to the list without refreshing, and some code could be consolidated / improved. I just wanted to get it out there for people to have a look or help out. 