### PR TITLE
929: Users no results found

### DIFF
--- a/classes/class-list-table.php
+++ b/classes/class-list-table.php
@@ -718,55 +718,46 @@ class List_Table extends \WP_List_Table {
 	}
 
 	public function filter_select( $name, $title, $items, $ajax = false ) {
-		if ( $ajax ) {
-			$out = sprintf(
-				'<input type="hidden" name="%s" class="chosen-select" value="%s" data-placeholder="%s" />',
-				esc_attr( $name ),
-				esc_attr( wp_stream_filter_input( INPUT_GET, $name ) ),
-				esc_attr( $title )
-			);
-		} else {
-			$options  = array( '<option value=""></option>' );
-			$selected = wp_stream_filter_input( INPUT_GET, $name );
+		$options  = [ '<option value=""></option>' ];
+		$selected = wp_stream_filter_input( INPUT_GET, $name );
 
-			foreach ( $items as $key => $item ) {
-				$value       = isset( $item['children'] ) ? 'group-' . $key : $key;
-				$option_args = array(
-					'value'    => $value,
-					'selected' => selected( $value, $selected, false ),
-					'disabled' => isset( $item['disabled'] ) ? $item['disabled'] : null,
-					'icon'     => isset( $item['icon'] ) ? $item['icon'] : null,
-					'group'    => isset( $item['children'] ) ? $key : null,
-					'tooltip'  => isset( $item['tooltip'] ) ? $item['tooltip'] : null,
-					'class'    => isset( $item['children'] ) ? 'level-1' : null,
-					'label'    => isset( $item['label'] ) ? $item['label'] : null,
-				);
-				$options[]   = $this->filter_option( $option_args );
+		foreach ( $items as $key => $item ) {
+			$value       = isset( $item['children'] ) ? 'group-' . $key : $key;
+			$option_args = [
+				'value'    => $value,
+				'selected' => selected( $value, $selected, false ),
+				'disabled' => isset( $item['disabled'] ) ? $item['disabled'] : null,
+				'icon'     => isset( $item['icon'] ) ? $item['icon'] : null,
+				'group'    => isset( $item['children'] ) ? $key : null,
+				'tooltip'  => isset( $item['tooltip'] ) ? $item['tooltip'] : null,
+				'class'    => isset( $item['children'] ) ? 'level-1' : null,
+				'label'    => isset( $item['label'] ) ? $item['label'] : null,
+			];
+			$options[]   = $this->filter_option( $option_args );
 
-				if ( isset( $item['children'] ) ) {
-					foreach ( $item['children'] as $child_value => $child_item ) {
-						$option_args = array(
-							'value'    => $child_value,
-							'selected' => selected( $child_value, $selected, false ),
-							'disabled' => isset( $child_item['disabled'] ) ? $child_item['disabled'] : null,
-							'icon'     => isset( $child_item['icon'] ) ? $child_item['icon'] : null,
-							'group'    => $key,
-							'tooltip'  => isset( $child_item['tooltip'] ) ? $child_item['tooltip'] : null,
-							'class'    => 'level-2',
-							'label'    => isset( $child_item['label'] ) ? '- ' . $child_item['label'] : null,
-						);
-						$options[]   = $this->filter_option( $option_args );
-					}
+			if ( isset( $item['children'] ) ) {
+				foreach ( $item['children'] as $child_value => $child_item ) {
+					$option_args = [
+						'value'    => $child_value,
+						'selected' => selected( $child_value, $selected, false ),
+						'disabled' => isset( $child_item['disabled'] ) ? $child_item['disabled'] : null,
+						'icon'     => isset( $child_item['icon'] ) ? $child_item['icon'] : null,
+						'group'    => $key,
+						'tooltip'  => isset( $child_item['tooltip'] ) ? $child_item['tooltip'] : null,
+						'class'    => 'level-2',
+						'label'    => isset( $child_item['label'] ) ? '- ' . $child_item['label'] : null,
+					];
+					$options[]   = $this->filter_option( $option_args );
 				}
 			}
-			$out = sprintf(
-				'<select name="%s" class="chosen-select" data-placeholder="%s">%s</select>',
-				esc_attr( $name ),
-				// translators: Placeholder refers to the title of the dropdown menu (e.g. "users")
-				sprintf( esc_attr__( 'Show all %s', 'stream' ), $title ),
-				implode( '', $options )
-			);
 		}
+		$out = sprintf(
+			'<select name="%s" class="chosen-select" data-placeholder="%s">%s</select>',
+			esc_attr( $name ),
+			// translators: Placeholder refers to the title of the dropdown menu (e.g. "users")
+			sprintf( esc_attr__( 'Show all %s', 'stream' ), $title ),
+			implode( '', $options )
+		);
 
 		return $out;
 	}

--- a/classes/class-list-table.php
+++ b/classes/class-list-table.php
@@ -886,6 +886,7 @@ class List_Table extends \WP_List_Table {
 		}
 		echo '</select></div>';
 		wp_nonce_field( 'stream_record_actions_nonce', 'stream_record_actions_nonce' );
+		wp_nonce_field( 'stream_filters_user_search_nonce', 'stream_filters_user_search_nonce' );
 
 		printf( '<input type="hidden" name="page" value="%s">', esc_attr( wp_stream_filter_input( INPUT_GET, 'page' ) ) );
 		printf( '<input type="hidden" name="date_predefined" value="%s">', esc_attr( wp_stream_filter_input( INPUT_GET, 'date_predefined' ) ) );

--- a/classes/class-list-table.php
+++ b/classes/class-list-table.php
@@ -718,12 +718,12 @@ class List_Table extends \WP_List_Table {
 	}
 
 	public function filter_select( $name, $title, $items, $ajax = false ) {
-		$options  = [ '<option value=""></option>' ];
+		$options  = array( '<option value=""></option>' );
 		$selected = wp_stream_filter_input( INPUT_GET, $name );
 
 		foreach ( $items as $key => $item ) {
 			$value       = isset( $item['children'] ) ? 'group-' . $key : $key;
-			$option_args = [
+			$option_args = array(
 				'value'    => $value,
 				'selected' => selected( $value, $selected, false ),
 				'disabled' => isset( $item['disabled'] ) ? $item['disabled'] : null,
@@ -732,12 +732,12 @@ class List_Table extends \WP_List_Table {
 				'tooltip'  => isset( $item['tooltip'] ) ? $item['tooltip'] : null,
 				'class'    => isset( $item['children'] ) ? 'level-1' : null,
 				'label'    => isset( $item['label'] ) ? $item['label'] : null,
-			];
+			);
 			$options[]   = $this->filter_option( $option_args );
 
 			if ( isset( $item['children'] ) ) {
 				foreach ( $item['children'] as $child_value => $child_item ) {
-					$option_args = [
+					$option_args = array(
 						'value'    => $child_value,
 						'selected' => selected( $child_value, $selected, false ),
 						'disabled' => isset( $child_item['disabled'] ) ? $child_item['disabled'] : null,
@@ -746,7 +746,7 @@ class List_Table extends \WP_List_Table {
 						'tooltip'  => isset( $child_item['tooltip'] ) ? $child_item['tooltip'] : null,
 						'class'    => 'level-2',
 						'label'    => isset( $child_item['label'] ) ? '- ' . $child_item['label'] : null,
-					];
+					);
 					$options[]   = $this->filter_option( $option_args );
 				}
 			}

--- a/ui/js/admin.js
+++ b/ui/js/admin.js
@@ -25,7 +25,7 @@ jQuery(
 							record.text = record.text.substring( 2 );
 						}
 
-						if ( 'undefined' !== typeof record.id ) {
+						if ( 'undefined' !== typeof record.id && 'string' === typeof record.id ) {
 							if ( record.id.indexOf( 'group-' ) === 0 ) {
 								$result.addClass( 'parent' );
 							} else if ( $elem.hasClass( 'level-2' ) ) {


### PR DESCRIPTION
Fixes #929.

This approach removes the hidden input field for ajax items. This is no longer required as part of [select2](https://select2.org/upgrading/migrating-from-35#no-more-hidden-input-tags).

It also adds the nonce to list table filters so ajax nonce checks work.

I haven't performed any of the checklist items below. I can, but would rather this gets some eyes from XWP team to see what I can't see with the proposal.

# To test

- Ensure your WP instance has over 50 users.
- Visit stream logs
- Click `user` filter option
- Search for known usernames
- Rejoice

# Future suggestion

- The way stream works now, it won't give you any users in the list on initial load. Maybe it should load the 50 first users retrieved 🤷‍♂ 

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [ ] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: Describe a bug fix included in this release.
- New: Describe a new feature in this release.


## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).


Change `[ ]` to `[x]` to mark the items as done.
