### PR TITLE
Allow tags to be built by Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ branches:
   only:
   - master
   - develop
+  - /^\d+\.\d+(\.\d+)?(-.*)?$/
 
 notifications:
   email: false


### PR DESCRIPTION
Fixes #1054 

Adds support for the following tag structures:

- 1.2.3
- 1.2
- 1.2-alpha
- 1.2.3-beta
- 1.2.3-rc.2

This will allow Travis to run the configured `deploy` step.

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [ ] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: Travis CI will now build and deploy on releasing a tag

## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).


Change `[ ]` to `[x]` to mark the items as done.
