### PR TITLE
Support proxy mode by checking the `X-Forwarded-For` header first

### DIFF
--- a/classes/class-log.php
+++ b/classes/class-log.php
@@ -112,18 +112,18 @@ class Log {
 		$ip_address = $ip_address ? $ip_address : wp_stream_filter_input( INPUT_SERVER, 'REMOTE_ADDR', FILTER_VALIDATE_IP );
 
 		$recordarr = array(
-			'object_id'  => (int) $object_id,
-			'site_id'    => (int) is_multisite() ? get_current_site()->id : 1,
-			'blog_id'    => (int) apply_filters( 'wp_stream_blog_id_logged', get_current_blog_id() ),
-			'user_id'    => (int) $user_id,
-			'user_role'  => (string) $role,
-			'created'    => (string) $iso_8601_extended_date,
-			'summary'    => (string) vsprintf( $message, $args ),
-			'connector'  => (string) $connector,
-			'context'    => (string) $context,
-			'action'     => (string) $action,
-			'ip'         => (string) $ip_address,
-			'meta'       => (array) $stream_meta,
+			'object_id' => (int) $object_id,
+			'site_id'   => (int) is_multisite() ? get_current_site()->id : 1,
+			'blog_id'   => (int) apply_filters( 'wp_stream_blog_id_logged', get_current_blog_id() ),
+			'user_id'   => (int) $user_id,
+			'user_role' => (string) $role,
+			'created'   => (string) $iso_8601_extended_date,
+			'summary'   => (string) vsprintf( $message, $args ),
+			'connector' => (string) $connector,
+			'context'   => (string) $context,
+			'action'    => (string) $action,
+			'ip'        => (string) $ip_address,
+			'meta'      => (array) $stream_meta,
 		);
 
 		if ( 0 === $recordarr['object_id'] ) {

--- a/classes/class-log.php
+++ b/classes/class-log.php
@@ -107,6 +107,10 @@ class Log {
 			$role = '';
 		}
 
+		// Support proxy mode by checking the `X-Forwarded-For` header first
+		$ip_address = wp_stream_filter_input( INPUT_SERVER, 'HTTP_X_FORWARDED_FOR', FILTER_VALIDATE_IP );
+		$ip_address = $ip_address ? $ip_address : wp_stream_filter_input( INPUT_SERVER, 'REMOTE_ADDR', FILTER_VALIDATE_IP );
+
 		$recordarr = array(
 			'object_id'  => (int) $object_id,
 			'site_id'    => (int) is_multisite() ? get_current_site()->id : 1,
@@ -118,7 +122,7 @@ class Log {
 			'connector'  => (string) $connector,
 			'context'    => (string) $context,
 			'action'     => (string) $action,
-			'ip'         => (string) wp_stream_filter_input( INPUT_SERVER, 'REMOTE_ADDR', FILTER_VALIDATE_IP ),
+			'ip'         => (string) $ip_address,
 			'meta'       => (array) $stream_meta,
 		);
 


### PR DESCRIPTION
@lukecarbis When in reverse proxy mode, the `REMOTE_ADDR` value will always show the IP of the proxy server (ATS, Varnish, HAProxy, etc).  Most proxies will pass along the real client IP via the `X-Forwarded-For` header.  If it exists, Stream should prefer that as the real IP and only use `REMOTE_ADDR` as a fallback.

👋 It's been a while 😃 