### PR TITLE
Short-circuit save_alert_inline_edit when in customizer

### DIFF
--- a/classes/class-alerts-list.php
+++ b/classes/class-alerts-list.php
@@ -334,6 +334,10 @@ class Alerts_List {
 	 * @return array
 	 */
 	function save_alert_inline_edit( $data, $postarr ) {
+		if ( did_action( 'customize_preview_init' ) ) {
+			return $data;
+		}
+
 		$post_id = $postarr['ID'];
 		$post_type = wp_stream_filter_input( INPUT_POST, 'post_type' );
 		if ( Alerts::POST_TYPE !== $post_type ) {


### PR DESCRIPTION
This fixes a severe performance problem I encountered when the Customize Posts and JS Widgets plugin are both active. The customizer allows for modifications to many posts to be bundled in a single changeset. Also, in the customizer, the `wp_insert_post_data` filters may be manually applied in order to obtain a sanitized value for previewing. See [class-wp-customize-post-setting.php](https://github.com/xwp/wp-customize-posts/blob/c45762da27a6963cc22aa1525368859b3ffc0e0a/php/class-wp-customize-post-setting.php#L474). This means the `wp_insert_post_data` filter could be applied many times for a given customizer preview request in order to obtain the post value for preview, and this was causing responses to slow down 5x in my tests, and even to fail entirely. The filter is applying without the value being then saved to the DB, and so no alert should be triggered. 

Important: In general, all Stream hooks should no-op unless the `customize_save` action was done, as this indicates that the changes are actually being persisted to the DB. Otherwise, if `is_customize_preview()` (if the customizer is active) then no logging should be done at all since it is a preview state.