### PR TITLE
Move `count_users` out of roles foreach

### DIFF
--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -771,8 +771,8 @@ class Settings {
 
 				break;
 			case 'rule_list':
-				$users = count_users();
-				$form = new Form_Generator();
+				$users  = count_users();
+				$form   = new Form_Generator();
 				$output = '<p class="description">' . esc_html( $description ) . '</p>';
 
 				$actions_top    = sprintf( '<input type="button" class="button" id="%1$s_new_rule" value="&#43; %2$s" />', esc_attr( $section . '_' . $name ),  esc_html__( 'Add New Rule', 'stream' ) );

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -817,13 +817,14 @@ class Settings {
 					// Author or Role dropdown menu
 					$author_or_role_values   = array();
 					$author_or_role_selected = array();
+					$users = count_users();
 
 					foreach ( $this->get_roles() as $role_id => $role ) {
 						$args  = array(
 							'value' => $role_id,
 							'text' => $role,
 						);
-						$users = count_users();
+						
 						$count = isset( $users['avail_roles'][ $role_id ] ) ? $users['avail_roles'][ $role_id ] : 0;
 
 						if ( ! empty( $count ) ) {

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -771,6 +771,7 @@ class Settings {
 
 				break;
 			case 'rule_list':
+				$users = count_users();
 				$form = new Form_Generator();
 				$output = '<p class="description">' . esc_html( $description ) . '</p>';
 
@@ -817,7 +818,6 @@ class Settings {
 					// Author or Role dropdown menu
 					$author_or_role_values   = array();
 					$author_or_role_selected = array();
-					$users = count_users();
 
 					foreach ( $this->get_roles() as $role_id => $role ) {
 						$args  = array(

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -824,7 +824,6 @@ class Settings {
 							'value' => $role_id,
 							'text' => $role,
 						);
-						
 						$count = isset( $users['avail_roles'][ $role_id ] ) ? $users['avail_roles'][ $role_id ] : 0;
 
 						if ( ! empty( $count ) ) {


### PR DESCRIPTION
This pull request will move `count_users` out of roles foreach since it's expensive to call for every role. See #949 for more information.

This time against develop instead of master.