### PR TITLE
Release 3.4.1

### DIFF
--- a/classes/class-author.php
+++ b/classes/class-author.php
@@ -222,22 +222,18 @@ class Author {
 	}
 
 	/**
-	 * True if doing WP Cron, otherwise false
+	 * Check if the current request is part of a WP cron task.
 	 *
-	 * Note: If native WP Cron has been disabled and you are
-	 * hitting the cron endpoint with a system cron job, this
-	 * method will always return false.
+	 * Note: This will return true for all manual or custom
+	 * cron runs even if the default front-end cron is disabled.
+	 *
+	 * We're not using `wp_doing_cron()` since it was introduced
+	 * only in WordPress 4.8.0.
 	 *
 	 * @return bool
 	 */
 	public function is_doing_wp_cron() {
-		return (
-			wp_stream_is_cron_enabled()
-			&&
-			defined( 'DOING_CRON' )
-			&&
-			DOING_CRON
-		);
+		return ( defined( 'DOING_CRON' ) && DOING_CRON );
 	}
 
 	/**

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -9,7 +9,7 @@ class Plugin {
 	 *
 	 * @const string
 	 */
-	const VERSION = '3.4.0';
+	const VERSION = '3.4.1';
 
 	/**
 	 * WP-CLI command

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -381,19 +381,16 @@ class Settings {
 			array_push( $fields['advanced']['fields'], $akismet_tracking );
 		}
 
-		// If WP Cron is enabled, allow Admins to opt-in to WP Cron tracking
-		if ( wp_stream_is_cron_enabled() ) {
-			$wp_cron_tracking = array(
-				'name'        => 'wp_cron_tracking',
-				'title'       => esc_html__( 'WP Cron Tracking', 'stream' ),
-				'type'        => 'checkbox',
-				'desc'        => esc_html__( 'By default, Stream does not track activity performed by WordPress cron events unless you opt-in here. Enabling this is not necessary or recommended for most sites.', 'stream' ),
-				'after_field' => esc_html__( 'Enabled', 'stream' ),
-				'default'     => 0,
-			);
+		$wp_cron_tracking = array(
+			'name'        => 'wp_cron_tracking',
+			'title'       => esc_html__( 'WP Cron Tracking', 'stream' ),
+			'type'        => 'checkbox',
+			'desc'        => esc_html__( 'By default, Stream does not track activity performed by WordPress cron events unless you opt-in here. Enabling this is not necessary or recommended for most sites.', 'stream' ),
+			'after_field' => esc_html__( 'Enabled', 'stream' ),
+			'default'     => 0,
+		);
 
-			array_push( $fields['advanced']['fields'], $wp_cron_tracking );
-		}
+		array_push( $fields['advanced']['fields'], $wp_cron_tracking );
 
 		/**
 		 * Filter allows for modification of options fields

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -116,7 +116,8 @@ function wp_stream_is_vip() {
 }
 
 /**
- * True if native WP Cron is enabled, otherwise false
+ * Check if the default front-end WP Cron is enabled. It doesn't
+ * mean that the Cron is disabled in general.
  *
  * @return bool
  */

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: lukecarbis, fjarrett, stream, xwp
 Tags: wp stream, stream, activity, logs, track
 Requires at least: 4.5
 Tested up to: 5.2
-Stable tag: 3.4.0
+Stable tag: 3.4.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -87,6 +87,10 @@ Thank you for wanting to make Stream better for everyone!
 
 == Changelog ==
 
+= 3.4.1 - July 25, 2019 =
+
+* Fix: Allow tracking cron events even when the default WordPress front-end cron runner is disabled via `DISABLE_WP_CRON`. See [#959], props [@khromov](https://github.com/khromov) and [@tareiking](https://github.com/tareiking).
+
 = 3.4.0 - July 13, 2019 =
 
 * New: Add development environment and documentation, update tooling [#1016](https://github.com/xwp/stream/pull/1016).

--- a/stream.php
+++ b/stream.php
@@ -3,7 +3,7 @@
  * Plugin Name: Stream
  * Plugin URI: https://wp-stream.com/
  * Description: Stream tracks logged-in user activity so you can monitor every change made on your WordPress site in beautifully organized detail. All activity is organized by context, action and IP address for easy filtering. Developers can extend Stream with custom connectors to log any kind of action.
- * Version: 3.4.0
+ * Version: 3.4.1
  * Author: XWP
  * Author URI: https://xwp.co/
  * License: GPLv2+


### PR DESCRIPTION
## Release Changelog

- Fix: Allow tracking cron events even when the default WordPress front-end cron runner is disabled via `DISABLE_WP_CRON`. See #959, props @khromov and @tareiking.

## Release Checklist

- [x] This pull request is to the `master` branch.
- [x] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [x] Update changelog in `readme.txt`.
- [x] Bump version in `stream.php`.
- [x] Bump `Stable tag` in `readme.txt`.
- [x] Bump version in `classes/class-plugin.php`.
- [x] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).
