### PR TITLE
Add support for ACF Options pages

### DIFF
--- a/connectors/class-connector-acf.php
+++ b/connectors/class-connector-acf.php
@@ -367,6 +367,9 @@ class Connector_ACF extends Connector {
 			list( , $taxonomy, $term_id, $key ) = $matches; // Skips 0 index
 
 			$object_key = $taxonomy . '_' . $term_id;
+		} elseif( 'option' === $type) {
+			$object_key = 'options';
+			$key = preg_replace( '/^options_/', '', $key);
 		}
 
 		if ( isset( $this->cached_field_values_updates[ $object_key ][ $key ] ) ) {
@@ -385,6 +388,9 @@ class Connector_ACF extends Connector {
 				$title     = $term->name;
 				$tax_obj   = get_taxonomy( $taxonomy );
 				$type_name = strtolower( get_taxonomy_labels( $tax_obj )->singular_name );
+			} elseif ( 'option' === $type ) {
+				$title = 'settings page';
+				$type_name = 'option';
 			} else {
 				return false;
 			}
@@ -517,7 +523,7 @@ class Connector_ACF extends Connector {
 	 * @param string $value Option value
 	 */
 	public function callback_added_option( $key, $value ) {
-		$this->check_meta_values( 'taxonomy', 'added', null, null, $key, $value );
+		$this->check_meta_values( self::get_saved_option_type($key), 'added', null, null, $key, $value );
 	}
 
 	/**
@@ -529,7 +535,7 @@ class Connector_ACF extends Connector {
 	 */
 	public function callback_updated_option( $key, $old, $value ) {
 		unset( $old );
-		$this->check_meta_values( 'taxonomy', 'updated', null, null, $key, $value );
+		$this->check_meta_values( self::get_saved_option_type($key), 'updated', null, null, $key, $value );
 	}
 
 	/**
@@ -538,6 +544,16 @@ class Connector_ACF extends Connector {
 	 * @param $key
 	 */
 	public function callback_deleted_option( $key ) {
-		$this->check_meta_values( 'taxonomy', 'deleted', null, null, $key, null );
+		$this->check_meta_values( self::get_saved_option_type($key), 'deleted', null, null, $key, null );
+	}
+
+  /**
+   * Determines the type of option that is saved
+   *
+   * @param $key
+   * @return string
+   */
+	private function get_saved_option_type($key) {
+		return substr($key,0, 8) === 'options_' ? 'option' : 'taxonomy';
 	}
 }

--- a/connectors/class-connector-acf.php
+++ b/connectors/class-connector-acf.php
@@ -547,12 +547,12 @@ class Connector_ACF extends Connector {
 		$this->check_meta_values( self::get_saved_option_type( $key ), 'deleted', null, null, $key, null );
 	}
 
-  /**
-   * Determines the type of option that is saved
-   *
-   * @param $key
-   * @return string
-   */
+	/**
+	 * Determines the type of option that is saved
+	 *
+	 * @param $key
+	 * @return string
+	 */
 	private function get_saved_option_type( $key ) {
 		return substr( $key,0, 8 ) === 'options_' ? 'option' : 'taxonomy';
 	}

--- a/connectors/class-connector-acf.php
+++ b/connectors/class-connector-acf.php
@@ -367,9 +367,9 @@ class Connector_ACF extends Connector {
 			list( , $taxonomy, $term_id, $key ) = $matches; // Skips 0 index
 
 			$object_key = $taxonomy . '_' . $term_id;
-		} elseif( 'option' === $type) {
+		} elseif ( 'option' === $type ) {
 			$object_key = 'options';
-			$key = preg_replace( '/^options_/', '', $key);
+			$key = preg_replace( '/^options_/', '', $key );
 		}
 
 		if ( isset( $this->cached_field_values_updates[ $object_key ][ $key ] ) ) {
@@ -523,7 +523,7 @@ class Connector_ACF extends Connector {
 	 * @param string $value Option value
 	 */
 	public function callback_added_option( $key, $value ) {
-		$this->check_meta_values( self::get_saved_option_type($key), 'added', null, null, $key, $value );
+		$this->check_meta_values( self::get_saved_option_type( $key ), 'added', null, null, $key, $value );
 	}
 
 	/**
@@ -535,7 +535,7 @@ class Connector_ACF extends Connector {
 	 */
 	public function callback_updated_option( $key, $old, $value ) {
 		unset( $old );
-		$this->check_meta_values( self::get_saved_option_type($key), 'updated', null, null, $key, $value );
+		$this->check_meta_values( self::get_saved_option_type( $key ), 'updated', null, null, $key, $value );
 	}
 
 	/**
@@ -544,7 +544,7 @@ class Connector_ACF extends Connector {
 	 * @param $key
 	 */
 	public function callback_deleted_option( $key ) {
-		$this->check_meta_values( self::get_saved_option_type($key), 'deleted', null, null, $key, null );
+		$this->check_meta_values( self::get_saved_option_type( $key ), 'deleted', null, null, $key, null );
 	}
 
   /**
@@ -553,7 +553,7 @@ class Connector_ACF extends Connector {
    * @param $key
    * @return string
    */
-	private function get_saved_option_type($key) {
-		return substr($key,0, 8) === 'options_' ? 'option' : 'taxonomy';
+	private function get_saved_option_type( $key ) {
+		return substr( $key,0, 8 ) === 'options_' ? 'option' : 'taxonomy';
 	}
 }


### PR DESCRIPTION
Adds support for [ACF Options page](https://www.advancedcustomfields.com/add-ons/options-page/) values.

<img width="868" alt="screen shot 2017-08-07 at 19 21 17" src="https://user-images.githubusercontent.com/1207507/29037874-c28c6c26-7ba5-11e7-9c7a-a5f42fc9cbfb.png">

Mentioned here: https://github.com/xwp/stream/issues/919

I'm struggling a little bit to find a coherent log format, maybe someone has input. Right now it's hard coded to `<Field name> of "settings page" option.`. The crux is the only way to figure out what settings page this is on is by grabbing `get_current_screen()` or `$_GET['page']`. Neither of these provide the human-readable page name, but rather something like `toplevel_page_my_settings`. Would that still be better than not setting it?

I'd also like a more natural language: `Option <Field name> on <Settings page name>`, but the current connector can not be easily adapted to this format. Any thoughts here?
