### PR TITLE
Remove wp_kses_post from display fields.

### DIFF
--- a/alerts/class-alert-type-die.php
+++ b/alerts/class-alert-type-die.php
@@ -13,6 +13,7 @@ namespace WP_Stream;
  * @package WP_Stream
  */
 class Alert_Type_Die extends Alert_Type {
+
 	/**
 	 * Alert type name
 	 *

--- a/alerts/class-alert-type-email.php
+++ b/alerts/class-alert-type-email.php
@@ -42,7 +42,10 @@ class Alert_Type_Email extends Alert_Type {
 		if ( ! is_admin() ) {
 			return;
 		}
-		add_filter( 'wp_stream_alerts_save_meta', array( $this, 'add_alert_meta' ), 10, 2 );
+		add_filter( 'wp_stream_alerts_save_meta', array(
+			$this,
+			'add_alert_meta',
+		), 10, 2 );
 	}
 
 	/**
@@ -69,31 +72,31 @@ class Alert_Type_Email extends Alert_Type {
 		}
 
 		// translators: Placeholder refers to the title of a site (e.g. "FooBar Website")
-		$message   = sprintf( __( 'A Stream Alert was triggered on %s.', 'stream' ), get_bloginfo( 'name' ) ) . "\n\n";
+		$message = sprintf( __( 'A Stream Alert was triggered on %s.', 'stream' ), get_bloginfo( 'name' ) ) . "\n\n";
 
 		$user_id = $recordarr['user_id'];
-		$user = get_user_by( 'id', $user_id );
+		$user    = get_user_by( 'id', $user_id );
 
 		// translators: Placeholder refers to a username  (e.g. "administrator")
 		$message .= sprintf( __( "User:\t%s", 'stream' ), $user->user_login ) . "\n";
 
 		if ( ! empty( $alert->alert_meta['trigger_context'] ) ) {
-			$context  = $this->plugin->alerts->alert_triggers['context']->get_display_value( 'list_table', $alert );
+			$context = $this->plugin->alerts->alert_triggers['context']->get_display_value( 'list_table', $alert );
 
 			// translators: Placeholder refers to the context of the record (e.g. "Plugins")
-			$message .= sprintf( __( "Context:\t%s", 'stream' ),  $context ) . "\n";
+			$message .= sprintf( __( "Context:\t%s", 'stream' ), $context ) . "\n";
 		}
 		if ( ! empty( $alert->alert_meta['trigger_action'] ) ) {
-			$action   = $this->plugin->alerts->alert_triggers['action']->get_display_value( 'list_table', $alert );
+			$action = $this->plugin->alerts->alert_triggers['action']->get_display_value( 'list_table', $alert );
 
 			// translators: Placeholder refers to the action of the record (e.g. "Installed")
-			$message .= sprintf( __( "Action:\t%s", 'stream' ),  $action ) . "\n";
+			$message .= sprintf( __( "Action:\t%s", 'stream' ), $action ) . "\n";
 		}
 
 		$post = null;
 		if ( isset( $recordarr['object_id'] ) ) {
 			$post_id = $recordarr['object_id'];
-			$post = get_post( $post_id );
+			$post    = get_post( $post_id );
 		}
 		if ( is_object( $post ) && ! empty( $post ) ) {
 			$post_type = get_post_type_object( $post->post_type );
@@ -102,14 +105,14 @@ class Alert_Type_Email extends Alert_Type {
 
 			$edit_post_link = get_edit_post_link( $post->ID, 'raw' );
 
-			// translators: Placeholder refers to the post type singular name (e.g. "Post")
+			// translators: Placeholder refers to the post type singular name (e.g. "Post").
 			$message .= sprintf( __( 'Edit %s', 'stream' ), $post_type->labels->singular_name ) . "\n<$edit_post_link>\n";
 		}
 
 		$message .= "\n";
 
 		$edit_alert_link = admin_url( 'edit.php?post_type=wp_stream_alerts#post-' . $alert->ID );
-		$message .= __( 'Edit Alert', 'stream' ) . "\n<$edit_alert_link>";
+		$message        .= __( 'Edit Alert', 'stream' ) . "\n<$edit_alert_link>";
 
 		wp_mail( $options['email_recipient'], $options['email_subject'], $message );
 	}
@@ -136,24 +139,20 @@ class Alert_Type_Email extends Alert_Type {
 		echo '<span class="wp_stream_alert_type_description">' . esc_html__( 'Send a notification email to the recipient.', 'stream' ) . '</span>';
 		echo '<label for="wp_stream_email_recipient"><span class="title">' . esc_html__( 'Recipient', 'stream' ) . '</span>';
 		echo '<span class="input-text-wrap">';
-		echo wp_kses_post( $form->render_field(
-			'text', array( // Xss ok.
-			'name'    => 'wp_stream_email_recipient',
-			'title'   => esc_attr( __( 'Email Recipient', 'stream' ) ),
-			'value'   => $options['email_recipient'],
-			)
-		) );
+		echo $form->render_field( 'text', array(
+			'name'  => 'wp_stream_email_recipient',
+			'title' => esc_attr( __( 'Email Recipient', 'stream' ) ),
+			'value' => $options['email_recipient'],
+		) ); // Xss ok.
 		echo '</span></label>';
 
 		echo '<label for="wp_stream_email_subject"><span class="title">' . esc_html__( 'Subject', 'stream' ) . '</span>';
 		echo '<span class="input-text-wrap">';
-		echo wp_kses_post( $form->render_field(
-			'text', array( // Xss ok.
-			'name'    => 'wp_stream_email_subject',
-			'title'   => esc_attr( __( 'Email Subject', 'stream' ) ),
-			'value'   => $options['email_subject'],
-			)
-		) );
+		echo $form->render_field( 'text', array(
+			'name'  => 'wp_stream_email_subject',
+			'title' => esc_attr( __( 'Email Subject', 'stream' ) ),
+			'value' => $options['email_subject'],
+		) ); // Xss ok.
 		echo '</span></label>';
 	}
 
@@ -174,6 +173,7 @@ class Alert_Type_Email extends Alert_Type {
 			$alert->alert_meta['email_subject'] = sanitize_text_field( wp_unslash( $_POST['wp_stream_email_subject'] ) );
 		}
 	}
+
 	/**
 	 * Add alert meta if this is a highlight alert
 	 *
@@ -193,6 +193,7 @@ class Alert_Type_Email extends Alert_Type {
 				$alert_meta['email_subject'] = $email_subject;
 			}
 		}
+
 		return $alert_meta;
 	}
 }

--- a/alerts/class-alert-type-email.php
+++ b/alerts/class-alert-type-email.php
@@ -71,25 +71,25 @@ class Alert_Type_Email extends Alert_Type {
 			return;
 		}
 
-		// translators: Placeholder refers to the title of a site (e.g. "FooBar Website")
+		// translators: Placeholder refers to the title of a site (e.g. "FooBar Website").
 		$message = sprintf( __( 'A Stream Alert was triggered on %s.', 'stream' ), get_bloginfo( 'name' ) ) . "\n\n";
 
 		$user_id = $recordarr['user_id'];
 		$user    = get_user_by( 'id', $user_id );
 
-		// translators: Placeholder refers to a username  (e.g. "administrator")
+		// translators: Placeholder refers to a username  (e.g. "administrator").
 		$message .= sprintf( __( "User:\t%s", 'stream' ), $user->user_login ) . "\n";
 
 		if ( ! empty( $alert->alert_meta['trigger_context'] ) ) {
 			$context = $this->plugin->alerts->alert_triggers['context']->get_display_value( 'list_table', $alert );
 
-			// translators: Placeholder refers to the context of the record (e.g. "Plugins")
+			// translators: Placeholder refers to the context of the record (e.g. "Plugins").
 			$message .= sprintf( __( "Context:\t%s", 'stream' ), $context ) . "\n";
 		}
 		if ( ! empty( $alert->alert_meta['trigger_action'] ) ) {
 			$action = $this->plugin->alerts->alert_triggers['action']->get_display_value( 'list_table', $alert );
 
-			// translators: Placeholder refers to the action of the record (e.g. "Installed")
+			// translators: Placeholder refers to the action of the record (e.g. "Installed").
 			$message .= sprintf( __( "Action:\t%s", 'stream' ), $action ) . "\n";
 		}
 

--- a/alerts/class-alert-type-highlight.php
+++ b/alerts/class-alert-type-highlight.php
@@ -13,6 +13,7 @@ namespace WP_Stream;
  * @package WP_Stream
  */
 class Alert_Type_Highlight extends Alert_Type {
+
 	/**
 	 * Main JS file script handle.
 	 */
@@ -68,17 +69,32 @@ class Alert_Type_Highlight extends Alert_Type {
 		if ( ! is_admin() ) {
 			return;
 		}
-		add_filter( 'wp_stream_record_classes', array( $this, 'post_class' ), 10, 2 );
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-		add_action( 'wp_ajax_' . self::REMOVE_ACTION, array( $this, 'ajax_remove_highlight' ) );
+		add_filter( 'wp_stream_record_classes', array(
+			$this,
+			'post_class',
+		), 10, 2 );
+		add_action( 'admin_enqueue_scripts', array(
+			$this,
+			'enqueue_scripts',
+		) );
+		add_action( 'wp_ajax_' . self::REMOVE_ACTION, array(
+			$this,
+			'ajax_remove_highlight',
+		) );
 
 		if ( ! empty( $this->plugin->connectors->connectors ) && is_array( $this->plugin->connectors->connectors ) ) {
 			foreach ( $this->plugin->connectors->connectors as $connector ) {
-				add_filter( 'wp_stream_action_links_' . $connector->name, array( $this, 'action_link_remove_highlight' ), 10, 2 );
+				add_filter( 'wp_stream_action_links_' . $connector->name, array(
+					$this,
+					'action_link_remove_highlight',
+				), 10, 2 );
 			}
 		}
 
-		add_filter( 'wp_stream_alerts_save_meta', array( $this, 'add_alert_meta' ), 10, 2 );
+		add_filter( 'wp_stream_alerts_save_meta', array(
+			$this,
+			'add_alert_meta',
+		), 10, 2 );
 	}
 
 	/**
@@ -93,7 +109,7 @@ class Alert_Type_Highlight extends Alert_Type {
 	 * @return void
 	 */
 	public function alert( $record_id, $recordarr, $alert ) {
-		$recordarr['ID'] = $record_id;
+		$recordarr['ID']       = $record_id;
 		$this->single_alert_id = $alert->ID;
 		if ( ! empty( $alert->alert_meta['color'] ) ) {
 			$alert_meta = array(
@@ -132,6 +148,7 @@ class Alert_Type_Highlight extends Alert_Type {
 		) ); // Xss ok.
 		echo '</span></label>';
 	}
+
 	/**
 	 * Lists available color options for alerts.
 	 *
@@ -159,7 +176,7 @@ class Alert_Type_Highlight extends Alert_Type {
 			$alert->alert_meta['color'] = 'yellow';
 		}
 		$input_color = sanitize_text_field( wp_unslash( $_POST['wp_stream_highlight_color'] ) );
-		if ( ! array_key_exists( $input_color , $this->get_highlight_options() ) ) {
+		if ( ! array_key_exists( $input_color, $this->get_highlight_options() ) ) {
 			$alert->alert_meta['color'] = 'yellow';
 		} else {
 			$alert->alert_meta['color'] = $input_color;
@@ -204,7 +221,7 @@ class Alert_Type_Highlight extends Alert_Type {
 	 * @return mixed
 	 */
 	public function action_link_remove_highlight( $actions, $record ) {
-		$record = new Record( $record );
+		$record           = new Record( $record );
 		$alerts_triggered = $record->get_meta( Alerts::ALERTS_TRIGGERED_META_KEY, true );
 		if ( ! empty( $alerts_triggered[ $this->slug ] ) ) {
 			$actions[ __( 'Remove Highlight', 'stream' ) ] = '#';
@@ -247,9 +264,9 @@ class Alert_Type_Highlight extends Alert_Type {
 		if ( ! is_numeric( $record_id ) ) {
 			wp_send_json_error( $failure_message );
 		}
-		$record_obj = new \stdClass();
-		$record_obj->ID = $record_id;
-		$record = new Record( $record_obj );
+		$record_obj       = new \stdClass();
+		$record_obj->ID   = $record_id;
+		$record           = new Record( $record_obj );
 		$alerts_triggered = $record->get_meta( Alerts::ALERTS_TRIGGERED_META_KEY, true );
 		if ( isset( $alerts_triggered[ $this->slug ] ) ) {
 			unset( $alerts_triggered[ $this->slug ] );
@@ -268,9 +285,9 @@ class Alert_Type_Highlight extends Alert_Type {
 			wp_register_script( self::SCRIPT_HANDLE, $this->plugin->locations['url'] . 'alerts/js/alert-type-highlight.js', array( 'jquery' ) );
 
 			$exports = array(
-				'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+				'ajaxUrl'      => admin_url( 'admin-ajax.php' ),
 				'removeAction' => self::REMOVE_ACTION,
-				'security' => wp_create_nonce( self::REMOVE_ACTION_NONCE ),
+				'security'     => wp_create_nonce( self::REMOVE_ACTION_NONCE ),
 			);
 
 			wp_scripts()->add_data(
@@ -301,6 +318,7 @@ class Alert_Type_Highlight extends Alert_Type {
 				$alert_meta['color'] = $color;
 			}
 		}
+
 		return $alert_meta;
 	}
 }

--- a/alerts/class-alert-type-highlight.php
+++ b/alerts/class-alert-type-highlight.php
@@ -124,14 +124,12 @@ class Alert_Type_Highlight extends Alert_Type {
 		echo '<span class="wp_stream_alert_type_description">' . esc_html__( 'Highlight this alert on the Stream records page.', 'stream' ) . '</span>';
 		echo '<label for="wp_stream_highlight_color"><span class="title">' . esc_html__( 'Color', 'stream' ) . '</span>';
 		echo '<span class="input-text-wrap">';
-		echo wp_kses_post( $form->render_field(
-			'select', array( // Xss ok.
+		echo $form->render_field( 'select', array(
 			'name'    => 'wp_stream_highlight_color',
 			'title'   => esc_attr( __( 'Highlight Color', 'stream' ) ),
 			'options' => $this->get_highlight_options(),
 			'value'   => $options['color'],
-			)
-		) );
+		) ); // Xss ok.
 		echo '</span></label>';
 	}
 	/**

--- a/alerts/class-alert-type-ifttt.php
+++ b/alerts/class-alert-type-ifttt.php
@@ -49,6 +49,7 @@ namespace WP_Stream;
  * @package WP_Stream
  */
 class Alert_Type_IFTTT extends Alert_Type {
+
 	/**
 	 * Alert type name
 	 *
@@ -74,8 +75,12 @@ class Alert_Type_IFTTT extends Alert_Type {
 		if ( ! is_admin() ) {
 			return;
 		}
-		add_filter( 'wp_stream_alerts_save_meta', array( $this, 'add_alert_meta' ), 10, 2 );
+		add_filter( 'wp_stream_alerts_save_meta', array(
+			$this,
+			'add_alert_meta',
+		), 10, 2 );
 	}
+
 	/**
 	 * Record that the Alert was triggered by a Record.
 	 *
@@ -105,7 +110,7 @@ class Alert_Type_IFTTT extends Alert_Type {
 		}
 		$options = wp_parse_args(
 			$alert_meta, array(
-				'maker_key' => '',
+				'maker_key'  => '',
 				'event_name' => '',
 			)
 		);
@@ -118,13 +123,11 @@ class Alert_Type_IFTTT extends Alert_Type {
 		echo '</span>';
 		echo '<label for="wp_stream_ifttt_maker_key"><span class="title">' . esc_html__( 'Maker Key', 'stream' ) . '</span>';
 		echo '<span class="input-text-wrap">';
-		echo wp_kses_post( $form->render_field(
-			'text', array( // Xss ok.
-			'name'    => 'wp_stream_ifttt_maker_key',
-			'title'   => esc_attr( __( 'Maker Key', 'stream' ) ),
-			'value'   => $options['maker_key'],
-			)
-		) );
+		echo $form->render_field( 'text', array(
+			'name'  => 'wp_stream_ifttt_maker_key',
+			'title' => esc_attr( __( 'Maker Key', 'stream' ) ),
+			'value' => $options['maker_key'],
+		) ); // Xss ok.
 		echo '</span>';
 		printf(
 			'<span class="input-text-wrap"><a href="%1$s" target="_blank">%2$s %3$s</a></span>',
@@ -136,13 +139,11 @@ class Alert_Type_IFTTT extends Alert_Type {
 
 		echo '<label for="wp_stream_ifttt_event_name"><span class="title">' . esc_html__( 'Event Name', 'stream' ) . '</span>';
 		echo '<span class="input-text-wrap">';
-		echo wp_kses_post( $form->render_field(
-			'text', array( // Xss ok.
-			'name'    => 'wp_stream_ifttt_event_name',
-			'title'   => esc_attr( __( 'Event Name', 'stream' ) ),
-			'value'   => $options['event_name'],
-			)
-		) );
+		echo $form->render_field( 'text', array(
+			'name'  => 'wp_stream_ifttt_event_name',
+			'title' => esc_attr( __( 'Event Name', 'stream' ) ),
+			'value' => $options['event_name'],
+		) );  // Xss ok.
 		echo '</span>';
 		printf(
 			'<span class="input-text-wrap"><a href="%1$s" target="_blank">%2$s %3$s</a></span>',
@@ -183,7 +184,7 @@ class Alert_Type_IFTTT extends Alert_Type {
 	 * array keys of data.  (also documented below)
 	 *
 	 * @param object $alert The Alert object.
-	 * @param array  $recordarr  Array of Record data.
+	 * @param array  $recordarr Array of Record data.
 	 *
 	 * @return bool
 	 */
@@ -197,12 +198,13 @@ class Alert_Type_IFTTT extends Alert_Type {
 				// translators: Placeholder refers to the Event Name of the Alert (e.g. "Update a post")
 				'summary' => sprintf( __( 'The event %s was triggered' ), $alert->alert_meta['event_name'] ),
 				'user_id' => get_current_user_id(),
-				'created' => current_time( 'Y-m-d H:i:s' ),  // Blog's local time.
+				'created' => current_time( 'Y-m-d H:i:s' ),
+				// Blog's local time.
 			)
 		);
 
 		$user_id = $recordarr['user_id'];
-		$user = get_user_by( 'id', $user_id );
+		$user    = get_user_by( 'id', $user_id );
 
 		/**
 		 * Filter User data field
@@ -227,7 +229,7 @@ class Alert_Type_IFTTT extends Alert_Type {
 		 * @return string
 		 */
 		$date_format = apply_filters( 'wp_stream_alert_ifttt_date_format', 'Y-m-d H:i:s', $alert, $recordarr );
-		$date = date( $date_format, strtotime( $created ) );
+		$date        = date( $date_format, strtotime( $created ) );
 
 		$url = 'https://maker.ifttt.com/trigger/' . $alert->alert_meta['event_name'] . '/with/key/' . $alert->alert_meta['maker_key'];
 
@@ -246,17 +248,17 @@ class Alert_Type_IFTTT extends Alert_Type {
          *
 		 * The filters below allow complete customization of these data values.
 		 */
-		$args = array(
+		$args     = array(
 			'headers' => array(
 				'Content-Type' => 'application/json',
 			),
-			'body' => wp_json_encode(
+			'body'    => wp_json_encode(
 				array(
 					/**
 					 * Filter the first IFTTT alert value
 					 *
 					 * @param string $summary The Record's summary.
-					 * @param object $alert  The Alert.
+					 * @param object $alert The Alert.
 					 * @param array  $recordarr Array of Record data.
 					 * @return mixed
 					 */
@@ -266,7 +268,7 @@ class Alert_Type_IFTTT extends Alert_Type {
 					 * Filter the second IFTTT alert value
 					 *
 					 * @param string $user_value The user meta value requested above.
-					 * @param int    $user_id  The user ID who fired the Alert.
+					 * @param int    $user_id The user ID who fired the Alert.
 					 * @param object $alert The Alert.
 					 * @param array  $recordarr Array of Record data.
 					 * @return mixed
@@ -277,7 +279,7 @@ class Alert_Type_IFTTT extends Alert_Type {
 					 * Filter the third IFTTT alert value
 					 *
 					 * @param string $date The Record's date.
-					 * @param object $alert  The Alert.
+					 * @param object $alert The Alert.
 					 * @param array  $recordarr Array of Record data.
 					 * @return mixed
 					 */
@@ -289,8 +291,10 @@ class Alert_Type_IFTTT extends Alert_Type {
 		if ( ! is_array( $response ) ) {
 			return false;
 		}
+
 		return true;
 	}
+
 	/**
 	 * Add alert meta if this is a highlight alert
 	 *
@@ -310,6 +314,7 @@ class Alert_Type_IFTTT extends Alert_Type {
 				$alert_meta['event_name'] = $event_name;
 			}
 		}
+
 		return $alert_meta;
 	}
 }

--- a/alerts/class-alert-type-menu-alert.php
+++ b/alerts/class-alert-type-menu-alert.php
@@ -77,7 +77,7 @@ class Alert_Type_Menu_Alert extends Alert_Type {
 			)
 		);
 
-		echo $form->render_all(); // Xss ok.
+		echo $form->render_fields(); // Xss ok.
 	}
 
 	/**

--- a/alerts/class-alert-type-menu-alert.php
+++ b/alerts/class-alert-type-menu-alert.php
@@ -13,6 +13,7 @@ namespace WP_Stream;
  * @package WP_Stream
  */
 class Alert_Type_Menu_Alert extends Alert_Type {
+
 	/**
 	 * Alert type name
 	 *
@@ -106,11 +107,11 @@ class Alert_Type_Menu_Alert extends Alert_Type {
 
 		$wp_admin_bar->add_node(
 			array(
-				'id' => 'wp_stream_alert_notify',
+				'id'     => 'wp_stream_alert_notify',
 				'parent' => false,
-				'title' => __( 'New Stream Alert', 'stream' ),
-				'href' => '#',
-				'meta' => array(
+				'title'  => __( 'New Stream Alert', 'stream' ),
+				'href'   => '#',
+				'meta'   => array(
 					'class' => 'opposite',
 				),
 			)
@@ -131,6 +132,7 @@ class Alert_Type_Menu_Alert extends Alert_Type {
 		}
 
 		$this->clear_messages();
+
 		return true;
 	}
 
@@ -143,7 +145,8 @@ class Alert_Type_Menu_Alert extends Alert_Type {
 	 */
 	public function get_messages() {
 		$current_user = wp_get_current_user();
-		$messages = get_user_meta( $current_user->ID, $this->get_key(), false );
+		$messages     = get_user_meta( $current_user->ID, $this->get_key(), false );
+
 		return $messages;
 	}
 


### PR DESCRIPTION
`Form_Generator::render_field()` is already heavily sanitised. However the default type contains a filter which could bypass sanitisation. This will need to be addressed somehow.

This PR essentially bring `develop` inline with `master` branch.

Fixes #967 