### PR TITLE
Process DB migration 5000 rows at a time instead of all at once.

### DIFF
--- a/includes/db-updates.php
+++ b/includes/db-updates.php
@@ -63,8 +63,7 @@ function wp_stream_update_auto_300( $db_version, $current_version ) {
 	$starting_row   = 0;
 	$rows_per_round = 5000;
 
-	$prepared_query = $wpdb->prepare( "SELECT * FROM {$wpdb->base_prefix}stream_tmp LIMIT %d, %d", $starting_row, $rows_per_round );
-	$stream_entries = $wpdb->get_results( $prepared_query );
+	$stream_entries = $wpdb->get_results( $wpdb->prepare("SELECT * FROM {$wpdb->base_prefix}stream_tmp LIMIT %d, %d", $starting_row, $rows_per_round) );
 
 	while ( ! empty( $stream_entries ) ) {
 		foreach ( $stream_entries as $entry ) {
@@ -95,8 +94,7 @@ function wp_stream_update_auto_300( $db_version, $current_version ) {
 
 		$starting_row += $rows_per_round;
 
-		$prepared_query = $wpdb->prepare( "SELECT * FROM {$wpdb->base_prefix}stream_tmp LIMIT %d, %d", $starting_row, $rows_per_round );
-		$stream_entries = $wpdb->get_results( $prepared_query );
+		$stream_entries = $wpdb->get_results( $wpdb->prepare("SELECT * FROM {$wpdb->base_prefix}stream_tmp LIMIT %d, %d", $starting_row, $rows_per_round) );
 	}
 
 	$wpdb->query( "DROP TABLE {$wpdb->base_prefix}stream_tmp, {$wpdb->base_prefix}stream_context_tmp" );

--- a/includes/db-updates.php
+++ b/includes/db-updates.php
@@ -60,31 +60,37 @@ function wp_stream_update_auto_300( $db_version, $current_version ) {
 	$plugin = wp_stream_get_instance();
 	$plugin->install->install( $current_version );
 
-	$stream_entries = $wpdb->get_results( "SELECT * FROM {$wpdb->base_prefix}stream_tmp" );
+	$starting_row   = 0;
+	$rows_per_round = 5000;
 
-	foreach ( $stream_entries as $entry ) {
-		$context = $wpdb->get_row(
-			$wpdb->prepare( "SELECT * FROM {$wpdb->base_prefix}stream_context_tmp WHERE record_id = %s LIMIT 1", $entry->ID )
-		);
+	while ( ! empty( $stream_entries = $wpdb->get_results( "SELECT * FROM {$wpdb->base_prefix}stream_tmp LIMIT $starting_row, $rows_per_round" ) ) ) {
+		foreach ( $stream_entries as $entry ) {
+			$context = $wpdb->get_row(
+				$wpdb->prepare( "SELECT * FROM {$wpdb->base_prefix}stream_context_tmp WHERE record_id = %s LIMIT 1",
+					$entry->ID )
+			);
 
-		$new_entry = array(
-			'site_id' => $entry->site_id,
-			'blog_id' => $entry->blog_id,
-			'user_id' => $entry->author,
-			'user_role' => $entry->author_role,
-			'summary' => $entry->summary,
-			'created' => $entry->created,
-			'connector' => $context->connector,
-			'context' => $context->context,
-			'action' => $context->action,
-			'ip' => $entry->ip,
-		);
+			$new_entry = array(
+				'site_id'   => $entry->site_id,
+				'blog_id'   => $entry->blog_id,
+				'user_id'   => $entry->author,
+				'user_role' => $entry->author_role,
+				'summary'   => $entry->summary,
+				'created'   => $entry->created,
+				'connector' => $context->connector,
+				'context'   => $context->context,
+				'action'    => $context->action,
+				'ip'        => $entry->ip,
+			);
 
-		if ( $entry->object_id && 0 !== $entry->object_id ) {
-			$new_entry['object_id'] = $entry->object_id;
+			if ( $entry->object_id && 0 !== $entry->object_id ) {
+				$new_entry['object_id'] = $entry->object_id;
+			}
+
+			$wpdb->insert( $wpdb->base_prefix . 'stream', $new_entry );
 		}
 
-		$wpdb->insert( $wpdb->base_prefix . 'stream', $new_entry );
+		$starting_row += $rows_per_round;
 	}
 
 	$wpdb->query( "DROP TABLE {$wpdb->base_prefix}stream_tmp, {$wpdb->base_prefix}stream_context_tmp" );

--- a/includes/db-updates.php
+++ b/includes/db-updates.php
@@ -63,7 +63,7 @@ function wp_stream_update_auto_300( $db_version, $current_version ) {
 	$starting_row   = 0;
 	$rows_per_round = 5000;
 
-	$prepared_query = $wpdb->prepare("SELECT * FROM {$wpdb->base_prefix}stream_tmp LIMIT %d, %d", $starting_row, $rows_per_round);
+	$prepared_query = $wpdb->prepare( "SELECT * FROM {$wpdb->base_prefix}stream_tmp LIMIT %d, %d", $starting_row, $rows_per_round );
 	$stream_entries = $wpdb->get_results( $prepared_query );
 
 	while ( ! empty( $stream_entries ) ) {
@@ -95,7 +95,7 @@ function wp_stream_update_auto_300( $db_version, $current_version ) {
 
 		$starting_row += $rows_per_round;
 
-		$prepared_query = $wpdb->prepare("SELECT * FROM {$wpdb->base_prefix}stream_tmp LIMIT %d, %d", $starting_row, $rows_per_round);
+		$prepared_query = $wpdb->prepare( "SELECT * FROM {$wpdb->base_prefix}stream_tmp LIMIT %d, %d", $starting_row, $rows_per_round );
 		$stream_entries = $wpdb->get_results( $prepared_query );
 	}
 

--- a/includes/db-updates.php
+++ b/includes/db-updates.php
@@ -63,7 +63,8 @@ function wp_stream_update_auto_300( $db_version, $current_version ) {
 	$starting_row   = 0;
 	$rows_per_round = 5000;
 
-	$stream_entries = $wpdb->get_results( $wpdb->prepare("SELECT * FROM {$wpdb->base_prefix}stream_tmp LIMIT %d, %d", $starting_row, $rows_per_round) );
+	$stream_entries = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->base_prefix}stream_tmp LIMIT %d, %d",
+		$starting_row, $rows_per_round ) );
 
 	while ( ! empty( $stream_entries ) ) {
 		foreach ( $stream_entries as $entry ) {
@@ -94,7 +95,8 @@ function wp_stream_update_auto_300( $db_version, $current_version ) {
 
 		$starting_row += $rows_per_round;
 
-		$stream_entries = $wpdb->get_results( $wpdb->prepare("SELECT * FROM {$wpdb->base_prefix}stream_tmp LIMIT %d, %d", $starting_row, $rows_per_round) );
+		$stream_entries = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->base_prefix}stream_tmp LIMIT %d, %d",
+			$starting_row, $rows_per_round ) );
 	}
 
 	$wpdb->query( "DROP TABLE {$wpdb->base_prefix}stream_tmp, {$wpdb->base_prefix}stream_context_tmp" );

--- a/includes/db-updates.php
+++ b/includes/db-updates.php
@@ -63,7 +63,9 @@ function wp_stream_update_auto_300( $db_version, $current_version ) {
 	$starting_row   = 0;
 	$rows_per_round = 5000;
 
-	while ( ! empty( $stream_entries = $wpdb->get_results( "SELECT * FROM {$wpdb->base_prefix}stream_tmp LIMIT $starting_row, $rows_per_round" ) ) ) {
+	$stream_entries = $wpdb->get_results( "SELECT * FROM {$wpdb->base_prefix}stream_tmp LIMIT $starting_row, $rows_per_round" );
+
+	while ( ! empty( $stream_entries ) ) {
 		foreach ( $stream_entries as $entry ) {
 			$context = $wpdb->get_row(
 				$wpdb->prepare( "SELECT * FROM {$wpdb->base_prefix}stream_context_tmp WHERE record_id = %s LIMIT 1",
@@ -91,6 +93,8 @@ function wp_stream_update_auto_300( $db_version, $current_version ) {
 		}
 
 		$starting_row += $rows_per_round;
+
+		$stream_entries = $wpdb->get_results( "SELECT * FROM {$wpdb->base_prefix}stream_tmp LIMIT $starting_row, $rows_per_round" );
 	}
 
 	$wpdb->query( "DROP TABLE {$wpdb->base_prefix}stream_tmp, {$wpdb->base_prefix}stream_context_tmp" );

--- a/includes/db-updates.php
+++ b/includes/db-updates.php
@@ -63,7 +63,8 @@ function wp_stream_update_auto_300( $db_version, $current_version ) {
 	$starting_row   = 0;
 	$rows_per_round = 5000;
 
-	$stream_entries = $wpdb->get_results( "SELECT * FROM {$wpdb->base_prefix}stream_tmp LIMIT $starting_row, $rows_per_round" );
+	$prepared_query = $wpdb->prepare("SELECT * FROM {$wpdb->base_prefix}stream_tmp LIMIT %d, %d", $starting_row, $rows_per_round);
+	$stream_entries = $wpdb->get_results( $prepared_query );
 
 	while ( ! empty( $stream_entries ) ) {
 		foreach ( $stream_entries as $entry ) {
@@ -94,7 +95,8 @@ function wp_stream_update_auto_300( $db_version, $current_version ) {
 
 		$starting_row += $rows_per_round;
 
-		$stream_entries = $wpdb->get_results( "SELECT * FROM {$wpdb->base_prefix}stream_tmp LIMIT $starting_row, $rows_per_round" );
+		$prepared_query = $wpdb->prepare("SELECT * FROM {$wpdb->base_prefix}stream_tmp LIMIT %d, %d", $starting_row, $rows_per_round);
+		$stream_entries = $wpdb->get_results( $prepared_query );
 	}
 
 	$wpdb->query( "DROP TABLE {$wpdb->base_prefix}stream_tmp, {$wpdb->base_prefix}stream_context_tmp" );

--- a/includes/db-updates.php
+++ b/includes/db-updates.php
@@ -68,8 +68,7 @@ function wp_stream_update_auto_300( $db_version, $current_version ) {
 	while ( ! empty( $stream_entries ) ) {
 		foreach ( $stream_entries as $entry ) {
 			$context = $wpdb->get_row(
-				$wpdb->prepare( "SELECT * FROM {$wpdb->base_prefix}stream_context_tmp WHERE record_id = %s LIMIT 1",
-					$entry->ID )
+				$wpdb->prepare( "SELECT * FROM {$wpdb->base_prefix}stream_context_tmp WHERE record_id = %s LIMIT 1", $entry->ID )
 			);
 
 			$new_entry = array(

--- a/includes/db-updates.php
+++ b/includes/db-updates.php
@@ -63,8 +63,7 @@ function wp_stream_update_auto_300( $db_version, $current_version ) {
 	$starting_row   = 0;
 	$rows_per_round = 5000;
 
-	$stream_entries = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->base_prefix}stream_tmp LIMIT %d, %d",
-		$starting_row, $rows_per_round ) );
+	$stream_entries = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->base_prefix}stream_tmp LIMIT %d, %d", $starting_row, $rows_per_round ) );
 
 	while ( ! empty( $stream_entries ) ) {
 		foreach ( $stream_entries as $entry ) {
@@ -95,8 +94,7 @@ function wp_stream_update_auto_300( $db_version, $current_version ) {
 
 		$starting_row += $rows_per_round;
 
-		$stream_entries = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->base_prefix}stream_tmp LIMIT %d, %d",
-			$starting_row, $rows_per_round ) );
+		$stream_entries = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->base_prefix}stream_tmp LIMIT %d, %d", $starting_row, $rows_per_round ) );
 	}
 
 	$wpdb->query( "DROP TABLE {$wpdb->base_prefix}stream_tmp, {$wpdb->base_prefix}stream_context_tmp" );


### PR DESCRIPTION
This should allow migrations to work for sites that have lower memory limits, a very large amount of data, or both. Returning all the rows of the stream_tmp table at once can take a lot of memory if there's a lot of data there, causing the migration process to fail.

One of our sites was running Stream 1.4.9 and had ~2 million rows in its `stream` table. Despite having a generous memory limit, the migration process failed due to exceeding the memory limit when this function attempted to load all 2 million rows into memory at once. Local testing showed that this change allowed for the migration to run successfully with a lower memory limit.