### PR TITLE
Always allow tracking CRON runs

### DIFF
--- a/classes/class-author.php
+++ b/classes/class-author.php
@@ -222,22 +222,15 @@ class Author {
 	}
 
 	/**
-	 * True if doing WP Cron, otherwise false
+	 * Check if the current request is part of a WP cron task.
 	 *
-	 * Note: If native WP Cron has been disabled and you are
-	 * hitting the cron endpoint with a system cron job, this
-	 * method will always return false.
+	 * Note: This will return true for all manual or custom
+	 * cron runs even if the default front-end cron is disabled.
 	 *
 	 * @return bool
 	 */
 	public function is_doing_wp_cron() {
-		return (
-			wp_stream_is_cron_enabled()
-			&&
-			defined( 'DOING_CRON' )
-			&&
-			DOING_CRON
-		);
+		return ( defined( 'DOING_CRON' ) && DOING_CRON );
 	}
 
 	/**

--- a/classes/class-author.php
+++ b/classes/class-author.php
@@ -227,6 +227,9 @@ class Author {
 	 * Note: This will return true for all manual or custom
 	 * cron runs even if the default front-end cron is disabled.
 	 *
+	 * We're not using `wp_doing_cron()` since it was introduced
+	 * only in WordPress 4.8.0.
+	 *
 	 * @return bool
 	 */
 	public function is_doing_wp_cron() {

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -381,19 +381,16 @@ class Settings {
 			array_push( $fields['advanced']['fields'], $akismet_tracking );
 		}
 
-		// If WP Cron is enabled, allow Admins to opt-in to WP Cron tracking
-		if ( wp_stream_is_cron_enabled() ) {
-			$wp_cron_tracking = array(
-				'name'        => 'wp_cron_tracking',
-				'title'       => esc_html__( 'WP Cron Tracking', 'stream' ),
-				'type'        => 'checkbox',
-				'desc'        => esc_html__( 'By default, Stream does not track activity performed by WordPress cron events unless you opt-in here. Enabling this is not necessary or recommended for most sites.', 'stream' ),
-				'after_field' => esc_html__( 'Enabled', 'stream' ),
-				'default'     => 0,
-			);
+		$wp_cron_tracking = array(
+			'name'        => 'wp_cron_tracking',
+			'title'       => esc_html__( 'WP Cron Tracking', 'stream' ),
+			'type'        => 'checkbox',
+			'desc'        => esc_html__( 'By default, Stream does not track activity performed by WordPress cron events unless you opt-in here. Enabling this is not necessary or recommended for most sites.', 'stream' ),
+			'after_field' => esc_html__( 'Enabled', 'stream' ),
+			'default'     => 0,
+		);
 
-			array_push( $fields['advanced']['fields'], $wp_cron_tracking );
-		}
+		array_push( $fields['advanced']['fields'], $wp_cron_tracking );
 
 		/**
 		 * Filter allows for modification of options fields

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -116,7 +116,8 @@ function wp_stream_is_vip() {
 }
 
 /**
- * Check if the default front-end WP Cron is enabled.
+ * Check if the default front-end WP Cron is enabled. It doesn't
+ * mean that the Cron is disabled in general.
  *
  * @return bool
  */

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -116,7 +116,7 @@ function wp_stream_is_vip() {
 }
 
 /**
- * True if native WP Cron is enabled, otherwise false
+ * Check if the default front-end WP Cron is enabled.
  *
  * @return bool
  */


### PR DESCRIPTION
Fixes #959 and #1013.

- Allow enabling CRON tracking even if the front-end WP Cron is disabled.

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [ ] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.
