### PR TITLE
Bugfix/issue 965

### DIFF
--- a/includes/lib/Carbon.php
+++ b/includes/lib/Carbon.php
@@ -675,12 +675,13 @@ class Carbon extends DateTime
      * @param integer $hour
      * @param integer $minute
      * @param integer $second
+     * @param integer $microseconds
      *
      * @return static
      */
-    public function setTime($hour, $minute, $second = 0)
+    public function setTime($hour, $minute, $second = 0, $microseconds = 0 )
     {
-        parent::setTime($hour, $minute, $second);
+        parent::setTime($hour, $minute, $second, $microseconds );
 
         return $this;
     }

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,8 @@ Planes have a black box, WordPress has Stream. When something goes wrong, you ne
 **Stable tag:** 3.2  
 **License:** [GPLv2 or later](https://www.gnu.org/licenses/gpl-2.0.html)  
 
+[![Build Status](https://travis-ci.org/xwp/stream.svg?branch=master)](https://travis-ci.org/xwp/stream) [![Join the chat at https://gitter.im/xwp/stream](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/xwp/stream) 
+
 ## Description ##
 
 With Stream, you're never left in the dark about WordPress Admin activity.
@@ -89,7 +91,7 @@ Thank you for wanting to make Stream better for everyone!
 
 ## Changelog ##
 
-### 3.2 - March 15, 2017 ###
+### 3.2.0 - March 15, 2017 ###
 * New: Stream now support alternate Database Drivers. ([#889](https://github.com/xwp/stream/pull/889))
 * Fix: Exclude dropdown menus ([e5c8677](https://github.com/xwp/stream/commit/e5c8677), [3626ba8](https://github.com/xwp/stream/commit/3626ba8), [e923a92](https://github.com/xwp/stream/commit/e923a92))
 * Fix: Prevent loading of connectors on frontend ([ed3a635](https://github.com/xwp/stream/commit/ed3a635))

--- a/readme.txt
+++ b/readme.txt
@@ -79,7 +79,7 @@ Thank you for wanting to make Stream better for everyone!
 
 == Changelog ==
 
-= 3.2 - March 15, 2017 =
+= 3.2.0 - March 15, 2017 =
 
 * New: Stream now support alternate Database Drivers. ([#889](https://github.com/xwp/stream/pull/889))
 * Fix: Exclude dropdown menus ([e5c8677](https://github.com/xwp/stream/commit/e5c8677), [3626ba8](https://github.com/xwp/stream/commit/3626ba8), [e923a92](https://github.com/xwp/stream/commit/e923a92))

--- a/tests/tests/test-class-admin.php
+++ b/tests/tests/test-class-admin.php
@@ -384,7 +384,7 @@ class Test_Admin extends WP_StreamTestCase {
 		$_POST['q'] = $user->display_name;
 		$_POST['nonce'] = wp_create_nonce( 'stream_filters_user_search_nonce' );
 
-		$this->setExpectedException( 'WPAjaxDieStopException' );
+		$this->expectException( 'WPAjaxDieStopException' );
 
 		try {
 			$this->_handleAjax( 'wp_stream_filters' );

--- a/tests/tests/test-class-admin.php
+++ b/tests/tests/test-class-admin.php
@@ -372,8 +372,11 @@ class Test_Admin extends WP_StreamTestCase {
 		$this->assertFalse( $role->has_cap( $this->admin->view_cap ) );
 	}
 
-	/*
+	/**
+	 * Test Ajax Filters
+	 *
 	 * @group ajax
+	 * @requires PHPUnit 5.7
 	 */
 	public function test_ajax_filters() {
 		$user = new \WP_User( get_current_user_id() );

--- a/tests/tests/test-class-alerts.php
+++ b/tests/tests/test-class-alerts.php
@@ -33,8 +33,11 @@ class Test_Alerts extends WP_StreamTestCase {
 		$this->assertEquals( 1, $action->get_call_count() );
 	}
 
+	/**
+	 * @group test
+	 * @expectedException PHPUnit_Framework_Error_Notice
+	 */
 	function test_load_bad_alert_type() {
-		$this->setExpectedException( 'PHPUnit_Framework_Error_Notice' );
 
 		add_filter( 'wp_stream_alert_types', array( $this, 'callback_load_bad_alert_register' ), 10, 1 );
 		$alerts = new Alerts( $this->plugin );
@@ -56,8 +59,10 @@ class Test_Alerts extends WP_StreamTestCase {
 		$this->assertEquals( 1, $action->get_call_count() );
 	}
 
+	/**
+	 * @expectedException PHPUnit_Framework_Error_Notice
+	 */
 	function test_load_bad_alert_trigger() {
-		$this->setExpectedException( 'PHPUnit_Framework_Error_Notice' );
 
 		add_filter( 'wp_stream_alert_triggers', array( $this, 'callback_load_bad_alert_register' ), 10, 1 );
 		$alerts = new Alerts( $this->plugin );
@@ -350,6 +355,7 @@ class Test_Alerts extends WP_StreamTestCase {
 	$this->assertObjectHasAttribute( 'success', $response );
 	$this->assertTrue( $response->success );
 }
+
 	function test_save_new_alert_no_nonce() {
 		$alerts = new Alerts( $this->plugin );
 		try {
@@ -357,7 +363,8 @@ class Test_Alerts extends WP_StreamTestCase {
 			$_POST['wp_stream_trigger_context'] = 'posts-post';
 			$_POST['wp_stream_trigger_action'] = 'edit';
 			$_POST['wp_stream_alert_type'] = 'highlight';
-			$this->setExpectedException( 'WPAjaxDieStopException' );
+
+			$this->expectException( 'WPAjaxDieStopException' );
 			$this->_handleAjax( 'save_new_alert' );
 		} catch ( \WPAjaxDieContinueException $e ) {
 			$exception = $e;

--- a/tests/tests/test-class-alerts.php
+++ b/tests/tests/test-class-alerts.php
@@ -34,8 +34,7 @@ class Test_Alerts extends WP_StreamTestCase {
 	}
 
 	/**
-	 * @group test
-	 * @expectedException PHPUnit_Framework_Error_Notice
+	 * @requires PHPUnit 5.7
 	 */
 	function test_load_bad_alert_type() {
 		$alerts = new Alerts( $this->plugin );
@@ -65,7 +64,7 @@ class Test_Alerts extends WP_StreamTestCase {
 	}
 
 	/**
-	 * @expectedException PHPUnit_Framework_Error_Notice
+	 * Test bad trigger is not added.
 	 */
 	function test_load_bad_alert_trigger() {
 		$alerts = new Alerts( $this->plugin );
@@ -80,7 +79,7 @@ class Test_Alerts extends WP_StreamTestCase {
 	}
 
 	function callback_load_bad_alert_register( $classes ) {
-		$classes['bad_alert_trigger'] = new \stdClass;
+		$classes['bad_alert_trigger'] = new \stdClass();
 		return $classes;
 	}
 

--- a/tests/tests/test-class-alerts.php
+++ b/tests/tests/test-class-alerts.php
@@ -356,6 +356,9 @@ class Test_Alerts extends WP_StreamTestCase {
 	$this->assertTrue( $response->success );
 }
 
+	/**
+	 * @requires PHPUnit 5.7
+	 */
 	function test_save_new_alert_no_nonce() {
 		$alerts = new Alerts( $this->plugin );
 		try {

--- a/tests/tests/test-class-export.php
+++ b/tests/tests/test-class-export.php
@@ -128,8 +128,6 @@ class Test_Export extends WP_StreamTestCase {
 
 	/**
 	 * Test registering a invalid class type produces an error
-	 *
-	 * @expectedException PHPUnit_Framework_Error_Notice
 	 */
 	public function test_register_exporter_invalid_class() {
 		add_filter( 'wp_stream_exporters', function( $exporters ) {
@@ -137,6 +135,7 @@ class Test_Export extends WP_StreamTestCase {
 			remove_all_filters( 'wp_stream_exporters' );
 			return $exporters;
 		});
+		$this->expectException('PHPUnit_Framework_Error_Notice');
 
 		$this->export->register_exporters();
 	}

--- a/tests/tests/test-class-export.php
+++ b/tests/tests/test-class-export.php
@@ -128,18 +128,18 @@ class Test_Export extends WP_StreamTestCase {
 
 	/**
 	 * Test registering a invalid class type produces an error
-	 *
 	 * @requires PHPUnit 5.7
 	 */
 	public function test_register_exporter_invalid_class() {
 		add_filter( 'wp_stream_exporters', function( $exporters ) {
-			$exporters['test'] = new \stdClass;
+			$exporters['test'] = new \stdClass();
 			remove_all_filters( 'wp_stream_exporters' );
 			return $exporters;
 		});
-		$this->expectException('PHPUnit_Framework_Error_Notice');
-
 		$this->export->register_exporters();
+
+		$exporters = $this->export->get_exporters();
+		$this->assertFalse( isset( $exporters['test'] ) );
 	}
 
 	/**

--- a/tests/tests/test-class-export.php
+++ b/tests/tests/test-class-export.php
@@ -129,7 +129,7 @@ class Test_Export extends WP_StreamTestCase {
 	/**
 	 * Test registering a invalid class type produces an error
 	 *
-	 * @expectedException PHPUnit_Framework_Error
+	 * @expectedException PHPUnit_Framework_Error_Notice
 	 */
 	public function test_register_exporter_invalid_class() {
 		add_filter( 'wp_stream_exporters', function( $exporters ) {

--- a/tests/tests/test-class-export.php
+++ b/tests/tests/test-class-export.php
@@ -128,6 +128,8 @@ class Test_Export extends WP_StreamTestCase {
 
 	/**
 	 * Test registering a invalid class type produces an error
+	 *
+	 * @requires PHPUnit 5.7
 	 */
 	public function test_register_exporter_invalid_class() {
 		add_filter( 'wp_stream_exporters', function( $exporters ) {


### PR DESCRIPTION
- Resync develop to master
- Fix incompatible DateTIme extension 
- Fix failing unit tests in PHPUnit 5.7+

@lukecarbis between phpunit 4.6 and 5.7, the way exceptions are tested is changing. this is part of the issue why it started to fail when testing `trigger_error()`.

Fixes #965 