### PR TITLE
Fix/foreign lang connector bug

### DIFF
--- a/connectors/class-connector-blogs.php
+++ b/connectors/class-connector-blogs.php
@@ -74,7 +74,7 @@ class Connector_Blogs extends Connector {
 
 			foreach ( $blogs as $blog ) {
 				$blog_details   = get_blog_details( $blog->blog_id );
-				$key            = sanitize_key( $blog_details->blogname );
+				$key            = $blog_details->blogname;
 				$labels[ $key ] = $blog_details->blogname;
 			}
 		}

--- a/connectors/class-connector-blogs.php
+++ b/connectors/class-connector-blogs.php
@@ -74,7 +74,7 @@ class Connector_Blogs extends Connector {
 
 			foreach ( $blogs as $blog ) {
 				$blog_details   = get_blog_details( $blog->blog_id );
-				$key            = $blog_details->blogname;
+				$key            = sprintf( 'blog-%d', $blog->blog_id );
 				$labels[ $key ] = $blog_details->blogname;
 			}
 		}

--- a/connectors/class-connector-mercator.php
+++ b/connectors/class-connector-mercator.php
@@ -65,7 +65,7 @@ class Connector_Mercator extends Connector {
 
 			foreach ( $blogs as $blog ) {
 				$blog_details   = get_site( $blog->blog_id );
-				$key            = $blog_details->blogname;
+				$key            = sprintf( 'blog-%d', $blog->blog_id );
 				$labels[ $key ] = $blog_details->blogname;
 			}
 		}

--- a/connectors/class-connector-mercator.php
+++ b/connectors/class-connector-mercator.php
@@ -65,7 +65,7 @@ class Connector_Mercator extends Connector {
 
 			foreach ( $blogs as $blog ) {
 				$blog_details   = get_site( $blog->blog_id );
-				$key            = sanitize_key( $blog_details->blogname );
+				$key            = $blog_details->blogname;
 				$labels[ $key ] = $blog_details->blogname;
 			}
 		}

--- a/tests/tests/connectors/test-class-connector-blogs.php
+++ b/tests/tests/connectors/test-class-connector-blogs.php
@@ -1,21 +1,21 @@
 <?php
 /**
- * PHP Unit Tests for Connector_Blogs class
+ * PHP Unit Tests for Connector_Blogs class.
+ *
  * @package WP_Stream
  */
 
 namespace WP_Stream;
 
 /**
- * Class Test_WP_Stream_Connector_Blogs
+ * Class Test_WP_Stream_Connector_Blogs.
  *
  * @package WP_Stream
- * @group connectors
  */
 class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 
 	/**
-	 * Holds the connector blogs base class
+	 * Holds the connector blogs base class.
 	 *
 	 * @var Connector_Blogs
 	 */
@@ -29,10 +29,10 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 	}
 	
 	/**
-	 * Test for get_context_labels()
+	 * Test for get_context_labels().
 	 */
 	public function test_get_context_labels() {
-		//Validate this works for foreign characters as well.
+		// Validate this works for foreign characters as well.
 		$this->factory->blog->create( array( 'title' => 'ובזכויותיהם' ) );
 		$labels = $this->connector_blogs->get_context_labels();
 		$this->assertArrayHasKey( 'ובזכויותיהם', $labels );

--- a/tests/tests/connectors/test-class-connector-blogs.php
+++ b/tests/tests/connectors/test-class-connector-blogs.php
@@ -27,9 +27,9 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 			$this->markTestSkipped( 'This test requires multisite.' );
 		}
 		// Validate this works for foreign characters as well.
-		$this->factory->blog->create( array( 'title' => 'ובזכויותיהם' ) );
+		$id = $this->factory->blog->create( array( 'title' => 'ובזכויותיהם' ) );
 		$labels = $this->connector_blogs->get_context_labels();
-		$this->assertArrayHasKey( 'ובזכויותיהם', $labels );
-		$this->assertArrayHasKey( 'Test Blog', $labels );
+		$this->assertArrayHasKey( 'blog-1', $labels );
+		$this->assertArrayHasKey( 'blog-' . $id . $id, $labels );
 	}
 }

--- a/tests/tests/connectors/test-class-connector-blogs.php
+++ b/tests/tests/connectors/test-class-connector-blogs.php
@@ -1,0 +1,30 @@
+<?php
+namespace WP_Stream;
+
+class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
+
+    /**
+	 * Holds the connector blogs base class
+	 *
+	 * @var Connector_Blogs
+	 */
+	protected $connector_blogs;
+
+	public function setUp() {
+		parent::setUp();
+
+        $this->connector_blogs = new Connector_Blogs;
+		$this->assertNotEmpty( $this->connector_blogs );
+    }
+	
+	/**
+	 * Test for get_context_labels()
+	 */
+    public function test_get_context_labels() {
+		//Validate this works for foreign characters as well.
+		$id = $this->factory->blog->create( array( 'title' => 'ובזכויותיהם' ) );
+        $labels = $this->connector_blogs->get_context_labels();
+		$this->assertArrayHasKey( 'ובזכויותיהם', $labels );
+		$this->assertArrayHasKey( 'Test Blog', $labels );
+	}
+}

--- a/tests/tests/connectors/test-class-connector-blogs.php
+++ b/tests/tests/connectors/test-class-connector-blogs.php
@@ -23,6 +23,9 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 	 * @group ms-required 
 	 */
 	public function test_get_context_labels() {
+		if ( ! is_multisite() ) {
+			$this->skipWithMultisite();
+		}
 		// Validate this works for foreign characters as well.
 		$this->factory->blog->create( array( 'title' => 'ובזכויותיהם' ) );
 		$labels = $this->connector_blogs->get_context_labels();

--- a/tests/tests/connectors/test-class-connector-blogs.php
+++ b/tests/tests/connectors/test-class-connector-blogs.php
@@ -24,7 +24,7 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 	 */
 	public function test_get_context_labels() {
 		if ( ! is_multisite() ) {
-			$this->skipWithMultisite();
+			$this->markTestSkipped( 'This test requires multisite.' );
 		}
 		// Validate this works for foreign characters as well.
 		$this->factory->blog->create( array( 'title' => 'ובזכויותיהם' ) );

--- a/tests/tests/connectors/test-class-connector-blogs.php
+++ b/tests/tests/connectors/test-class-connector-blogs.php
@@ -22,7 +22,7 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 	 */
 	public function test_get_context_labels() {
 		//Validate this works for foreign characters as well.
-		$id     = $this->factory->blog->create( array( 'title' => 'ובזכויותיהם' ) );
+		$this->factory->blog->create( array( 'title' => 'ובזכויותיהם' ) );
 		$labels = $this->connector_blogs->get_context_labels();
 		$this->assertArrayHasKey( 'ובזכויותיהם', $labels );
 		$this->assertArrayHasKey( 'Test Blog', $labels );

--- a/tests/tests/connectors/test-class-connector-blogs.php
+++ b/tests/tests/connectors/test-class-connector-blogs.php
@@ -3,7 +3,7 @@ namespace WP_Stream;
 
 class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 
-    /**
+	/**
 	 * Holds the connector blogs base class
 	 *
 	 * @var Connector_Blogs
@@ -13,17 +13,17 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 	public function setUp() {
 		parent::setUp();
 
-        $this->connector_blogs = new Connector_Blogs;
+		$this->connector_blogs = new Connector_Blogs;
 		$this->assertNotEmpty( $this->connector_blogs );
-    }
+	}
 	
 	/**
 	 * Test for get_context_labels()
 	 */
-    public function test_get_context_labels() {
+	public function test_get_context_labels() {
 		//Validate this works for foreign characters as well.
-		$id = $this->factory->blog->create( array( 'title' => 'ובזכויותיהם' ) );
-        $labels = $this->connector_blogs->get_context_labels();
+		$id     = $this->factory->blog->create( array( 'title' => 'ובזכויותיהם' ) );
+		$labels = $this->connector_blogs->get_context_labels();
 		$this->assertArrayHasKey( 'ובזכויותיהם', $labels );
 		$this->assertArrayHasKey( 'Test Blog', $labels );
 	}

--- a/tests/tests/connectors/test-class-connector-blogs.php
+++ b/tests/tests/connectors/test-class-connector-blogs.php
@@ -1,17 +1,6 @@
 <?php
-/**
- * PHP Unit Tests for Connector_Blogs class.
- *
- * @package WP_Stream
- */
-
 namespace WP_Stream;
 
-/**
- * Class Test_WP_Stream_Connector_Blogs.
- *
- * @package WP_Stream
- */
 class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 
 	/**

--- a/tests/tests/connectors/test-class-connector-blogs.php
+++ b/tests/tests/connectors/test-class-connector-blogs.php
@@ -30,6 +30,6 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 		$id = $this->factory->blog->create( array( 'title' => 'ובזכויותיהם' ) );
 		$labels = $this->connector_blogs->get_context_labels();
 		$this->assertArrayHasKey( 'blog-1', $labels );
-		$this->assertArrayHasKey( 'blog-' . $id . $id, $labels );
+		$this->assertArrayHasKey( 'blog-' . $id, $labels );
 	}
 }

--- a/tests/tests/connectors/test-class-connector-blogs.php
+++ b/tests/tests/connectors/test-class-connector-blogs.php
@@ -1,6 +1,17 @@
 <?php
+/**
+ * PHP Unit Tests for Connector_Blogs class
+ * @package WP_Stream
+ */
+
 namespace WP_Stream;
 
+/**
+ * Class Test_WP_Stream_Connector_Blogs
+ *
+ * @package WP_Stream
+ * @group connectors
+ */
 class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 
 	/**

--- a/tests/tests/connectors/test-class-connector-blogs.php
+++ b/tests/tests/connectors/test-class-connector-blogs.php
@@ -19,6 +19,8 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 	
 	/**
 	 * Test for get_context_labels().
+	 *
+	 * @group ms-required 
 	 */
 	public function test_get_context_labels() {
 		// Validate this works for foreign characters as well.

--- a/tests/tests/connectors/test-class-connector-mercator.php
+++ b/tests/tests/connectors/test-class-connector-mercator.php
@@ -22,7 +22,7 @@ class Test_WP_Stream_Connector_Mercator extends WP_StreamTestCase {
 	 */
 	public function test_get_context_labels() {
 		//Validate this works for foreign characters as well.
-		$id     = $this->factory->blog->create( array( 'title' => 'ובזכויותיהם' ) );
+		$this->factory->blog->create( array( 'title' => 'ובזכויותיהם' ) );
 		$labels = $this->connector_mercator->get_context_labels();
 		$this->assertArrayHasKey( 'ובזכויותיהם', $labels );
 		$this->assertArrayHasKey( 'Test Blog', $labels );

--- a/tests/tests/connectors/test-class-connector-mercator.php
+++ b/tests/tests/connectors/test-class-connector-mercator.php
@@ -1,6 +1,7 @@
 <?php
 /**
- * PHP Unit Tests for Connector_Mercator class
+ * PHP Unit Tests for Connector_Mercator class.
+ *
  * @package WP_Stream
  */
 
@@ -10,12 +11,11 @@ namespace WP_Stream;
  * Class Test_WP_Stream_Connector_Mercator
  *
  * @package WP_Stream
- * @group connectors
  */
 class Test_WP_Stream_Connector_Mercator extends WP_StreamTestCase {
 
 	/**
-	 * Holds the connector mercator base class
+	 * Holds the connector mercator base class.
 	 *
 	 * @var Connector_Mercator
 	 */
@@ -29,10 +29,10 @@ class Test_WP_Stream_Connector_Mercator extends WP_StreamTestCase {
 	}
 
 	/**
-	 * Test for get_context_labels()
+	 * Test for get_context_labels().
 	 */
 	public function test_get_context_labels() {
-		//Validate this works for foreign characters as well.
+		// Validate this works for foreign characters as well.
 		$this->factory->blog->create( array( 'title' => 'ובזכויותיהם' ) );
 		$labels = $this->connector_mercator->get_context_labels();
 		$this->assertArrayHasKey( 'ובזכויותיהם', $labels );

--- a/tests/tests/connectors/test-class-connector-mercator.php
+++ b/tests/tests/connectors/test-class-connector-mercator.php
@@ -23,6 +23,9 @@ class Test_WP_Stream_Connector_Mercator extends WP_StreamTestCase {
 	 * @group ms-required 
 	 */
 	public function test_get_context_labels() {
+		if ( ! is_multisite() ) {
+			$this->skipWithMultisite();
+		}
 		// Validate this works for foreign characters as well.
 		$this->factory->blog->create( array( 'title' => 'ובזכויותיהם' ) );
 		$labels = $this->connector_mercator->get_context_labels();

--- a/tests/tests/connectors/test-class-connector-mercator.php
+++ b/tests/tests/connectors/test-class-connector-mercator.php
@@ -19,6 +19,8 @@ class Test_WP_Stream_Connector_Mercator extends WP_StreamTestCase {
 
 	/**
 	 * Test for get_context_labels().
+	 *
+	 * @group ms-required 
 	 */
 	public function test_get_context_labels() {
 		// Validate this works for foreign characters as well.

--- a/tests/tests/connectors/test-class-connector-mercator.php
+++ b/tests/tests/connectors/test-class-connector-mercator.php
@@ -3,7 +3,7 @@ namespace WP_Stream;
 
 class Test_WP_Stream_Connector_Mercator extends WP_StreamTestCase {
 
-    /**
+	/**
 	 * Holds the connector mercator base class
 	 *
 	 * @var Connector_Mercator
@@ -13,18 +13,18 @@ class Test_WP_Stream_Connector_Mercator extends WP_StreamTestCase {
 	public function setUp() {
 		parent::setUp();
 
-        $this->connector_mercator = new Connector_Mercator;
+		$this->connector_mercator = new Connector_Mercator;
 		$this->assertNotEmpty( $this->connector_mercator );
-    }
-    
+	}
+
 	/**
 	 * Test for get_context_labels()
 	 */
-    public function test_get_context_labels() {
-        //Validate this works for foreign characters as well.
-        $id = $this->factory->blog->create( array( 'title' => 'ובזכויותיהם' ) );
-        $labels = $this->connector_mercator->get_context_labels();
-        $this->assertArrayHasKey( 'ובזכויותיהם', $labels );
-        $this->assertArrayHasKey( 'Test Blog', $labels );
+	public function test_get_context_labels() {
+		//Validate this works for foreign characters as well.
+		$id     = $this->factory->blog->create( array( 'title' => 'ובזכויותיהם' ) );
+		$labels = $this->connector_mercator->get_context_labels();
+		$this->assertArrayHasKey( 'ובזכויותיהם', $labels );
+		$this->assertArrayHasKey( 'Test Blog', $labels );
 	}
 }

--- a/tests/tests/connectors/test-class-connector-mercator.php
+++ b/tests/tests/connectors/test-class-connector-mercator.php
@@ -1,0 +1,30 @@
+<?php
+namespace WP_Stream;
+
+class Test_WP_Stream_Connector_Mercator extends WP_StreamTestCase {
+
+    /**
+	 * Holds the connector mercator base class
+	 *
+	 * @var Connector_Mercator
+	 */
+	protected $connector_mercator;
+
+	public function setUp() {
+		parent::setUp();
+
+        $this->connector_mercator = new Connector_Mercator;
+		$this->assertNotEmpty( $this->connector_mercator );
+    }
+    
+	/**
+	 * Test for get_context_labels()
+	 */
+    public function test_get_context_labels() {
+        //Validate this works for foreign characters as well.
+        $id = $this->factory->blog->create( array( 'title' => 'ובזכויותיהם' ) );
+        $labels = $this->connector_mercator->get_context_labels();
+        $this->assertArrayHasKey( 'ובזכויותיהם', $labels );
+        $this->assertArrayHasKey( 'Test Blog', $labels );
+	}
+}

--- a/tests/tests/connectors/test-class-connector-mercator.php
+++ b/tests/tests/connectors/test-class-connector-mercator.php
@@ -1,6 +1,17 @@
 <?php
+/**
+ * PHP Unit Tests for Connector_Mercator class
+ * @package WP_Stream
+ */
+
 namespace WP_Stream;
 
+/**
+ * Class Test_WP_Stream_Connector_Mercator
+ *
+ * @package WP_Stream
+ * @group connectors
+ */
 class Test_WP_Stream_Connector_Mercator extends WP_StreamTestCase {
 
 	/**

--- a/tests/tests/connectors/test-class-connector-mercator.php
+++ b/tests/tests/connectors/test-class-connector-mercator.php
@@ -1,17 +1,6 @@
 <?php
-/**
- * PHP Unit Tests for Connector_Mercator class.
- *
- * @package WP_Stream
- */
-
 namespace WP_Stream;
 
-/**
- * Class Test_WP_Stream_Connector_Mercator
- *
- * @package WP_Stream
- */
 class Test_WP_Stream_Connector_Mercator extends WP_StreamTestCase {
 
 	/**

--- a/tests/tests/connectors/test-class-connector-mercator.php
+++ b/tests/tests/connectors/test-class-connector-mercator.php
@@ -27,9 +27,9 @@ class Test_WP_Stream_Connector_Mercator extends WP_StreamTestCase {
 			$this->markTestSkipped( 'This test requires multisite.' );
 		}
 		// Validate this works for foreign characters as well.
-		$this->factory->blog->create( array( 'title' => 'ובזכויותיהם' ) );
+		$id = $this->factory->blog->create( array( 'title' => 'ובזכויותיהם' ) );
 		$labels = $this->connector_mercator->get_context_labels();
-		$this->assertArrayHasKey( 'ובזכויותיהם', $labels );
-		$this->assertArrayHasKey( 'Test Blog', $labels );
+		$this->assertArrayHasKey( 'blog-1', $labels );
+		$this->assertArrayHasKey( 'blog-' . $id , $labels );
 	}
 }

--- a/tests/tests/connectors/test-class-connector-mercator.php
+++ b/tests/tests/connectors/test-class-connector-mercator.php
@@ -24,7 +24,7 @@ class Test_WP_Stream_Connector_Mercator extends WP_StreamTestCase {
 	 */
 	public function test_get_context_labels() {
 		if ( ! is_multisite() ) {
-			$this->skipWithMultisite();
+			$this->markTestSkipped( 'This test requires multisite.' );
 		}
 		// Validate this works for foreign characters as well.
 		$this->factory->blog->create( array( 'title' => 'ובזכויותיהם' ) );


### PR DESCRIPTION
Fixes #1051.

Hi @kasparsd ,

Could you use this PR that solves #1051 ?

This simply removes `sanitize_key()`. It looks like this value is later escaped:
https://github.com/xwp/stream/blob/develop/classes/class-list-table.php#L780 as well as label: https://github.com/xwp/stream/blob/develop/classes/class-list-table.php#L787

Since this is not getting saved into the database, my idea is it won't do any harm removing it, and there's no benefit adding an escaping function, which was my other solution. 

The unit tests seem to pass, as well as the problem is fixed by testing locally.

Thanks!

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [x] I have added phpunit tests.


## Release Changelog

- Fix: Describe a bug fix included in this release.
- New: Describe a new feature in this release.


## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).


Change `[ ]` to `[x]` to mark the items as done.
