### PR TITLE
Codeclimate & Editorconfig support

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,64 @@
+---
+engines:
+  csslint:
+    enabled: true
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - javascript
+      - php
+  fixme:
+    enabled: true
+  phpcodesniffer:
+    enabled: true
+    config:
+      standard: "WordPress-Core,WordPress-Docs,WordPress-Extra"
+  phpmd:
+    enabled: true
+    checks:
+      Controversial/CamelCaseParameterName:
+        enabled: false
+      Controversial/CamelCaseMethodName:
+        enabled: false
+      Controversial/CamelCasePropertyName:
+        enabled: false
+      Controversial/CamelCaseVariableName:
+        enabled: false
+      CleanCode/ElseExpression:
+        enabled: false
+  eslint:
+    enabled: true
+    channel: "eslint-2"
+  scss-lint:
+    enabled: true
+  markdownlint:
+    enabled: true
+ratings:
+  paths:
+  - "**.css"
+  - "**.scss"
+  - "**.inc"
+  - "**.js"
+  - "**.jsx"
+  - "**.module"
+  - "**.php"
+  - "**.md"
+  - "**.py"
+  - "**.rb"
+exclude_paths:
+  - "**.png"
+  - "**.jpg"
+  - "**.gif"
+  - "gulpfile.js"
+  - "composer.lock"
+  - "phpcs.xml"
+  - "**.json"
+  - "**.pot"
+  - "**.txt"
+  - "**-min.js"
+  - "**-min.css"
+  - "**.min.js"
+  - "**.min.css"
+  - "**.dist"
+  - "**.sh"

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# https://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[{.jshintrc,*.json,*.yml}]
+indent_style = space
+indent_size = 2
+
+[{*.txt,wp-config-sample.php}]
+end_of_line = crlf

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,10 @@ Planes have a black box, WordPress has Stream. When something goes wrong, you ne
 **Stable tag:** 3.1.1  
 **License:** [GPLv2 or later](https://www.gnu.org/licenses/gpl-2.0.html)  
 
+[![Code Climate](https://codeclimate.com/github/xwp/stream/badges/gpa.svg)](https://codeclimate.com/github/xwp/stream)
+[![Test Coverage](https://codeclimate.com/github/xwp/stream/badges/coverage.svg)](https://codeclimate.com/github/xwp/stream/coverage)
+[![Issue Count](https://codeclimate.com/github/xwp/stream/badges/issue_count.svg)](https://codeclimate.com/github/xwp/stream)
+
 ## Description ##
 
 With Stream, you're never left in the dark about WordPress Admin activity.


### PR DESCRIPTION
Added support for CodeClimate set to use WordPress standards. Also added WordPress default `.editorconfig` file.