### PR TITLE
Fix "trim() expects parameter 1 to be string, array given"

### DIFF
--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -84,7 +84,9 @@ class Settings {
 			'message' => esc_html__( 'There was an error in the request', 'stream' ),
 		);
 
-		$search = wp_unslash( trim( wp_stream_filter_input( INPUT_POST, 'find' ) ) );
+		$search = wp_stream_filter_input( INPUT_POST, 'find' );
+		$search = is_string( $search ) ? trim( $search ) : $search;
+		$search = wp_unslash( $search );
 
 		$request = (object) array(
 			'find' => $search,


### PR DESCRIPTION
Sometimes `wp_stream_filter_input` returns a array than a string and you can't use `trim` with array. This pull request will solve that problem.

<img width="849" alt="skarmklipp 2016-11-04 14 19 08" src="https://cloud.githubusercontent.com/assets/14610/20006848/c1ce3bd8-a299-11e6-9a29-8b3a8857f55e.png">
