### PR TITLE
Added missing parameter

### DIFF
--- a/includes/lib/Carbon.php
+++ b/includes/lib/Carbon.php
@@ -678,7 +678,7 @@ class Carbon extends DateTime
      *
      * @return static
      */
-    public function setTime($hour, $minute, $second = 0)
+    public function setTime($hour, $minute, $second = 0, $microseconds = NULL)
     {
         parent::setTime($hour, $minute, $second);
 


### PR DESCRIPTION
Carbon::setTime($hour, $minute, $second = NULL) not compatible with PHP 7.1.0 DateTime::setTime($hour, $minute, $second = null, $microseconds = NULL )
http://php.net/manual/en/datetime.settime.php
7.1.0	The microseconds parameter was added.