### PR TITLE
Delay Ajax request for 0.5 seconds when performing a user search on stream plugin page

### DIFF
--- a/ui/js/admin.js
+++ b/ui/js/admin.js
@@ -68,6 +68,7 @@ jQuery(
 						width: '165px',
 						ajax: {
 							url: ajaxurl,
+							delay: 500,
 							dataType: 'json',
 							quietMillis: 100,
 							data: function( term ) {


### PR DESCRIPTION
Fixes #1081 .

Describe your approach and how it fixes the issue.

Hi @kasparsd, could you use this PR? 

The solution proposed by @lkraav seems to be in line with select2 documentation: https://select2.org/data-sources/ajax#rate-limiting-requests

Alternatively, it looks like `quietMillis`  could have been a good option to use per documentation https://select2.github.io/select2/ :  

quietMillis | int | Number of milliseconds to wait for the user to stop typing before issuing the ajax request.
-- | -- | --

This didn't work for me however.

I'm wondering if this line should also be taken out since it looks it serves no purpose for now: https://github.com/xwp/stream/blob/develop/ui/js/admin.js#L72

As for the time window, 0.5 seconds seem to be the sweet spot for me.

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [X] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: Describe a bug fix included in this release.
- New: Describe a new feature in this release.


## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).


Change `[ ]` to `[x]` to mark the items as done.
