### PR TITLE
Fix busted IN, NOT IN query system [1]

### DIFF
--- a/classes/class-query.php
+++ b/classes/class-query.php
@@ -118,12 +118,10 @@ class Query {
 
 				$field = str_replace( array( 'record_', '__in' ), '', $key );
 				$field = empty( $field ) ? 'ID' : $field;
-				$type  = is_numeric( array_shift( $value ) ) ? '%d' : '%s';
+				$type  = is_numeric( $value[ 0 ] ) ? '%d' : '%s';
 
-				if ( ! empty( $value ) ) {
-					$format = '(' . join( ',', array_fill( 0, count( $value ), $type ) ) . ')';
-					$where .= $wpdb->prepare( " AND $wpdb->stream.%s IN {$format}", $field, $value ); // @codingStandardsIgnoreLine prepare okay
-				}
+				$format = '(' . join( ',', array_fill( 0, count( $value ), $type ) ) . ')';
+				$where .= $wpdb->prepare( " AND $wpdb->stream.{$field} IN {$format}", $value ); // @codingStandardsIgnoreLine prepare okay
 			}
 		}
 
@@ -146,12 +144,10 @@ class Query {
 
 				$field = str_replace( array( 'record_', '__not_in' ), '', $key );
 				$field = empty( $field ) ? 'ID' : $field;
-				$type  = is_numeric( array_shift( $value ) ) ? '%d' : '%s';
+				$type  = is_numeric( $value[ 0 ] ) ? '%d' : '%s';
 
-				if ( ! empty( $value ) ) {
-					$format = '(' . join( ',', array_fill( 0, count( $value ), $type ) ) . ')';
-					$where .= $wpdb->prepare( " AND $wpdb->stream.%s NOT IN {$format}", $field, $value ); // @codingStandardsIgnoreLine prepare okay
-				}
+				$format = '(' . join( ',', array_fill( 0, count( $value ), $type ) ) . ')';
+				$where .= $wpdb->prepare( " AND $wpdb->stream.{$field} NOT IN {$format}", $value ); // @codingStandardsIgnoreLine prepare okay
 			}
 		}
 


### PR DESCRIPTION
(retrying #958)

Trying to use any `__in` or `__not_in` results in a database error:

```
WordPress database error You have an error in your SQL syntax; check the
manual that corresponds to your MariaDB server version for the right syntax to
use near ''context' IN ('')
```

It looks like the algorithm here has been busted for years. `array_shift()`
mutates the underlying `$values` array, losing data user has passed into the
query parameters.

This required rewriting some of the algorithm and throwing some stuff out.

I modelled the fix mostly by grepping for `prepare.*\\\ IN\\\ ` for examples
and picked [1]

EXAMPLE QUERY (custom connector `posts-viewed`)
```
$stream = wp_stream_get_instance();

 $records = $stream->db->get_records( [
     'action' => 'viewed',
     'author' => get_current_user_id(),
     'connector' => 'posts-viewed',
     'context__in' => [ 'course', 'lesson' ],
 ] );
```

[1]: https://github.com/WordPress/WordPress/blob/4.9.1/wp-includes/class-wp-comment-query.php#L794