### PR TITLE
Fix/local docker mysql

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - ./build:/var/www/html/wp-content/plugins/stream
       - ./vendor/wordpress/wordpress/tests/phpunit:/var/www/html/tests/wordpress-phpunit
       - ./local/config/wp-tests-config.php:/var/www/html/tests/wordpress-phpunit/wp-tests-config.php
+      - ./local/docker/wordpress/php.ini:/usr/local/etc/php/php.ini
     restart: always
     environment:
       APACHE_RUN_USER: "#1000" # Ensure Apache can write to the filesystem.
@@ -42,6 +43,13 @@ services:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
       MYSQL_DATABASE: "wordpress_test"
       MYSQL_ROOT_PASSWORD: ""
+
+  # Capture and display all email sent by WordPress.
+  mailhog:
+    image: mailhog/mailhog
+    ports:
+      - "1025:1025"
+      - "8025:8025"
 
 volumes:
   db_data: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     ports:
       - "80:80"
       - "443:443"
+      - "9000:9000" # Xdebug
     volumes:
       - ./local/public:/var/www/html # Use host-mount to ensure correct permissions for all.
       - .:/var/www/html/wp-content/plugins/stream-src

--- a/local/docker/wordpress/Dockerfile
+++ b/local/docker/wordpress/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update; \
 	apt-get install -y --no-install-recommends \
 	# WP-CLI dependencies.
 	bash less default-mysql-client git \
-	# Mailcatcher dependencies.
+	# MailHog dependencies.
 	msmtp;
 
 # Setup xdebug.

--- a/local/docker/wordpress/Dockerfile
+++ b/local/docker/wordpress/Dockerfile
@@ -6,7 +6,7 @@ ENV PATH="/var/www/html/wp-content/plugins/stream-src/vendor/bin:${PATH}"
 RUN apt-get update; \
 	apt-get install -y --no-install-recommends \
 	# WP-CLI dependencies.
-	bash less mysql-client git \
+	bash less default-mysql-client git \
 	# Mailcatcher dependencies.
 	ssmtp;
 

--- a/local/docker/wordpress/Dockerfile
+++ b/local/docker/wordpress/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update; \
 	# WP-CLI dependencies.
 	bash less default-mysql-client git \
 	# Mailcatcher dependencies.
-	ssmtp;
+	msmtp;
 
 # Setup xdebug.
 RUN	pecl install xdebug; \

--- a/local/docker/wordpress/php.ini
+++ b/local/docker/wordpress/php.ini
@@ -1,0 +1,5 @@
+upload_max_filesize = 64M
+post_max_size = 64M
+
+# Forward mail to the MailHog container.
+sendmail_path = "/usr/bin/msmtp --host=mailhog --port=1025 --from=local@stream.local --read-recipients"

--- a/local/docker/wordpress/php.ini
+++ b/local/docker/wordpress/php.ini
@@ -3,3 +3,8 @@ post_max_size = 64M
 
 # Forward mail to the MailHog container.
 sendmail_path = "/usr/bin/msmtp --host=mailhog --port=1025 --from=local@stream.local --read-recipients"
+
+# Enable remote Xdebug.
+xdebug.remote_enable = 1
+xdebug.remote_autostart = 1
+xdebug.remote_connect_back = 1


### PR DESCRIPTION
Fixes #1025.

- [x] Switch to using `default-mysql-client` which will now install a version of MariaDB client instead.
- [x] Switch to using `msmtp`.
- [x] Enable and configure Xdebug.
- [ ] Decument Xdebug usage.
- [x] Add MailHog mail catcher.
- [ ] Decument MailHog usage.
