### PR TITLE
Allow filtering the min suffix for asset URLs since they're not bundled

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -131,7 +131,9 @@ function wp_stream_is_cron_enabled() {
  */
 function wp_stream_min_suffix() {
 	$min = '';
-	if ( ! defined( 'SCRIPT_DEBUG' ) || false === SCRIPT_DEBUG ) {
+	$is_script_debugging = ! defined( 'SCRIPT_DEBUG' ) || false === SCRIPT_DEBUG;
+
+	if ( apply_filters( 'wp_stream_load_min_assets', $is_script_debugging ) ) {
 		$min = 'min.';
 	}
 


### PR DESCRIPTION
Since compiled assets are not bundled, the minified suffix check breaks the plugin where it is submoduled.

This allows filtering the check to disallow the suffix from being added.