### PR TITLE
Fix a notice where $old_roles indices are not properly sorted

### DIFF
--- a/connectors/class-connector-users.php
+++ b/connectors/class-connector-users.php
@@ -210,7 +210,7 @@ class Connector_Users extends Connector {
 			),
 			array(
 				'display_name' => get_user_by( 'id', $user_id )->display_name,
-				'old_role'     => translate_user_role( $wp_roles->role_names[ $old_roles[0] ] ),
+				'old_role'     => translate_user_role( $wp_roles->role_names[ current( $old_roles ) ] ),
 				'new_role'     => translate_user_role( $wp_roles->role_names[ $new_role ] ),
 			),
 			$user_id,

--- a/connectors/class-connector-users.php
+++ b/connectors/class-connector-users.php
@@ -211,7 +211,7 @@ class Connector_Users extends Connector {
 			array(
 				'display_name' => get_user_by( 'id', $user_id )->display_name,
 				'old_role'     => translate_user_role( $wp_roles->role_names[ current( $old_roles ) ] ),
-				'new_role'     => translate_user_role( $wp_roles->role_names[ $new_role ] ),
+				'new_role'     => $new_role ? translate_user_role( $wp_roles->role_names[ $new_role ] ) : __( 'N/A', 'stream' ),
 			),
 			$user_id,
 			'profiles',


### PR DESCRIPTION
Because of this [`array_filter`](https://github.com/WordPress/WordPress/blob/master/wp-includes/class-wp-user.php#L474) call, `$old_roles`'s first member might not always be at the zero index ( if it is not actually a valid role ).