### PR TITLE
Use unique kets for stream meta

### DIFF
--- a/classes/class-db-driver-wpdb.php
+++ b/classes/class-db-driver-wpdb.php
@@ -68,8 +68,8 @@ class DB_Driver_WPDB implements DB_Driver {
 
 		// Insert record meta
 		foreach ( (array) $meta as $key => $vals ) {
-			foreach ( (array) $vals as $val ) {
-				$this->insert_meta( $record_id, $key, $val );
+			foreach ( (array) $vals as $meta_key $val ) {
+				$this->insert_meta( $record_id, $meta_key, $val );
 			}
 		}
 


### PR DESCRIPTION
Right now stream use the same key if meta has an array. See the screenshot below. Stream uses`user_meta` as key for all the data in array `user_meta` instead of array keys

<img width="1173" alt="Screen Shot 2019-10-16 at 3 26 44 PM" src="https://user-images.githubusercontent.com/581008/66908843-67f5d400-f029-11e9-8df3-a84682b4e11a.png">


![image](https://user-images.githubusercontent.com/581008/66908554-e9009b80-f028-11e9-85d8-058ff3eb6245.png)

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [ ] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: Describe a bug fix included in this release.
- New: Describe a new feature in this release.


## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).


Change `[ ]` to `[x]` to mark the items as done.
