### PR TITLE
Connectors Documentation

### DIFF
--- a/connectors/class-connector-acf.php
+++ b/connectors/class-connector-acf.php
@@ -1,6 +1,15 @@
 <?php
+/**
+ * Connector - Advanced Custom Fields
+ *
+ * @package WP_Stream
+ */
+
 namespace WP_Stream;
 
+/**
+ * Class - Connector_ACF
+ */
 class Connector_ACF extends Connector {
 	/**
 	 * Connector slug
@@ -126,8 +135,8 @@ class Connector_ACF extends Connector {
 	 *
 	 * @filter wp_stream_action_links_{connector}
 	 *
-	 * @param array  $links   Previous links registered
-	 * @param object $record Stream record
+	 * @param array  $links  Previous links registered.
+	 * @param object $record Stream record.
 	 *
 	 * @return array          Action links
 	 */
@@ -201,12 +210,12 @@ class Connector_ACF extends Connector {
 	/**
 	 * Track addition of post/user meta
 	 *
-	 * @param string     $type       Type of object, post or user
-	 * @param string     $action     Added, updated, deleted
-	 * @param integer    $meta_id
-	 * @param integer    $object_id
-	 * @param string     $meta_key
-	 * @param mixed|null $meta_value
+	 * @param string     $type       Type of object, post or user.
+	 * @param string     $action     Added, updated, deleted.
+	 * @param integer    $meta_id    Meta ID.
+	 * @param integer    $object_id  Object ID.
+	 * @param string     $meta_key   Meta Key.
+	 * @param mixed|null $meta_value Value being stored in meta.
 	 */
 	public function check_meta( $type, $action, $meta_id, $object_id, $meta_key, $meta_value = null ) {
 		$post = get_post( $object_id );
@@ -217,14 +226,14 @@ class Connector_ACF extends Connector {
 
 		$action_labels = $this->get_action_labels();
 
-		// Fields
+		// Fields.
 		if ( 0 === strpos( $meta_key, 'field_' ) ) {
 			if ( 'deleted' === $action ) {
 				$meta_value = get_post_meta( $object_id, $meta_key, true );
 			}
 
 			$this->log(
-				// translators: Placeholders refer to a field label, a form title, and an action (e.g. "Message", "Contact", "Created")
+				/* translators: %1$s: field label, %2$s: form title, %3$s: action (e.g. "Message", "Contact", "Created") */
 				esc_html_x( '"%1$s" field in "%2$s" %3$s', 'acf', 'stream' ),
 				array(
 					'label'  => $meta_value['label'],
@@ -255,7 +264,7 @@ class Connector_ACF extends Connector {
 			);
 
 			$this->log(
-				// translators: Placeholders refer to a form title, and a position (e.g. "Contact", "Side")
+				/* translators: %1$s: form title, %2$s a position (e.g. "Contact", "Side") */
 				esc_html_x( 'Position of "%1$s" updated to "%2$s"', 'acf', 'stream' ),
 				array(
 					'title'        => $post->post_title,
@@ -278,7 +287,7 @@ class Connector_ACF extends Connector {
 			);
 
 			$this->log(
-				// translators: Placeholders refer to a form title, and a layout (e.g. "Contact", "Seamless")
+				/* translators: %1$s: form title, %2$s a layout (e.g. "Contact", "Seamless") */
 				esc_html_x( 'Style of "%1$s" updated to "%2$s"', 'acf', 'stream' ),
 				array(
 					'title'        => $post->post_title,
@@ -321,7 +330,7 @@ class Connector_ACF extends Connector {
 			}
 
 			$this->log(
-				// translators: Placeholders refer to a form title, and a display option (e.g. "Contact", "All screens")
+				/* translators: %1$s: a form title, %2$s: a display option (e.g. "Contact", "All screens") */
 				esc_html_x( '"%1$s" set to display on "%2$s"', 'acf', 'stream' ),
 				array(
 					'title'        => $post->post_title,
@@ -339,12 +348,12 @@ class Connector_ACF extends Connector {
 	/**
 	 * Track changes to ACF values within rendered post meta forms
 	 *
-	 * @param string     $type       Type of object, post or user
-	 * @param string     $action     Added, updated, deleted
-	 * @param integer    $meta_id
-	 * @param integer    $object_id
-	 * @param string     $key
-	 * @param mixed|null $value
+	 * @param string     $type       Type of object, post or user.
+	 * @param string     $action     Added, updated, deleted.
+	 * @param integer    $meta_id    Meta ID.
+	 * @param integer    $object_id  Object ID.
+	 * @param string     $key        Meta Key.
+	 * @param mixed|null $value      Value being stored in meta.
 	 *
 	 * @return bool
 	 */
@@ -361,7 +370,7 @@ class Connector_ACF extends Connector {
 		if ( 'user' === $type ) {
 			$object_key = 'user_' . $object_id;
 		} elseif ( 'taxonomy' === $type ) {
-			if ( 0 === strpos( $key, '_' ) ) { // Ignore the 'revision' stuff!
+			if ( 0 === strpos( $key, '_' ) ) { // Ignore the 'revision' stuff!.
 				return false;
 			}
 
@@ -369,7 +378,7 @@ class Connector_ACF extends Connector {
 				return false;
 			}
 
-			list( , $taxonomy, $term_id, $key ) = $matches; // Skips 0 index
+			list( , $taxonomy, $term_id, $key ) = $matches; // Skips 0 index.
 
 			$object_key = $taxonomy . '_' . $term_id;
 		} elseif ( 'option' === $type ) {
@@ -403,7 +412,7 @@ class Connector_ACF extends Connector {
 			$cache = $this->cached_field_values_updates[ $object_key ][ $key ];
 
 			$this->log(
-				// translators: Placeholders refer to a field label, an object title, and an object type (e.g. "Message", "Hello World", "post")
+				/* translators: %1$s: a field label, %2$s: an object title, %3$s: an object type (e.g. "Message", "Hello World", "post") */
 				esc_html_x( '"%1$s" of "%2$s" %3$s updated', 'acf', 'stream' ),
 				array(
 					'field_label'   => $cache['field']['label'],
@@ -442,7 +451,7 @@ class Connector_ACF extends Connector {
 			$deleted = array_diff( $old, $new );
 
 			$this->log(
-				// translators: Placeholders refer to a form title, the number of rules added, and the number of rules deleted (e.g. "Contact", "42", "7")
+				/* translators: %1$s: a form title, %2$d: the number of rules added, %3$d: the number of rules deleted (e.g. "Contact", "42", "7") */
 				esc_html_x( 'Updated rules of "%1$s" (%2$d added, %3$d deleted)', 'acf', 'stream' ),
 				array(
 					'title'      => $post->post_title,
@@ -461,7 +470,7 @@ class Connector_ACF extends Connector {
 	/**
 	 * Override connector log for our own Settings / Actions
 	 *
-	 * @param array $data
+	 * @param array $data  Record data.
 	 *
 	 * @return array|bool
 	 */
@@ -483,9 +492,9 @@ class Connector_ACF extends Connector {
 	 * Track changes to custom field values updates, saves filtered values to be
 	 * processed by callback_updated_post_meta
 	 *
-	 * @param string $value
-	 * @param int    $post_id
-	 * @param string $field
+	 * @param string $value    Field value.
+	 * @param int    $post_id  Field post ID.
+	 * @param string $field    Field name.
 	 *
 	 * @return string
 	 */
@@ -497,8 +506,8 @@ class Connector_ACF extends Connector {
 	/**
 	 * Track changes to post main attributes, ie: Order No.
 	 *
-	 * @param int   $post_id
-	 * @param array $data  Array with the updated post data
+	 * @param int   $post_id Field post ID.
+	 * @param array $data    Array with the updated post data.
 	 */
 	public function callback_pre_post_update( $post_id, $data ) {
 		$post = get_post( $post_id );
@@ -510,7 +519,7 @@ class Connector_ACF extends Connector {
 		// menu_order, aka Order No.
 		if ( $data['menu_order'] !== $post->menu_order ) {
 			$this->log(
-				// translators: Placeholders refer to a form title, a numeric position, and another numeric position (e.g. "Contact", "42", "7")
+				/* translators: %1$s: a form title, %2$d: a numeric position, %3$d: numeric position (e.g. "Contact", "42", "7") */
 				esc_html_x( '"%1$s" reordered from %2$d to %3$d', 'acf', 'stream' ),
 				array(
 					'title'          => $post->post_title,
@@ -527,8 +536,8 @@ class Connector_ACF extends Connector {
 	/**
 	 * Track addition of new options
 	 *
-	 * @param string $key   Option name
-	 * @param string $value Option value
+	 * @param string $key   Option name.
+	 * @param string $value Option value.
 	 */
 	public function callback_added_option( $key, $value ) {
 		$this->check_meta_values( self::get_saved_option_type( $key ), 'added', null, null, $key, $value );
@@ -537,9 +546,9 @@ class Connector_ACF extends Connector {
 	/**
 	 * Track addition of new options
 	 *
-	 * @param $key
-	 * @param $old
-	 * @param $value
+	 * @param string $key   Option key.
+	 * @param string $old   Old value.
+	 * @param string $value New value.
 	 */
 	public function callback_updated_option( $key, $old, $value ) {
 		unset( $old );
@@ -549,7 +558,7 @@ class Connector_ACF extends Connector {
 	/**
 	 * Track addition of new options
 	 *
-	 * @param $key
+	 * @param string $key Option key.
 	 */
 	public function callback_deleted_option( $key ) {
 		$this->check_meta_values( self::get_saved_option_type( $key ), 'deleted', null, null, $key, null );
@@ -558,7 +567,7 @@ class Connector_ACF extends Connector {
 	/**
 	 * Determines the type of option that is saved
 	 *
-	 * @param $key
+	 * @param string $key Option key.
 	 * @return string
 	 */
 	private function get_saved_option_type( $key ) {

--- a/connectors/class-connector-bbpress.php
+++ b/connectors/class-connector-bbpress.php
@@ -1,6 +1,15 @@
 <?php
+/**
+ * Connector for bbPress
+ *
+ * @package WP_Stream
+ */
+
 namespace WP_Stream;
 
+/**
+ * Class - Connector_BbPress
+ */
 class Connector_BbPress extends Connector {
 	/**
 	 * Connector slug
@@ -120,8 +129,8 @@ class Connector_BbPress extends Connector {
 	 *
 	 * @filter wp_stream_action_links_{connector}
 	 *
-	 * @param  array  $links      Previous links registered
-	 * @param  object $record    Stream record
+	 * @param  array  $links   Previous links registered.
+	 * @param  object $record  Stream record.
 	 *
 	 * @return array             Action links
 	 */
@@ -140,6 +149,9 @@ class Connector_BbPress extends Connector {
 		return $links;
 	}
 
+	/**
+	 * Register the connector
+	 */
 	public function register() {
 		parent::register();
 
@@ -149,7 +161,7 @@ class Connector_BbPress extends Connector {
 	/**
 	 * Override connector log for our own Settings / Actions
 	 *
-	 * @param array $data
+	 * @param array $data  Record data.
 	 *
 	 * @return array|bool
 	 */
@@ -184,12 +196,12 @@ class Connector_BbPress extends Connector {
 		} elseif ( 'posts' === $data['connector'] && in_array( $data['context'], array( 'forum', 'topic', 'reply' ), true ) ) {
 			if ( 'reply' === $data['context'] ) {
 				if ( 'updated' === $data['action'] ) {
-					// translators: Placeholder refers to a post title (e.g. "Hello World")
-					$data['message']            = esc_html__( 'Replied on "%1$s"', 'stream' );
+					/* translators: %s a post title (e.g. "Hello World") */
+					$data['message']            = esc_html__( 'Replied on "%s"', 'stream' );
 					$data['args']['post_title'] = get_post( wp_get_post_parent_id( $data['object_id'] ) )->post_title;
 				}
 				$data['args']['post_title'] = sprintf(
-					// translators: Placeholder refers to a post title (e.g. "Hello World")
+					/* translators: %s a post title (e.g. "Hello World") */
 					__( 'Reply to: %s', 'stream' ),
 					get_post( wp_get_post_parent_id( $data['object_id'] ) )->post_title
 				);
@@ -206,10 +218,10 @@ class Connector_BbPress extends Connector {
 	/**
 	 * Tracks togging the forum topics
 	 *
-	 * @param bool     $success
-	 * @param \WP_Post $post_data
-	 * @param string   $action
-	 * @param string   $message
+	 * @param bool     $success    If action success.
+	 * @param \WP_Post $post_data  Post data.
+	 * @param string   $action     Record action.
+	 * @param string   $message    Message status data.
 	 *
 	 * @return array|bool
 	 */
@@ -232,7 +244,7 @@ class Connector_BbPress extends Connector {
 		$topic = get_post( $message['topic_id'] );
 
 		$this->log(
-			// translators: Placeholders refer to an action, and a topic title (e.g. "Created", "Read this first")
+			/* translators: %1$s: an action, %2$s: a topic title (e.g. "Created", "Read this first") */
 			_x( '%1$s "%2$s" topic', '1: Action, 2: Topic title', 'stream' ),
 			array(
 				'action_title' => $actions[ $action ],

--- a/connectors/class-connector-bbpress.php
+++ b/connectors/class-connector-bbpress.php
@@ -196,7 +196,7 @@ class Connector_BbPress extends Connector {
 		} elseif ( 'posts' === $data['connector'] && in_array( $data['context'], array( 'forum', 'topic', 'reply' ), true ) ) {
 			if ( 'reply' === $data['context'] ) {
 				if ( 'updated' === $data['action'] ) {
-					/* translators: %s a post title (e.g. "Hello World") */
+					/* translators: %s: a post title (e.g. "Hello World") */
 					$data['message']            = esc_html__( 'Replied on "%s"', 'stream' );
 					$data['args']['post_title'] = get_post( wp_get_post_parent_id( $data['object_id'] ) )->post_title;
 				}

--- a/connectors/class-connector-blogs.php
+++ b/connectors/class-connector-blogs.php
@@ -1,6 +1,15 @@
 <?php
+/**
+ * Connector for Blog actions.
+ *
+ * @package WP_Stream
+ */
+
 namespace WP_Stream;
 
+/**
+ * Class - Connector_Blogs
+ */
 class Connector_Blogs extends Connector {
 	/**
 	 * Connector slug
@@ -87,8 +96,8 @@ class Connector_Blogs extends Connector {
 	 *
 	 * @filter wp_stream_action_links_{connector}
 	 *
-	 * @param array  $links
-	 * @param Record $record
+	 * @param  array  $links   Previous links registered.
+	 * @param  object $record  Stream record.
 	 *
 	 * @return array
 	 */
@@ -122,15 +131,15 @@ class Connector_Blogs extends Connector {
 	 *
 	 * @action wpmu_new_blog
 	 *
-	 * @param int $blog_id
+	 * @param int $blog_id  Blog ID.
 	 */
 	public function callback_wpmu_new_blog( $blog_id ) {
 		$blog = get_blog_details( $blog_id );
 
 		$this->log(
-			// translators: Placeholder refers to site name (e.g. "FooBar Blog")
+			/* translators: %s: site name (e.g. "FooBar Blog") */
 			_x(
-				'"%1$s" site was created',
+				'"%s" site was created',
 				'1. Site name',
 				'stream'
 			),
@@ -148,16 +157,16 @@ class Connector_Blogs extends Connector {
 	 *
 	 * @action wpmu_activate_blog
 	 *
-	 * @param int $blog_id
-	 * @param int $user_id
+	 * @param int $blog_id  Blog ID.
+	 * @param int $user_id  User ID.
 	 */
 	public function callback_wpmu_activate_blog( $blog_id, $user_id ) {
 		$blog = get_blog_details( $blog_id );
 
 		$this->log(
-			// translators: Placeholder refers to site name (e.g. "FooBar Blog")
+			/* translators: %s: site name (e.g. "FooBar Blog") */
 			_x(
-				'"%1$s" site was registered',
+				'"%s" site was registered',
 				'1. Site name',
 				'stream'
 			),
@@ -176,9 +185,9 @@ class Connector_Blogs extends Connector {
 	 *
 	 * @action add_user_to_blog
 	 *
-	 * @param int    $user_id
-	 * @param string $role
-	 * @param int    $blog_id
+	 * @param int    $user_id  User ID.
+	 * @param string $role     User role.
+	 * @param int    $blog_id  Blog ID.
 	 */
 	public function callback_add_user_to_blog( $user_id, $role, $blog_id ) {
 		$blog = get_blog_details( $blog_id );
@@ -189,7 +198,7 @@ class Connector_Blogs extends Connector {
 		}
 
 		$this->log(
-			// translators: Placeholders refer to a user's display name, a site name, and a user role (e.g. "Jane Doe", "FooBar Blog", "subscriber")
+			/* translators: %1$s: a user's display name, %2$s: a site name, %3$s: a user role (e.g. "Jane Doe", "FooBar Blog", "subscriber") */
 			_x(
 				'%1$s was added to the "%2$s" site with %3$s capabilities',
 				'1. User\'s name, 2. Site name, 3. Role',
@@ -211,8 +220,8 @@ class Connector_Blogs extends Connector {
 	 *
 	 * @action remove_user_from_blog
 	 *
-	 * @param int $user_id
-	 * @param int $blog_id
+	 * @param int $user_id  User ID.
+	 * @param int $blog_id  Blog ID.
 	 */
 	public function callback_remove_user_from_blog( $user_id, $blog_id ) {
 		$blog = get_blog_details( $blog_id );
@@ -223,7 +232,7 @@ class Connector_Blogs extends Connector {
 		}
 
 		$this->log(
-			// translators: Placeholders refer to a user's display name, and a site name (e.g. "Jane Doe", "FooBar Blog")
+			/* translators: %1$s: a user's display name, %2$s: a site name (e.g. "Jane Doe", "FooBar Blog") */
 			_x(
 				'%1$s was removed from the "%2$s" site',
 				'1. User\'s name, 2. Site name',
@@ -244,7 +253,7 @@ class Connector_Blogs extends Connector {
 	 *
 	 * @action make_spam_blog
 	 *
-	 * @param int $blog_id
+	 * @param int $blog_id  Blog ID.
 	 */
 	public function callback_make_spam_blog( $blog_id ) {
 		$this->callback_update_blog_status( $blog_id, esc_html__( 'marked as spam', 'stream' ), 'updated' );
@@ -255,7 +264,7 @@ class Connector_Blogs extends Connector {
 	 *
 	 * @action make_ham_blog
 	 *
-	 * @param int $blog_id
+	 * @param int $blog_id  Blog ID.
 	 */
 	public function callback_make_ham_blog( $blog_id ) {
 		$this->callback_update_blog_status( $blog_id, esc_html__( 'marked as not spam', 'stream' ), 'updated' );
@@ -266,7 +275,7 @@ class Connector_Blogs extends Connector {
 	 *
 	 * @action mature_blog
 	 *
-	 * @param int $blog_id
+	 * @param int $blog_id  Blog ID.
 	 */
 	public function callback_mature_blog( $blog_id ) {
 		$this->callback_update_blog_status( $blog_id, esc_html__( 'marked as mature', 'stream' ), 'updated' );
@@ -277,7 +286,7 @@ class Connector_Blogs extends Connector {
 	 *
 	 * @action unmature_blog
 	 *
-	 * @param int $blog_id
+	 * @param int $blog_id  Blog ID.
 	 */
 	public function callback_unmature_blog( $blog_id ) {
 		$this->callback_update_blog_status( $blog_id, esc_html__( 'marked as not mature', 'stream' ), 'updated' );
@@ -288,7 +297,7 @@ class Connector_Blogs extends Connector {
 	 *
 	 * @action archive_blog
 	 *
-	 * @param int $blog_id
+	 * @param int $blog_id  Blog ID.
 	 */
 	public function callback_archive_blog( $blog_id ) {
 		$this->callback_update_blog_status( $blog_id, esc_html__( 'archived', 'stream' ), 'archive_blog' );
@@ -299,7 +308,7 @@ class Connector_Blogs extends Connector {
 	 *
 	 * @action unarchive_blog
 	 *
-	 * @param int $blog_id
+	 * @param int $blog_id  Blog ID.
 	 */
 	public function callback_unarchive_blog( $blog_id ) {
 		$this->callback_update_blog_status( $blog_id, esc_html__( 'restored from archive', 'stream' ), 'updated' );
@@ -310,7 +319,7 @@ class Connector_Blogs extends Connector {
 	 *
 	 * @action make_delete_blog
 	 *
-	 * @param int $blog_id
+	 * @param int $blog_id  Blog ID.
 	 */
 	public function callback_make_delete_blog( $blog_id ) {
 		$this->callback_update_blog_status( $blog_id, esc_html__( 'deleted', 'stream' ), 'deleted' );
@@ -321,7 +330,7 @@ class Connector_Blogs extends Connector {
 	 *
 	 * @action undelete_blog
 	 *
-	 * @param int $blog_id
+	 * @param int $blog_id  Blog ID.
 	 */
 	public function callback_make_undelete_blog( $blog_id ) {
 		$this->callback_update_blog_status( $blog_id, esc_html__( 'restored', 'stream' ), 'updated' );
@@ -332,8 +341,8 @@ class Connector_Blogs extends Connector {
 	 *
 	 * @action update_blog_public
 	 *
-	 * @param int    $blog_id
-	 * @param string $value
+	 * @param int    $blog_id  Blog ID.
+	 * @param string $value    Status flag.
 	 */
 	public function callback_update_blog_public( $blog_id, $value ) {
 		if ( $value ) {
@@ -350,15 +359,15 @@ class Connector_Blogs extends Connector {
 	 *
 	 * @action update_blog_status
 	 *
-	 * @param int    $blog_id
-	 * @param string $status
-	 * @param string $action
+	 * @param int    $blog_id  Blog ID.
+	 * @param string $status   Blog Status.
+	 * @param string $action   Action.
 	 */
 	public function callback_update_blog_status( $blog_id, $status, $action ) {
 		$blog = get_blog_details( $blog_id );
 
 		$this->log(
-			// translators: Placeholders refer to a site name, and a blog status (e.g. "FooBar Blog", "archived")
+			/* translators: %1$s: a site name, %2$s: a blog status (e.g. "FooBar Blog", "archived") */
 			_x(
 				'"%1$s" site was %2$s',
 				'1. Site name, 2. Status',

--- a/connectors/class-connector-buddypress.php
+++ b/connectors/class-connector-buddypress.php
@@ -1,7 +1,15 @@
 <?php
+/**
+ * Connector for BuddyPress
+ *
+ * @package WP_Stream
+ */
 
 namespace WP_Stream;
 
+/**
+ * Class - Connector_BuddyPress
+ */
 class Connector_BuddyPress extends Connector {
 
 	/**
@@ -153,8 +161,8 @@ class Connector_BuddyPress extends Connector {
 	 *
 	 * @filter wp_stream_action_links_{connector}
 	 *
-	 * @param  array  $links Previous links registered
-	 * @param  object $record Stream record
+	 * @param  array  $links   Previous links registered.
+	 * @param  object $record  Stream record.
 	 *
 	 * @return array Action links
 	 */
@@ -200,7 +208,7 @@ class Connector_BuddyPress extends Connector {
 			);
 
 			if ( $group ) {
-				// Build actions URLs
+				// Build actions URLs.
 				$base_url   = \bp_get_admin_url( 'admin.php?page=bp-groups&amp;gid=' . $group_id );
 				$delete_url = wp_nonce_url( $base_url . '&amp;action=delete', 'bp-groups-delete' );
 				$edit_url   = $base_url . '&amp;action=edit';
@@ -240,7 +248,7 @@ class Connector_BuddyPress extends Connector {
 			$field_id = $record->get_meta( 'field_id', true );
 			$group_id = $record->get_meta( 'group_id', true );
 
-			if ( empty( $field_id ) ) { // is a group action
+			if ( empty( $field_id ) ) { // is a group action.
 				$links[ esc_html__( 'Edit', 'stream' ) ]   = add_query_arg(
 					array(
 						'page'     => 'bp-profile-setup',
@@ -285,6 +293,9 @@ class Connector_BuddyPress extends Connector {
 		return $links;
 	}
 
+	/**
+	 * Register the connector
+	 */
 	public function register() {
 		parent::register();
 
@@ -335,30 +346,73 @@ class Connector_BuddyPress extends Connector {
 		);
 	}
 
+	/**
+	 * Track option changes.
+	 *
+	 * @param string $option Option key.
+	 * @param string $old    Old value.
+	 * @param string $new    New value.
+	 */
 	public function callback_update_option( $option, $old, $new ) {
 		$this->check( $option, $old, $new );
 	}
 
+	/**
+	 * Track option creations.
+	 *
+	 * @param string $option Option key.
+	 * @param string $val    Value.
+	 */
 	public function callback_add_option( $option, $val ) {
 		$this->check( $option, null, $val );
 	}
 
+	/**
+	 * Track option deletions.
+	 *
+	 * @param string $option Option key.
+	 */
 	public function callback_delete_option( $option ) {
 		$this->check( $option, null, null );
 	}
 
+	/**
+	 * Track site option changes
+	 *
+	 * @param string $option Option key.
+	 * @param string $old    Old value.
+	 * @param string $new    New value.
+	 */
 	public function callback_update_site_option( $option, $old, $new ) {
 		$this->check( $option, $old, $new );
 	}
 
+	/**
+	 * Track site option creations.
+	 *
+	 * @param string $option Option key.
+	 * @param string $val    Value.
+	 */
 	public function callback_add_site_option( $option, $val ) {
 		$this->check( $option, null, $val );
 	}
 
+	/**
+	 * Track site option deletions.
+	 *
+	 * @param string $option Option key.
+	 */
 	public function callback_delete_site_option( $option ) {
 		$this->check( $option, null, null );
 	}
 
+	/**
+	 * Logs (site) option action.
+	 *
+	 * @param string $option     Option key.
+	 * @param string $old_value  Old value.
+	 * @param string $new_value  New value.
+	 */
 	public function check( $option, $old_value, $new_value ) {
 		if ( ! array_key_exists( $option, $this->options ) ) {
 			return;
@@ -382,7 +436,7 @@ class Connector_BuddyPress extends Connector {
 			$page         = isset( $data['page'] ) ? $data['page'] : null;
 
 			$this->log(
-				// translators: Placeholder refers to setting name (e.g. "Group Creation")
+				/* translators: %s: setting name (e.g. "Group Creation") */
 				__( '"%s" setting updated', 'stream' ),
 				compact( 'option_title', 'option', 'old_value', 'new_value', 'page' ),
 				null,
@@ -392,6 +446,12 @@ class Connector_BuddyPress extends Connector {
 		}
 	}
 
+	/**
+	 * Log buddyPress' components' state.
+	 *
+	 * @param array $old_value  Old value.
+	 * @param array $new_value  New value.
+	 */
 	public function check_bp_active_components( $old_value, $new_value ) {
 		$options = array();
 
@@ -435,6 +495,12 @@ class Connector_BuddyPress extends Connector {
 		}
 	}
 
+	/**
+	 * Log buddyPress' page assignment.
+	 *
+	 * @param array $old_value  Old value.
+	 * @param array $new_value  New value.
+	 */
 	public function check_bp_pages( $old_value, $new_value ) {
 		$options = array();
 
@@ -463,7 +529,7 @@ class Connector_BuddyPress extends Connector {
 
 			$this->log(
 				sprintf(
-					// translators: Placeholders refer to a directory page, and a page title (e.g. "Register", "Registration" )
+					/* translators: %1$s: a directory page, %2$s: a page title (e.g. "Register", "Registration" ) */
 					__( '"%1$s" page set to "%2$s"', 'stream' ),
 					$pages[ $option ],
 					$page
@@ -482,8 +548,13 @@ class Connector_BuddyPress extends Connector {
 		}
 	}
 
+	/**
+	 * @action bp_before_activity_delete
+	 *
+	 * @param array $args  Target activity data.
+	 */
 	public function callback_bp_before_activity_delete( $args ) {
-		if ( empty( $args['id'] ) ) { // Bail if we're deleting in bulk
+		if ( empty( $args['id'] ) ) { // Bail if we're deleting in bulk.
 			$this->_delete_activity_args = $args;
 
 			return;
@@ -494,12 +565,17 @@ class Connector_BuddyPress extends Connector {
 		$this->_deleted_activity = $activity;
 	}
 
+	/**
+	 * @action bp_activity_deleted_activities
+	 *
+	 * @param array $activities_ids  Activity IDs.
+	 */
 	public function callback_bp_activity_deleted_activities( $activities_ids ) {
-		if ( 1 === count( $activities_ids ) && isset( $this->_deleted_activity ) ) { // Single activity deletion
+		if ( 1 === count( $activities_ids ) && isset( $this->_deleted_activity ) ) { // Single activity deletion.
 			$activity = $this->_deleted_activity;
 			$this->log(
 				sprintf(
-					// translators: Placeholder refers to an activity title (e.g. "Update")
+					/* translators: %s: an activity title (e.g. "Update") */
 					__( '"%s" activity deleted', 'stream' ),
 					strip_tags( $activity->action )
 				),
@@ -513,9 +589,12 @@ class Connector_BuddyPress extends Connector {
 				$activity->component,
 				'deleted'
 			);
-		} else { // Bulk deletion
-			// Sometimes some objects removal are followed by deleting relevant
-			// activities, so we probably don't need to track those
+		} else {
+			/**
+			 * Bulk deletion
+			 * Sometimes some objects removal are followed by deleting relevant
+			 * activities, so we probably don't need to track those
+			 */
 			if ( $this->ignore_activity_bulk_deletion ) {
 				$this->ignore_activity_bulk_deletion = false;
 
@@ -523,7 +602,7 @@ class Connector_BuddyPress extends Connector {
 			}
 			$this->log(
 				sprintf(
-					// translators: Placeholder refers to an activity title (e.g. "Update")
+					/* translators: %s: an activity title (e.g. "Update") */
 					__( '"%s" activities were deleted', 'stream' ),
 					count( $activities_ids )
 				),
@@ -539,12 +618,18 @@ class Connector_BuddyPress extends Connector {
 		}
 	}
 
+	/**
+	 * @action bp_activity_mark_as_spam
+	 *
+	 * @param array $activity  Activity.
+	 * @param mixed $by        Marker.
+	 */
 	public function callback_bp_activity_mark_as_spam( $activity, $by ) {
 		unset( $by );
 
 		$this->log(
 			sprintf(
-				// translators: Placeholder refers to an activity title (e.g. "Update")
+				/* translators: %s an activity title (e.g. "Update") */
 				__( 'Marked activity "%s" as spam', 'stream' ),
 				strip_tags( $activity->action )
 			),
@@ -560,12 +645,18 @@ class Connector_BuddyPress extends Connector {
 		);
 	}
 
+	/**
+	 * @action bp_activity_mark_as_ham
+	 *
+	 * @param array $activity  Activity.
+	 * @param mixed $by        Marker.
+	 */
 	public function callback_bp_activity_mark_as_ham( $activity, $by ) {
 		unset( $by );
 
 		$this->log(
 			sprintf(
-				// translators: Placeholder refers to an activity title (e.g. "Update")
+				/* translators: %s: an activity title (e.g. "Update") */
 				__( 'Unmarked activity "%s" as spam', 'stream' ),
 				strip_tags( $activity->action )
 			),
@@ -581,12 +672,18 @@ class Connector_BuddyPress extends Connector {
 		);
 	}
 
+	/**
+	 * @action bp_activity_admin_edit_after
+	 *
+	 * @param array $activity  Activity.
+	 * @param mixed $error     Any errors.
+	 */
 	public function callback_bp_activity_admin_edit_after( $activity, $error ) {
 		unset( $error );
 
 		$this->log(
 			sprintf(
-				// translators: Placeholder refers to an activity title (e.g. "Update")
+				/* translators: %s: an activity title (e.g. "Update") */
 				__( '"%s" activity updated', 'stream' ),
 				strip_tags( $activity->action )
 			),

--- a/connectors/class-connector-buddypress.php
+++ b/connectors/class-connector-buddypress.php
@@ -347,7 +347,7 @@ class Connector_BuddyPress extends Connector {
 	}
 
 	/**
-	 * Track option changes.
+	 * Track buddyPress-specific option changes.
 	 *
 	 * @param string $option Option key.
 	 * @param string $old    Old value.
@@ -358,7 +358,7 @@ class Connector_BuddyPress extends Connector {
 	}
 
 	/**
-	 * Track option creations.
+	 * Track buddyPress-specific option creations.
 	 *
 	 * @param string $option Option key.
 	 * @param string $val    Value.
@@ -368,7 +368,7 @@ class Connector_BuddyPress extends Connector {
 	}
 
 	/**
-	 * Track option deletions.
+	 * Track buddyPress-specific option deletions.
 	 *
 	 * @param string $option Option key.
 	 */
@@ -377,7 +377,7 @@ class Connector_BuddyPress extends Connector {
 	}
 
 	/**
-	 * Track site option changes
+	 * Track buddyPress-specific site option changes
 	 *
 	 * @param string $option Option key.
 	 * @param string $old    Old value.
@@ -388,7 +388,7 @@ class Connector_BuddyPress extends Connector {
 	}
 
 	/**
-	 * Track site option creations.
+	 * Track buddyPress-specific site option creations.
 	 *
 	 * @param string $option Option key.
 	 * @param string $val    Value.
@@ -398,7 +398,7 @@ class Connector_BuddyPress extends Connector {
 	}
 
 	/**
-	 * Track site option deletions.
+	 * Track buddyPress-specific site option deletions.
 	 *
 	 * @param string $option Option key.
 	 */
@@ -407,7 +407,7 @@ class Connector_BuddyPress extends Connector {
 	}
 
 	/**
-	 * Logs (site) option action.
+	 * Logs buddyPress-specific (site) option action.
 	 *
 	 * @param string $option     Option key.
 	 * @param string $old_value  Old value.

--- a/connectors/class-connector-buddypress.php
+++ b/connectors/class-connector-buddypress.php
@@ -549,6 +549,8 @@ class Connector_BuddyPress extends Connector {
 	}
 
 	/**
+	 * Logs activity deletions
+	 *
 	 * @action bp_before_activity_delete
 	 *
 	 * @param array $args  Target activity data.
@@ -566,9 +568,11 @@ class Connector_BuddyPress extends Connector {
 	}
 
 	/**
+	 * Logs activity bulk deletions.
+	 *
 	 * @action bp_activity_deleted_activities
 	 *
-	 * @param array $activities_ids  Activity IDs.
+	 * @param array $activities_ids  Activity IDs of deleted activities.
 	 */
 	public function callback_bp_activity_deleted_activities( $activities_ids ) {
 		if ( 1 === count( $activities_ids ) && isset( $this->_deleted_activity ) ) { // Single activity deletion.
@@ -619,6 +623,8 @@ class Connector_BuddyPress extends Connector {
 	}
 
 	/**
+	 * Logs activates marked as spam
+	 *
 	 * @action bp_activity_mark_as_spam
 	 *
 	 * @param array $activity  Activity.
@@ -646,6 +652,8 @@ class Connector_BuddyPress extends Connector {
 	}
 
 	/**
+	 * Log activities marked as ham
+	 *
 	 * @action bp_activity_mark_as_ham
 	 *
 	 * @param array $activity  Activity.
@@ -673,6 +681,8 @@ class Connector_BuddyPress extends Connector {
 	}
 
 	/**
+	 * Log activity changes made in the WP Admin.
+	 *
 	 * @action bp_activity_admin_edit_after
 	 *
 	 * @param array $activity  Activity.
@@ -699,6 +709,14 @@ class Connector_BuddyPress extends Connector {
 		);
 	}
 
+	/**
+	 * Logs group actions
+	 *
+	 * @param int|object $group   Group object or group ID.
+	 * @param string     $action  Action.
+	 * @param array      $meta    Meta data.
+	 * @param string     $message Message.
+	 */
 	public function group_action( $group, $action, $meta = array(), $message = null ) {
 		if ( is_numeric( $group ) ) {
 			$group = \groups_get_group(
@@ -714,30 +732,30 @@ class Connector_BuddyPress extends Connector {
 
 		if ( ! $message ) {
 			if ( 'created' === $action ) {
-				// translators: Placeholder refers to a group name (e.g. "Favourites")
+				/* translators: %s: a group name (e.g. "Favourites") */
 				$message = esc_html__( '"%s" group created', 'stream' );
 			} elseif ( 'updated' === $action ) {
-				// translators: Placeholder refers to a group name (e.g. "Favourites")
+				/* translators: %s: a group name (e.g. "Favourites") */
 				$message = esc_html__( '"%s" group updated', 'stream' );
 			} elseif ( 'deleted' === $action ) {
-				// translators: Placeholder refers to a group name (e.g. "Favourites")
+				/* translators: %s: a group name (e.g. "Favourites") */
 				$message = esc_html__( '"%s" group deleted', 'stream' );
 			} elseif ( 'joined' === $action ) {
-				// translators: Placeholder refers to a group name (e.g. "Favourites")
+				/* translators: %s: a group name (e.g. "Favourites") */
 				$message = esc_html__( 'Joined group "%s"', 'stream' );
 			} elseif ( 'left' === $action ) {
-				// translators: Placeholder refers to a group name (e.g. "Favourites")
+				/* translators: %s: a group name (e.g. "Favourites") */
 				$message = esc_html__( 'Left group "%s"', 'stream' );
 			} elseif ( 'banned' === $action ) {
-				// translators: Placeholders refer to a user display name, and a group name (e.g. "Jane Doe", "Favourites")
+				/* translators: %1$s: a user display name, %2$s: a group name (e.g. "Jane Doe", "Favourites") */
 				$message        = esc_html__( 'Banned "%2$s" from "%1$s"', 'stream' );
 				$replacements[] = get_user_by( 'id', $meta['user_id'] )->display_name;
 			} elseif ( 'unbanned' === $action ) {
-				// translators: Placeholders refer to a user display name, and a group name (e.g. "Jane Doe", "Favourites")
+				/* translators: %1$s: a user display name, %2$s: a group name (e.g. "Jane Doe", "Favourites") */
 				$message        = esc_html__( 'Unbanned "%2$s" from "%1$s"', 'stream' );
 				$replacements[] = get_user_by( 'id', $meta['user_id'] )->display_name;
 			} elseif ( 'removed' === $action ) {
-				// translators: Placeholders refer to a user display name, and a group name (e.g. "Jane Doe", "Favourites")
+				/* translators: %1$s: a user display name, %2$s: a group name (e.g. "Jane Doe", "Favourites") */
 				$message        = esc_html__( 'Removed "%2$s" from "%1$s"', 'stream' );
 				$replacements[] = get_user_by( 'id', $meta['user_id'] )->display_name;
 			} else {
@@ -764,6 +782,15 @@ class Connector_BuddyPress extends Connector {
 		);
 	}
 
+	/**
+	 * Log creation of new group.
+	 *
+	 * @action groups_create_group
+	 *
+	 * @param int    $group_id  Group ID.
+	 * @param object $member    Group founder user object.
+	 * @param object $group     Group object.
+	 */
 	public function callback_groups_create_group( $group_id, $member, $group ) {
 		unset( $group_id );
 		unset( $member );
@@ -771,22 +798,51 @@ class Connector_BuddyPress extends Connector {
 		$this->group_action( $group, 'created' );
 	}
 
+	/**
+	 * Log update to existing group.
+	 *
+	 * @action groups_update_group
+	 *
+	 * @param int    $group_id Group ID.
+	 * @param object $group    Group object.
+	 */
 	public function callback_groups_update_group( $group_id, $group ) {
 		unset( $group_id );
 
 		$this->group_action( $group, 'updated' );
 	}
 
+	/**
+	 * Log group deletion
+	 *
+	 * @action groups_before_delete_group
+	 *
+	 * @param int $group_id  Group ID.
+	 */
 	public function callback_groups_before_delete_group( $group_id ) {
 		$this->ignore_activity_bulk_deletion = true;
 		$this->group_action( $group_id, 'deleted' );
 	}
 
+	/**
+	 * Log change to group details
+	 *
+	 * @action groups_details_updated
+	 *
+	 * @param int $group_id  Group ID.
+	 */
 	public function callback_groups_details_updated( $group_id ) {
 		$this->is_update = true;
 		$this->group_action( $group_id, 'updated' );
 	}
 
+	/**
+	 * Log change to group settings
+	 *
+	 * @action groups_settings_updated
+	 *
+	 * @param int $group_id  Group ID.
+	 */
 	public function callback_groups_settings_updated( $group_id ) {
 		if ( $this->is_update ) {
 			return;
@@ -794,14 +850,39 @@ class Connector_BuddyPress extends Connector {
 		$this->group_action( $group_id, 'updated' );
 	}
 
+	/**
+	 * Logs user leaving group
+	 *
+	 * @action groups_leave_group
+	 *
+	 * @param int $group_id  Group ID.
+	 * @param int $user_id  User ID of member.
+	 */
 	public function callback_groups_leave_group( $group_id, $user_id ) {
 		$this->group_action( $group_id, 'left', compact( 'user_id' ) );
 	}
 
+	/**
+	 * Logs user joining group
+	 *
+	 * @action groups_join_group
+	 *
+	 * @param int $group_id  Group ID.
+	 * @param int $user_id  User ID of member.
+	 */
 	public function callback_groups_join_group( $group_id, $user_id ) {
 		$this->group_action( $group_id, 'joined', compact( 'user_id' ) );
 	}
 
+	/**
+	 * Logs group member promotion.
+	 *
+	 * @action groups_promote_member
+	 *
+	 * @param int    $group_id  Group ID.
+	 * @param int    $user_id   User ID of member.
+	 * @param string $status    Member's new user role.
+	 */
 	public function callback_groups_promote_member( $group_id, $user_id, $status ) {
 		$group   = \groups_get_group(
 			array(
@@ -814,7 +895,7 @@ class Connector_BuddyPress extends Connector {
 			'mod'   => esc_html_x( 'Moderator', 'buddypress', 'stream' ),
 		);
 		$message = sprintf(
-			// translators: Placeholders refer to a user's display name, a user role, and a group name (e.g. "Jane Doe", "subscriber", "Favourites")
+			/* translators: %1$s: a user's display name, %2$s: a user role, %3$s: a group name (e.g. "Jane Doe", "subscriber", "Favourites") */
 			__( 'Promoted "%1$s" to "%2$s" in "%3$s"', 'stream' ),
 			$user->display_name,
 			$roles[ $status ],
@@ -823,6 +904,14 @@ class Connector_BuddyPress extends Connector {
 		$this->group_action( $group_id, 'promoted', compact( 'user_id', 'status' ), $message );
 	}
 
+	/**
+	 * Log group member demotion
+	 *
+	 * @action groups_demote_member
+	 *
+	 * @param int $group_id  Group ID.
+	 * @param int $user_id   User ID of member.
+	 */
 	public function callback_groups_demote_member( $group_id, $user_id ) {
 		$group   = \groups_get_group(
 			array(
@@ -831,7 +920,7 @@ class Connector_BuddyPress extends Connector {
 		);
 		$user    = new \WP_User( $user_id );
 		$message = sprintf(
-			// translators: Placeholders refer to a user's display name, a user role, and a group name (e.g. "Jane Doe", "Member", "Favourites")
+			/* translators: %1$s: a user's display name, %2$s: a user role, %3$s: a group name (e.g. "Jane Doe", "Member", "Favourites") */
 			__( 'Demoted "%1$s" to "%2$s" in "%3$s"', 'stream' ),
 			$user->display_name,
 			_x( 'Member', 'buddypress', 'stream' ),
@@ -840,18 +929,50 @@ class Connector_BuddyPress extends Connector {
 		$this->group_action( $group_id, 'demoted', compact( 'user_id' ), $message );
 	}
 
+	/**
+	 * Log member banning
+	 *
+	 * @action groups_ban_member
+	 *
+	 * @param int $group_id  Group ID.
+	 * @param int $user_id   User ID of banned member.
+	 */
 	public function callback_groups_ban_member( $group_id, $user_id ) {
 		$this->group_action( $group_id, 'banned', compact( 'user_id' ) );
 	}
 
+	/**
+	 * Log member reinstatement
+	 *
+	 * @action groups_unban_member
+	 *
+	 * @param int $group_id  Group ID.
+	 * @param int $user_id   User ID of reinstated member.
+	 */
 	public function callback_groups_unban_member( $group_id, $user_id ) {
 		$this->group_action( $group_id, 'unbanned', compact( 'user_id' ) );
 	}
 
+	/**
+	 * Log member removal.
+	 *
+	 * @action groups_remove_member
+	 *
+	 * @param int $group_id  Group ID.
+	 * @param int $user_id   User ID of removed member.
+	 */
 	public function callback_groups_remove_member( $group_id, $user_id ) {
 		$this->group_action( $group_id, 'removed', compact( 'user_id' ) );
 	}
 
+	/**
+	 * Logs user profile field actions
+	 *
+	 * @param object $field    Field object.
+	 * @param string $action   Action.
+	 * @param array  $meta     Meta.
+	 * @param string $message  Message.
+	 */
 	public function field_action( $field, $action, $meta = array(), $message = null ) {
 		$replacements = array(
 			$field->name,
@@ -859,13 +980,13 @@ class Connector_BuddyPress extends Connector {
 
 		if ( ! $message ) {
 			if ( 'created' === $action ) {
-				// translators: Placeholder refers to a user profile field (e.g. "Job Title")
+				/* translators: %s: a user profile field (e.g. "Job Title") */
 				$message = esc_html__( 'Created profile field "%s"', 'stream' );
 			} elseif ( 'updated' === $action ) {
-				// translators: Placeholder refers to a user profile field (e.g. "Job Title")
+				/* translators: %s: a user profile field (e.g. "Job Title") */
 				$message = esc_html__( 'Updated profile field "%s"', 'stream' );
 			} elseif ( 'deleted' === $action ) {
-				// translators: Placeholder refers to a user profile field (e.g. "Job Title")
+				/* translators: %s: a user profile field (e.g. "Job Title") */
 				$message = esc_html__( 'Deleted profile field "%s"', 'stream' );
 			} else {
 				return;
@@ -891,15 +1012,37 @@ class Connector_BuddyPress extends Connector {
 		);
 	}
 
+	/**
+	 * Logs field writes
+	 *
+	 * @action xprofile_field_after_save
+	 *
+	 * @param object $field  Field object.
+	 */
 	public function callback_xprofile_field_after_save( $field ) {
 		$action = isset( $field->id ) ? 'updated' : 'created';
 		$this->field_action( $field, $action );
 	}
 
+	/**
+	 * Logs field deletions
+	 *
+	 * @action xprofile_fields_deleted_field
+	 *
+	 * @param object $field  Field object.
+	 */
 	public function callback_xprofile_fields_deleted_field( $field ) {
 		$this->field_action( $field, 'deleted' );
 	}
 
+	/**
+	 * Logs user profile field group actions
+	 *
+	 * @param int    $group    Field group object.
+	 * @param string $action   Action.
+	 * @param array  $meta     Meta.
+	 * @param string $message  Message.
+	 */
 	public function field_group_action( $group, $action, $meta = array(), $message = null ) {
 		$replacements = array(
 			$group->name,
@@ -907,13 +1050,13 @@ class Connector_BuddyPress extends Connector {
 
 		if ( ! $message ) {
 			if ( 'created' === $action ) {
-				// translators: Placeholder refers to a user profile field group (e.g. "Appearance")
+				/* translators: %s: a user profile field group (e.g. "Appearance") */
 				$message = esc_html__( 'Created profile field group "%s"', 'stream' );
 			} elseif ( 'updated' === $action ) {
-				// translators: Placeholder refers to a user profile field group (e.g. "Appearance")
+				/* translators: %s: a user profile field group (e.g. "Appearance") */
 				$message = esc_html__( 'Updated profile field group "%s"', 'stream' );
 			} elseif ( 'deleted' === $action ) {
-				// translators: Placeholder refers to a user profile field group (e.g. "Appearance")
+				/* translators: %s: a user profile field group (e.g. "Appearance") */
 				$message = esc_html__( 'Deleted profile field group "%s"', 'stream' );
 			} else {
 				return;
@@ -938,27 +1081,49 @@ class Connector_BuddyPress extends Connector {
 		);
 	}
 
+	/**
+	 * Logs field group writes
+	 *
+	 * @action xprofile_group_after_save
+	 *
+	 * @param object $group  Field group.
+	 */
 	public function callback_xprofile_group_after_save( $group ) {
 		global $wpdb;
-		// a bit hacky, due to inconsistency with BP action scheme, see callback_xprofile_field_after_save for correct behavior
+		/**
+		 * A bit hacky, due to inconsistency with BP action scheme,
+		 * see callback_xprofile_field_after_save for correct behavior.
+		 */
 		$action = ( $group->id === $wpdb->insert_id ) ? 'created' : 'updated';
 		$this->field_group_action( $group, $action );
 	}
 
+	/**
+	 * Logs field group deletions
+	 *
+	 * @action xprofile_groups_deleted_group
+	 *
+	 * @param object $group  Field group object.
+	 */
 	public function callback_xprofile_groups_deleted_group( $group ) {
 		$this->field_group_action( $group, 'deleted' );
 	}
 
+	/**
+	 * Returns the directory pages
+	 *
+	 * @return array
+	 */
 	private function bp_get_directory_pages() {
 		$bp              = \buddypress();
 		$directory_pages = array();
 
-		// Loop through loaded components and collect directories
+		// Loop through loaded components and collect directories.
 		if ( is_array( $bp->loaded_components ) ) {
 			foreach ( $bp->loaded_components as $component_slug => $component_id ) {
-				// Only components that need directories should be listed here
+				// Only components that need directories should be listed here.
 				if ( isset( $bp->{$component_id} ) && ! empty( $bp->{$component_id}->has_directory ) ) {
-					// component->name was introduced in BP 1.5, so we must provide a fallback
+					// component->name was introduced in BP 1.5, so we must provide a fallback.
 					$directory_pages[ $component_id ] = ! empty( $bp->{$component_id}->name ) ? $bp->{$component_id}->name : ucwords( $component_id );
 				}
 			}

--- a/connectors/class-connector-comments.php
+++ b/connectors/class-connector-comments.php
@@ -1,6 +1,15 @@
 <?php
+/**
+ * Connector for Comments
+ *
+ * @package WP_Stream
+ */
+
 namespace WP_Stream;
 
+/**
+ * Class - Connector_Comments
+ */
 class Connector_Comments extends Connector {
 	/**
 	 * Connector slug
@@ -97,7 +106,7 @@ class Connector_Comments extends Connector {
 	/**
 	 * Return the comment type label for a given comment ID
 	 *
-	 * @param int $comment_id  ID of the comment
+	 * @param int $comment_id  ID of the comment.
 	 *
 	 * @return string The comment type label
 	 */
@@ -120,8 +129,8 @@ class Connector_Comments extends Connector {
 	 *
 	 * @filter wp_stream_action_links_{connector}
 	 *
-	 * @param array  $links   Previous links registered
-	 * @param object $record Stream record
+	 * @param array  $links   Previous links registered.
+	 * @param object $record  Stream record.
 	 *
 	 * @return array Action links
 	 */
@@ -163,8 +172,8 @@ class Connector_Comments extends Connector {
 	 * name and e-mail or that users be logged in to comment. In either case it
 	 * will try to see if the e-mail provided does belong to a registered user.
 	 *
-	 * @param object|int $comment A comment object or comment ID
-	 * @param string     $field       What field you want to return
+	 * @param object|int $comment  A comment object or comment ID.
+	 * @param string     $field    What field you want to return.
 	 *
 	 * @return int|string $output User ID or user display name
 	 */
@@ -205,8 +214,8 @@ class Connector_Comments extends Connector {
 	 *
 	 * @action comment_flood_trigger
 	 *
-	 * @param string $time_lastcomment
-	 * @param string $time_newcomment
+	 * @param string $time_lastcomment  Time of last comment before block.
+	 * @param string $time_newcomment   Time of first comment after block.
 	 */
 	public function callback_comment_flood_trigger( $time_lastcomment, $time_newcomment ) {
 		$options        = wp_stream_get_instance()->settings->options;
@@ -227,7 +236,7 @@ class Connector_Comments extends Connector {
 		}
 
 		$this->log(
-			// translators: Placeholder refers to a username (e.g. "administrator")
+			/* translators: %s: a username (e.g. "administrator") */
 			__( 'Comment flooding by %s detected and prevented', 'stream' ),
 			compact( 'user_name', 'user_id', 'time_lastcomment', 'time_newcomment' ),
 			null,
@@ -241,8 +250,8 @@ class Connector_Comments extends Connector {
 	 *
 	 * @action wp_insert_comment
 	 *
-	 * @param int    $comment_id
-	 * @param object $comment
+	 * @param int        $comment_id  Comment ID.
+	 * @param WP_Comment $comment     Comment object.
 	 */
 	public function callback_wp_insert_comment( $comment_id, $comment ) {
 		if ( in_array( $comment->comment_type, $this->get_ignored_comment_types(), true ) ) {
@@ -258,7 +267,7 @@ class Connector_Comments extends Connector {
 		$comment_status = ( 1 === $comment->comment_approved ) ? esc_html__( 'approved automatically', 'stream' ) : esc_html__( 'pending approval', 'stream' );
 		$is_spam        = false;
 
-		// Auto-marked spam comments
+		// Auto-marked spam comments.
 		$options     = wp_stream_get_instance()->settings->options;
 		$ak_tracking = isset( $options['advanced_akismet_tracking'] ) ? $options['advanced_akismet_tracking'] : false;
 
@@ -276,7 +285,7 @@ class Connector_Comments extends Connector {
 			$parent_user_name = get_comment_author( $comment->comment_parent );
 
 			$this->log(
-				// translators: Placeholders refer to a parent comment's author, a comment author, a post title, a comment status, and a comment type
+				/* translators: %1$s: a parent comment's author, %2$s: a comment author, %3$s: a post title, %4$s: a comment status, %5$s: a comment type */
 				_x(
 					'Reply to %1$s\'s %5$s by %2$s on %3$s %4$s',
 					"1: Parent comment's author, 2: Comment author, 3: Post title, 4: Comment status, 5: Comment type",
@@ -290,7 +299,7 @@ class Connector_Comments extends Connector {
 			);
 		} else {
 			$this->log(
-				// translators: Placeholders refer to a comment author, a post title, a comment status, and a comment type
+				/* translators: %1$s: a comment author, %2$s: a post title, %3$s: a comment status, %4$s: and a comment type */
 				_x(
 					'New %4$s by %1$s on %2$s %3$s',
 					'1: Comment author, 2: Post title 3: Comment status, 4: Comment type',
@@ -310,7 +319,7 @@ class Connector_Comments extends Connector {
 	 *
 	 * @action edit_comment
 	 *
-	 * @param int $comment_id
+	 * @param int $comment_id  Comment ID.
 	 */
 	public function callback_edit_comment( $comment_id ) {
 		$comment = get_comment( $comment_id );
@@ -328,7 +337,7 @@ class Connector_Comments extends Connector {
 		$comment_type = mb_strtolower( $this->get_comment_type_label( $comment_id ) );
 
 		$this->log(
-			// translators: Placeholders refer to a comment author, a post title, and a comment type
+			/* translators: %1$s: a comment author, %2$s: a post title, %3$s: a comment type */
 			_x(
 				'%1$s\'s %3$s on %2$s edited',
 				'1: Comment author, 2: Post title, 3: Comment type',
@@ -346,7 +355,7 @@ class Connector_Comments extends Connector {
 	 *
 	 * @action before_delete_post
 	 *
-	 * @param int $post_id
+	 * @param int $post_id  Post ID.
 	 */
 	public function callback_before_delete_post( $post_id ) {
 		if ( wp_is_post_revision( $post_id ) ) {
@@ -361,7 +370,7 @@ class Connector_Comments extends Connector {
 	 *
 	 * @action deleted_post
 	 *
-	 * @param int $post_id
+	 * @param int $post_id  Post ID.
 	 */
 	public function callback_deleted_post( $post_id ) {
 		if ( wp_is_post_revision( $post_id ) ) {
@@ -376,7 +385,7 @@ class Connector_Comments extends Connector {
 	 *
 	 * @action delete_comment
 	 *
-	 * @param int $comment_id
+	 * @param int $comment_id  Comment ID.
 	 */
 	public function callback_delete_comment( $comment_id ) {
 		$comment = get_comment( $comment_id );
@@ -398,7 +407,7 @@ class Connector_Comments extends Connector {
 		}
 
 		$this->log(
-			// translators: Placeholders refer to a comment author, a post title, and a comment type
+			/* translators: %1$s: a comment author, %2$s: a post title, %3$s: a comment type */
 			_x(
 				'%1$s\'s %3$s on %2$s deleted permanently',
 				'1: Comment author, 2: Post title, 3: Comment type',
@@ -416,7 +425,7 @@ class Connector_Comments extends Connector {
 	 *
 	 * @action trash_comment
 	 *
-	 * @param int $comment_id
+	 * @param int $comment_id  Comment ID.
 	 */
 	public function callback_trash_comment( $comment_id ) {
 		$comment = get_comment( $comment_id );
@@ -434,7 +443,7 @@ class Connector_Comments extends Connector {
 		$comment_type = mb_strtolower( $this->get_comment_type_label( $comment_id ) );
 
 		$this->log(
-			// translators: Placeholders refer to a comment author, a post title, and a comment type
+			/* translators: %1$s: a comment author, %2$s a post title, %3$s a comment type */
 			_x(
 				'%1$s\'s %3$s on %2$s trashed',
 				'1: Comment author, 2: Post title, 3: Comment type',
@@ -452,7 +461,7 @@ class Connector_Comments extends Connector {
 	 *
 	 * @action untrash_comment
 	 *
-	 * @param int $comment_id
+	 * @param int $comment_id  Comment ID.
 	 */
 	public function callback_untrash_comment( $comment_id ) {
 		$comment = get_comment( $comment_id );
@@ -470,7 +479,7 @@ class Connector_Comments extends Connector {
 		$comment_type = mb_strtolower( $this->get_comment_type_label( $comment_id ) );
 
 		$this->log(
-			// translators: Placeholders refer to a comment author, a post title, and a comment type
+			/* translators: %1$s: a comment author, %2$s: a post title, %3$s: a comment type */
 			_x(
 				'%1$s\'s %3$s on %2$s restored',
 				'1: Comment author, 2: Post title, 3: Comment type',
@@ -488,7 +497,7 @@ class Connector_Comments extends Connector {
 	 *
 	 * @action spam_comment
 	 *
-	 * @param int $comment_id
+	 * @param int $comment_id  Comment ID.
 	 */
 	public function callback_spam_comment( $comment_id ) {
 		$comment = get_comment( $comment_id );
@@ -506,7 +515,7 @@ class Connector_Comments extends Connector {
 		$comment_type = mb_strtolower( $this->get_comment_type_label( $comment_id ) );
 
 		$this->log(
-			// translators: Placeholders refer to a comment author, a post title, and a comment type
+			/* translators: %1$s: a comment author, %2$s: a post title, %3$s: a comment type */
 			_x(
 				'%1$s\'s %3$s on %2$s marked as spam',
 				'1: Comment author, 2: Post title, 3: Comment type',
@@ -524,7 +533,7 @@ class Connector_Comments extends Connector {
 	 *
 	 * @action unspam_comment
 	 *
-	 * @param int $comment_id
+	 * @param int $comment_id  Comment ID.
 	 */
 	public function callback_unspam_comment( $comment_id ) {
 		$comment = get_comment( $comment_id );
@@ -542,7 +551,7 @@ class Connector_Comments extends Connector {
 		$comment_type = mb_strtolower( $this->get_comment_type_label( $comment_id ) );
 
 		$this->log(
-			// translators: Placeholders refer to a comment author, a post title, and a comment type
+			/* translators: %1$s: a comment author, %2$s: a post title, %3$s: a comment type */
 			_x(
 				'%1$s\'s %3$s on %2$s unmarked as spam',
 				'1: Comment author, 2: Post title, 3: Comment type',
@@ -560,9 +569,9 @@ class Connector_Comments extends Connector {
 	 *
 	 * @action transition_comment_status
 	 *
-	 * @param string $new_status
-	 * @param string $old_status
-	 * @param object $comment
+	 * @param string     $new_status  New comment status.
+	 * @param string     $old_status  Old comment status.
+	 * @param WP_Comment $comment     Comment object.
 	 */
 	public function callback_transition_comment_status( $new_status, $old_status, $comment ) {
 		if ( in_array( $comment->comment_type, $this->get_ignored_comment_types(), true ) ) {
@@ -582,7 +591,7 @@ class Connector_Comments extends Connector {
 		$comment_type = get_comment_type( $comment->comment_ID );
 
 		$this->log(
-			// translators: Placeholders refer to a comment author, a post title, and a comment type
+			/* translators: %1$s: a comment author, %2$s: a post title, %3$s: a comment type */
 			_x(
 				'%1$s\'s %3$s %2$s',
 				'Comment status transition. 1: Comment author, 2: Post title, 3: Comment type',
@@ -600,7 +609,7 @@ class Connector_Comments extends Connector {
 	 *
 	 * @action comment_duplicate_trigger
 	 *
-	 * @param array $comment_data
+	 * @param array $comment_data  Comment data.
 	 */
 	public function callback_comment_duplicate_trigger( $comment_data ) {
 		global $wpdb;
@@ -622,7 +631,7 @@ class Connector_Comments extends Connector {
 		$comment_type = mb_strtolower( $this->get_comment_type_label( $comment_id ) );
 
 		$this->log(
-			// translators: Placeholders refer to a comment author, a post title, and a comment type
+			/* translators: %1$s: a comment author, %2$s: a post title, %3$s: a comment type */
 			_x(
 				'Duplicate %3$s by %1$s prevented on %2$s',
 				'1: Comment author, 2: Post title, 3: Comment type',

--- a/connectors/class-connector-edd.php
+++ b/connectors/class-connector-edd.php
@@ -1,7 +1,15 @@
 <?php
+/**
+ * Connector for Easy Digital Downloads
+ *
+ * @package WP_Stream
+ */
 
 namespace WP_Stream;
 
+/**
+ * Class - Connector_EDD
+ */
 class Connector_EDD extends Connector {
 
 	/**
@@ -144,8 +152,8 @@ class Connector_EDD extends Connector {
 	 *
 	 * @filter wp_stream_action_links_{connector}
 	 *
-	 * @param  array  $links Previous links registered
-	 * @param  object $record Stream record
+	 * @param  array  $links   Previous links registered.
+	 * @param  object $record  Stream record.
 	 *
 	 * @return array             Action links
 	 */
@@ -157,7 +165,7 @@ class Connector_EDD extends Connector {
 			$post_type_label = get_post_type_labels( get_post_type_object( 'edd_discount' ) )->singular_name;
 			$base            = admin_url( 'edit.php?post_type=download&page=edd-discounts' );
 
-			// translators: Placeholder refers to a post type (e.g. "Post")
+			/* translators: %s: a post type (e.g. "Post") */
 			$links[ sprintf( esc_html__( 'Edit %s', 'stream' ), $post_type_label ) ] = add_query_arg(
 				array(
 					'edd-action' => 'edit_discount',
@@ -167,7 +175,7 @@ class Connector_EDD extends Connector {
 			);
 
 			if ( 'active' === get_post( $record->object_id )->post_status ) {
-				// translators: Placeholder refers to a post type (e.g. "Post")
+				/* translators: %s: a post type (e.g. "Post") */
 				$links[ sprintf( esc_html__( 'Deactivate %s', 'stream' ), $post_type_label ) ] = add_query_arg(
 					array(
 						'edd-action' => 'deactivate_discount',
@@ -176,7 +184,7 @@ class Connector_EDD extends Connector {
 					$base
 				);
 			} else {
-				// translators: Placeholder refers to a post type (e.g. "Post")
+				/* translators: %s a post type (e.g. "Post") */
 				$links[ sprintf( esc_html__( 'Activate %s', 'stream' ), $post_type_label ) ] = add_query_arg(
 					array(
 						'edd-action' => 'activate_discount',
@@ -194,7 +202,7 @@ class Connector_EDD extends Connector {
 			true
 		) ) {
 			$tax_label = get_taxonomy_labels( get_taxonomy( $record->context ) )->singular_name;
-			// translators: Placeholder refers to a taxonomy (e.g. "Category")
+			/* translators: %s a taxonomy (e.g. "Category") */
 			$links[ sprintf( esc_html__( 'Edit %s', 'stream' ), $tax_label ) ] = get_edit_term_link( $record->object_id, $record->get_meta( 'taxonomy', true ) );
 		} elseif ( 'api_keys' === $record->context ) {
 			$user = new \WP_User( $record->object_id );
@@ -235,6 +243,9 @@ class Connector_EDD extends Connector {
 		return $links;
 	}
 
+	/**
+	 * Register the connector
+	 */
 	public function register() {
 		parent::register();
 
@@ -245,30 +256,73 @@ class Connector_EDD extends Connector {
 		);
 	}
 
+	/**
+	 * Track EDD-specific option changes.
+	 *
+	 * @param string $option Option key.
+	 * @param string $old    Old value.
+	 * @param string $new    New value.
+	 */
 	public function callback_update_option( $option, $old, $new ) {
 		$this->check( $option, $old, $new );
 	}
 
+	/**
+	 * Track EDD-specific option creations.
+	 *
+	 * @param string $option Option key.
+	 * @param string $val    Value.
+	 */
 	public function callback_add_option( $option, $val ) {
 		$this->check( $option, null, $val );
 	}
 
+	/**
+	 * Track EDD-specific option deletions.
+	 *
+	 * @param string $option Option key.
+	 */
 	public function callback_delete_option( $option ) {
 		$this->check( $option, null, null );
 	}
 
+	/**
+	 * Track EDD-specific site option changes
+	 *
+	 * @param string $option Option key.
+	 * @param string $old    Old value.
+	 * @param string $new    New value.
+	 */
 	public function callback_update_site_option( $option, $old, $new ) {
 		$this->check( $option, $old, $new );
 	}
 
+	/**
+	 * Track EDD-specific site option creations.
+	 *
+	 * @param string $option Option key.
+	 * @param string $val    Value.
+	 */
 	public function callback_add_site_option( $option, $val ) {
 		$this->check( $option, null, $val );
 	}
 
+	/**
+	 * Track EDD-specific site option deletions.
+	 *
+	 * @param string $option Option key.
+	 */
 	public function callback_delete_site_option( $option ) {
 		$this->check( $option, null, null );
 	}
 
+	/**
+	 * Logs EDD-specific (site) option action.
+	 *
+	 * @param string $option     Option key.
+	 * @param string $old_value  Old value.
+	 * @param string $new_value  New value.
+	 */
 	public function check( $option, $old_value, $new_value ) {
 		if ( ! array_key_exists( $option, $this->options ) ) {
 			return;
@@ -291,7 +345,7 @@ class Connector_EDD extends Connector {
 			$context      = isset( $data['context'] ) ? $data['context'] : 'settings';
 
 			$this->log(
-				// translators: Placeholder refers to a setting title (e.g. "Language")
+				/* translators: %s: a setting title (e.g. "Language") */
 				__( '"%s" setting updated', 'stream' ),
 				compact( 'option_title', 'option', 'old_value', 'new_value' ),
 				null,
@@ -301,6 +355,12 @@ class Connector_EDD extends Connector {
 		}
 	}
 
+	/**
+	 * Logs EDD setting changes.
+	 *
+	 * @param string $old_value  Old value.
+	 * @param string $new_value  New value.
+	 */
 	public function check_edd_settings( $old_value, $new_value ) {
 		$options = array();
 
@@ -312,7 +372,7 @@ class Connector_EDD extends Connector {
 			$options[ $field_key ] = $field_value;
 		}
 
-		// TODO: Check this exists first
+		// TODO: Check this exists first.
 		$settings = \edd_get_registered_settings();
 
 		foreach ( $options as $option => $option_value ) {
@@ -337,7 +397,7 @@ class Connector_EDD extends Connector {
 			}
 
 			$this->log(
-				// translators: Placeholder refers to a setting title (e.g. "Language")
+				/* translators: %s: a setting title (e.g. "Language") */
 				__( '"%s" setting updated', 'stream' ),
 				array(
 					'option_title' => $field['name'],
@@ -356,7 +416,7 @@ class Connector_EDD extends Connector {
 	/**
 	 * Override connector log for our own Settings / Actions
 	 *
-	 * @param array $data
+	 * @param array $data  Record data.
 	 *
 	 * @return array|bool
 	 */
@@ -366,31 +426,31 @@ class Connector_EDD extends Connector {
 		}
 
 		if ( 'posts' === $data['connector'] && 'download' === $data['context'] ) {
-			// Download posts operations
+			// Download posts operations.
 			$data['context']   = 'downloads';
 			$data['connector'] = $this->name;
 		} elseif ( 'posts' === $data['connector'] && 'edd_discount' === $data['context'] ) {
-			// Discount posts operations
+			// Discount posts operations.
 			if ( $this->is_discount_status_change ) {
 				return false;
 			}
 
 			if ( 'deleted' === $data['action'] ) {
-				// translators: Placeholder refers to a discount title (e.g. "Mother's Day")
-				$data['message'] = esc_html__( '"%1s" discount deleted', 'stream' );
+				/* translators: %s: a discount title (e.g. "Mother's Day") */
+				$data['message'] = esc_html__( '"%s" discount deleted', 'stream' );
 			}
 
 			$data['context']   = 'discounts';
 			$data['connector'] = $this->name;
 		} elseif ( 'posts' === $data['connector'] && 'edd_payment' === $data['context'] ) {
-			// Payment posts operations
+			// Payment posts operations.
 			return false; // Do not track payments, they're well logged!
 		} elseif ( 'posts' === $data['connector'] && 'edd_log' === $data['context'] ) {
-			// Logging operations
+			// Logging operations.
 			return false; // Do not track notes, because they're basically logs
 		} elseif ( 'comments' === $data['connector'] && 'edd_payment' === $data['context'] ) {
-			// Payment notes ( comments ) operations
-			return false; // Do not track notes, because they're basically logs
+			// Payment notes ( comments ) operations.
+			return false; // Do not track notes, because they're basically logs.
 		} elseif ( 'taxonomies' === $data['connector'] && 'download_category' === $data['context'] ) {
 			$data['connector'] = $this->name;
 		} elseif ( 'taxonomies' === $data['connector'] && 'download_tag' === $data['context'] ) {
@@ -423,27 +483,56 @@ class Connector_EDD extends Connector {
 			'updated'
 		);
 	}
-
+	/**
+	 * Logs PDFs
+	 *
+	 * @action edd_generate_pdf
+	 */
 	private function callback_edd_generate_pdf() {
 		$this->report_generated( 'pdf' );
 	}
 
+	/**
+	 * Logs earning reports.
+	 *
+	 * @action edd_earnings_export
+	 */
 	public function callback_edd_earnings_export() {
 		$this->report_generated( 'earnings' );
 	}
 
+	/**
+	 * Logs payment reports.
+	 *
+	 * @action edd_payment_export
+	 */
 	public function callback_edd_payment_export() {
 		$this->report_generated( 'payments' );
 	}
 
+	/**
+	 * Logs email reports.
+	 *
+	 * @action edd_email_export
+	 */
 	public function callback_edd_email_export() {
 		$this->report_generated( 'emails' );
 	}
 
+	/**
+	 * Logs download history reports.
+	 *
+	 * @action edd_downloads_history_export
+	 */
 	public function callback_edd_downloads_history_export() {
 		$this->report_generated( 'download-history' );
 	}
 
+	/**
+	 * Logs generated reports.
+	 *
+	 * @param string $type  Report type.
+	 */
 	private function report_generated( $type ) {
 		$label = '';
 
@@ -461,7 +550,7 @@ class Connector_EDD extends Connector {
 
 		$this->log(
 			sprintf(
-				// translators: Placeholder refers to a report title (e.g. "Sales and Earnings")
+				/* translators: %s: a report title (e.g. "Sales and Earnings") */
 				__( 'Generated %s report', 'stream' ),
 				$label
 			),
@@ -474,6 +563,11 @@ class Connector_EDD extends Connector {
 		);
 	}
 
+	/**
+	 * Logs exported settings
+	 *
+	 * @action edd_export_settings
+	 */
 	public function callback_edd_export_settings() {
 		$this->log(
 			__( 'Exported Settings', 'stream' ),
@@ -484,6 +578,11 @@ class Connector_EDD extends Connector {
 		);
 	}
 
+	/**
+	 * Logs imported settings
+	 *
+	 * @action edd_import_settings
+	 */
 	public function callback_edd_import_settings() {
 		$this->log(
 			__( 'Imported Settings', 'stream' ),
@@ -494,19 +593,56 @@ class Connector_EDD extends Connector {
 		);
 	}
 
+	/**
+	 * Logs EDD-specific user meta changes.
+	 *
+	 * @action update_user_meta
+	 *
+	 * @param int    $meta_id      Meta ID.
+	 * @param int    $object_id    Object ID.
+	 * @param string $meta_key     Meta key.
+	 * @param string $_meta_value  Meta value.
+	 */
 	public function callback_update_user_meta( $meta_id, $object_id, $meta_key, $_meta_value ) {
 		unset( $meta_id );
 		$this->meta( $object_id, $meta_key, $_meta_value );
 	}
 
+	/**
+	 * Logs EDD-specific user meta creations.
+	 *
+	 * @action add_user_meta
+	 *
+	 * @param int    $object_id    Object ID.
+	 * @param string $meta_key     Meta key.
+	 * @param string $_meta_value  Meta value.
+	 */
 	public function callback_add_user_meta( $object_id, $meta_key, $_meta_value ) {
 		$this->meta( $object_id, $meta_key, $_meta_value, true );
 	}
 
+	/**
+	 * Logs EDD-specific user meta deletions.
+	 *
+	 * @action delete_user_meta
+	 *
+	 * @param int    $meta_id      Meta ID.
+	 * @param int    $object_id    Object ID.
+	 * @param string $meta_key     Meta key.
+	 * @param string $_meta_value  Meta value.
+	 */
 	public function callback_delete_user_meta( $meta_id, $object_id, $meta_key, $_meta_value ) {
 		$this->meta( $object_id, $meta_key, null );
 	}
 
+	/**
+	 * Logs EDD-specific user meta activity.
+	 *
+	 * @param int    $object_id  Object ID.
+	 * @param string $key        Meta key.
+	 * @param string $value      Meta value.
+	 * @param bool   $is_add     Is this a new meta?.
+	 */
 	public function meta( $object_id, $key, $value, $is_add = false ) {
 		if ( ! in_array( $key, $this->user_meta, true ) ) {
 			return false;
@@ -529,6 +665,13 @@ class Connector_EDD extends Connector {
 		);
 	}
 
+	/**
+	 * Logs change to User API key
+	 *
+	 * @param int    $user_id  User ID.
+	 * @param string $value    API Key.
+	 * @param bool   $is_add   Is this a new API key.
+	 */
 	private function meta_edd_user_public_key( $user_id, $value, $is_add = false ) {
 		if ( is_null( $value ) ) {
 			$action       = 'revoked';
@@ -543,7 +686,7 @@ class Connector_EDD extends Connector {
 
 		$this->log(
 			sprintf(
-				// translators: Placeholder refers to a status (e.g. "revoked")
+				/* translators: %s: a status (e.g. "revoked") */
 				__( 'User API Key %s', 'stream' ),
 				$action_title
 			),

--- a/connectors/class-connector-editor.php
+++ b/connectors/class-connector-editor.php
@@ -1,6 +1,15 @@
 <?php
+/**
+ * Connector for Editor
+ *
+ * @package WP_Stream
+ */
+
 namespace WP_Stream;
 
+/**
+ * Class - Connector_Editor
+ */
 class Connector_Editor extends Connector {
 	/**
 	 * Connector slug
@@ -85,8 +94,9 @@ class Connector_Editor extends Connector {
 	/**
 	 * Get the context based on wp_redirect location
 	 *
-	 * @param  string $location The URL of the redirect
-	 * @return string           Context slug
+	 * @param  string $location The URL of the redirect.
+	 *
+	 * @return string Context slug
 	 */
 	public function get_context( $location ) {
 		$context = null;
@@ -115,7 +125,7 @@ class Connector_Editor extends Connector {
 	 * @return string Translated string
 	 */
 	public function get_message() {
-		// translators: Placeholders refer to a file name, and a theme / plugin name (e.g. "index.php", "Stream")
+		/* translators: %1$s: a file name, %2$s: a theme / plugin name (e.g. "index.php", "Stream") */
 		return _x(
 			'"%1$s" in "%2$s" updated',
 			'1: File name, 2: Theme/plugin name',
@@ -128,8 +138,8 @@ class Connector_Editor extends Connector {
 	 *
 	 * @filter wp_stream_action_links_{connector}
 	 *
-	 * @param array  $links  Previous links registered
-	 * @param object $record Stream record
+	 * @param array  $links   Previous links registered.
+	 * @param object $record  Stream record.
 	 *
 	 * @return array Action links
 	 */
@@ -209,7 +219,7 @@ class Connector_Editor extends Connector {
 	/**
 	 * Retrieve theme data needed for the log message
 	 *
-	 * @param string $slug The theme slug (e.g. twentyfourteen)
+	 * @param string $slug  The theme slug (e.g. twentyfourteen).
 	 *
 	 * @return mixed $output Compacted variables
 	 */
@@ -251,8 +261,8 @@ class Connector_Editor extends Connector {
 	/**
 	 * Retrieve plugin data needed for the log message
 	 *
-	 * @param  string $slug   The plugin file base name (e.g. akismet/akismet.php)
-	 * @return mixed  $output Compacted variables
+	 * @param  string $slug    The plugin file base name (e.g. akismet/akismet.php).
+	 * @return mixed  $output  Compacted variables.
 	 */
 	public function get_plugin_data( $slug ) {
 		$base      = null;
@@ -286,11 +296,15 @@ class Connector_Editor extends Connector {
 	}
 
 	/**
+	 * Logs changes
+	 *
 	 * @filter wp_redirect
+	 *
+	 * @param string $location Location.
 	 */
 	public function log_changes( $location ) {
 		if ( ! empty( $this->edited_file ) ) {
-			// TODO: phpcs fix
+			// TODO: phpcs fix.
 			if ( md5_file( $this->edited_file['file_path'] ) !== $this->edited_file['file_md5'] ) {
 				$context = $this->get_context( $location );
 

--- a/connectors/class-connector-gravityforms.php
+++ b/connectors/class-connector-gravityforms.php
@@ -1,6 +1,15 @@
 <?php
+/**
+ * Connector for Gravity Forms
+ *
+ * @package WP_Stream
+ */
+
 namespace WP_Stream;
 
+/**
+ * Class - Connector_GravityForms
+ */
 class Connector_GravityForms extends Connector {
 	/**
 	 * Connector slug
@@ -130,8 +139,8 @@ class Connector_GravityForms extends Connector {
 	 *
 	 * @filter wp_stream_action_links_{connector}
 	 *
-	 * @param  array  $links     Previous links registered
-	 * @param  object $record    Stream record
+	 * @param  array  $links   Previous links registered.
+	 * @param  object $record  Stream record.
 	 *
 	 * @return array             Action links
 	 */
@@ -176,6 +185,9 @@ class Connector_GravityForms extends Connector {
 		return $links;
 	}
 
+	/**
+	 * Register all context hooks
+	 */
 	public function register() {
 		parent::register();
 
@@ -205,9 +217,8 @@ class Connector_GravityForms extends Connector {
 	/**
 	 * Track Create/Update actions on Forms
 	 *
-	 * @param array $form
-	 * @param bool  $is_new
-	 * @return void
+	 * @param array $form    Form data.
+	 * @param bool  $is_new  Is this a new form?.
 	 */
 	public function callback_gform_after_save_form( $form, $is_new ) {
 		$title = $form['title'];
@@ -215,7 +226,7 @@ class Connector_GravityForms extends Connector {
 
 		$this->log(
 			sprintf(
-				// translators: Placeholders refer to a form title, and a status (e.g. "Contact Form", "created")
+				/* translators: %1$s a form title, %2$s a status (e.g. "Contact Form", "created") */
 				__( '"%1$s" form %2$s', 'stream' ),
 				$title,
 				$is_new ? esc_html__( 'created', 'stream' ) : esc_html__( 'updated', 'stream' )
@@ -234,10 +245,9 @@ class Connector_GravityForms extends Connector {
 	/**
 	 * Track saving form confirmations
 	 *
-	 * @param array $confirmation
-	 * @param array $form
-	 * @param bool  $is_new
-	 * @return array
+	 * @param array $confirmation  Confirmation data.
+	 * @param array $form          Form data.
+	 * @param bool  $is_new        Is this a new form?.
 	 */
 	public function callback_gform_pre_confirmation_save( $confirmation, $form, $is_new = true ) {
 		if ( ! isset( $is_new ) ) {
@@ -246,7 +256,7 @@ class Connector_GravityForms extends Connector {
 
 		$this->log(
 			sprintf(
-				// translators: Placeholders refer to a confirmation name, a status, and a form title (e.g. "Email", "created", "Contact Form")
+				/* translators: %1$s: a confirmation name, %2$s: a status, %3$s: a form title (e.g. "Email", "created", "Contact Form") */
 				__( '"%1$s" confirmation %2$s for "%3$s"', 'stream' ),
 				$confirmation['name'],
 				$is_new ? esc_html__( 'created', 'stream' ) : esc_html__( 'updated', 'stream' ),
@@ -267,9 +277,9 @@ class Connector_GravityForms extends Connector {
 	/**
 	 * Track saving form notifications
 	 *
-	 * @param array $notification
-	 * @param array $form
-	 * @param bool  $is_new
+	 * @param array $notification  Notification data.
+	 * @param array $form          Form data.
+	 * @param bool  $is_new        Is this a new form?.
 	 * @return array
 	 */
 	public function callback_gform_pre_notification_save( $notification, $form, $is_new = true ) {
@@ -279,7 +289,7 @@ class Connector_GravityForms extends Connector {
 
 		$this->log(
 			sprintf(
-				// translators: Placeholders refer to a notification name, a status, and a form title (e.g. "Email", "created", "Contact Form")
+				/* translators: %1$s: a notification name, %2$s: a status, %3$s: a form title (e.g. "Email", "created", "Contact Form") */
 				__( '"%1$s" notification %2$s for "%3$s"', 'stream' ),
 				$notification['name'],
 				$is_new ? esc_html__( 'created', 'stream' ) : esc_html__( 'updated', 'stream' ),
@@ -300,14 +310,13 @@ class Connector_GravityForms extends Connector {
 	/**
 	 * Track deletion of notifications
 	 *
-	 * @param array $notification
-	 * @param array $form
-	 * @return void
+	 * @param array $notification  Notification data.
+	 * @param array $form          Form data.
 	 */
 	public function callback_gform_pre_notification_deleted( $notification, $form ) {
 		$this->log(
 			sprintf(
-				// translators: Placeholders refer to a notification name, and a form title (e.g. "Email", "Contact Form")
+				/* translators: %1$s: a notification name, %2$s: a form title (e.g. "Email", "Contact Form") */
 				__( '"%1$s" notification deleted from "%2$s"', 'stream' ),
 				$notification['name'],
 				$form['title']
@@ -325,14 +334,13 @@ class Connector_GravityForms extends Connector {
 	/**
 	 * Track deletion of confirmations
 	 *
-	 * @param array $confirmation
-	 * @param array $form
-	 * @return void
+	 * @param array $confirmation  Confirmation data.
+	 * @param array $form          Form data.
 	 */
 	public function callback_gform_pre_confirmation_deleted( $confirmation, $form ) {
 		$this->log(
 			sprintf(
-				// translators: Placeholders refer to a confirmation name, and a form title (e.g. "Email", "Contact Form")
+				/* translators: %1$s: a confirmation name, %2$s: a form title (e.g. "Email", "Contact Form") */
 				__( '"%1$s" confirmation deleted from "%2$s"', 'stream' ),
 				$confirmation['name'],
 				$form['title']
@@ -350,15 +358,14 @@ class Connector_GravityForms extends Connector {
 	/**
 	 * Track status change of confirmations
 	 *
-	 * @param array $confirmation
-	 * @param array $form
-	 * @param bool  $is_active
-	 * @return void
+	 * @param array $confirmation  Confirmation data.
+	 * @param array $form          Form data.
+	 * @param bool  $is_active     Is this form active?.
 	 */
 	public function callback_gform_confirmation_status( $confirmation, $form, $is_active ) {
 		$this->log(
 			sprintf(
-				// translators: Placeholders refer to a confirmation name, a status, and a form title (e.g. "Email", "activated", "Contact Form")
+				/* translators: %1$s: a confirmation name, %2$s: a status, %3$s: a form title (e.g. "Email", "activated", "Contact Form") */
 				__( '"%1$s" confirmation %2$s from "%3$s"', 'stream' ),
 				$confirmation['name'],
 				$is_active ? esc_html__( 'activated', 'stream' ) : esc_html__( 'deactivated', 'stream' ),
@@ -378,15 +385,14 @@ class Connector_GravityForms extends Connector {
 	/**
 	 * Track status change of notifications
 	 *
-	 * @param array $notification
-	 * @param array $form
-	 * @param bool  $is_active
-	 * @return void
+	 * @param array $notification  Notification data.
+	 * @param array $form          Form data.
+	 * @param bool  $is_active     Is this form active?.
 	 */
 	public function callback_gform_notification_status( $notification, $form, $is_active ) {
 		$this->log(
 			sprintf(
-				// translators: Placeholders refer to a notification name, a status, and a form title (e.g. "Email", "activated", "Contact Form")
+				/* translators: %1$s: a notification name, %2$s: a status, %3$s: a form title (e.g. "Email", "activated", "Contact Form") */
 				__( '"%1$s" notification %2$s from "%3$s"', 'stream' ),
 				$notification['name'],
 				$is_active ? esc_html__( 'activated', 'stream' ) : esc_html__( 'deactivated', 'stream' ),
@@ -403,30 +409,73 @@ class Connector_GravityForms extends Connector {
 		);
 	}
 
+	/**
+	 * Track GravityForms-specific option changes.
+	 *
+	 * @param string $option Option key.
+	 * @param string $old    Old value.
+	 * @param string $new    New value.
+	 */
 	public function callback_update_option( $option, $old, $new ) {
 		$this->check( $option, $old, $new );
 	}
 
+	/**
+	 * Track GravityForms-specific option creations.
+	 *
+	 * @param string $option Option key.
+	 * @param string $val    Value.
+	 */
 	public function callback_add_option( $option, $val ) {
 		$this->check( $option, null, $val );
 	}
 
+	/**
+	 * Track GravityForms-specific option deletions.
+	 *
+	 * @param string $option Option key.
+	 */
 	public function callback_delete_option( $option ) {
 		$this->check( $option, null, null );
 	}
 
+	/**
+	 * Track GravityForms-specific site option changes
+	 *
+	 * @param string $option Option key.
+	 * @param string $old    Old value.
+	 * @param string $new    New value.
+	 */
 	public function callback_update_site_option( $option, $old, $new ) {
 		$this->check( $option, $old, $new );
 	}
 
+	/**
+	 * Track GravityForms-specific site option creations.
+	 *
+	 * @param string $option Option key.
+	 * @param string $val    Value.
+	 */
 	public function callback_add_site_option( $option, $val ) {
 		$this->check( $option, null, $val );
 	}
 
+	/**
+	 * Track GravityForms-specific site option deletions.
+	 *
+	 * @param string $option Option key.
+	 */
 	public function callback_delete_site_option( $option ) {
 		$this->check( $option, null, null );
 	}
 
+	/**
+	 * Logs GravityForms-specific (site) option activity.
+	 *
+	 * @param string $option     Option key.
+	 * @param string $old_value  Old value.
+	 * @param string $new_value  New value.
+	 */
 	public function check( $option, $old_value, $new_value ) {
 		if ( ! array_key_exists( $option, $this->options ) ) {
 			return;
@@ -440,7 +489,7 @@ class Connector_GravityForms extends Connector {
 			$context      = isset( $data['context'] ) ? $data['context'] : 'settings';
 
 			$this->log(
-				// translators: Placeholder refers to a setting title (e.g. "Language")
+				/* translators: %s: a setting title (e.g. "Language") */
 				__( '"%s" setting updated', 'stream' ),
 				compact( 'option_title', 'option', 'old_value', 'new_value' ),
 				null,
@@ -450,13 +499,20 @@ class Connector_GravityForms extends Connector {
 		}
 	}
 
+	/**
+	 * Log GravityForm license key changes
+	 *
+	 * @param string $old_value  Old license key.
+	 * @param string $new_value  New license key.
+	 * @return void
+	 */
 	public function check_rg_gforms_key( $old_value, $new_value ) {
 		$is_update = ( $new_value && strlen( $new_value ) );
 		$option    = 'rg_gforms_key';
 
 		$this->log(
 			sprintf(
-				// translators: Placeholder refers to a status (e.g. "updated")
+				/* translators: %s: a status (e.g. "updated") */
 				__( 'Gravity Forms license key %s', 'stream' ),
 				$is_update ? esc_html__( 'updated', 'stream' ) : esc_html__( 'deleted', 'stream' )
 			),
@@ -467,10 +523,20 @@ class Connector_GravityForms extends Connector {
 		);
 	}
 
+	/**
+	 * Logs form entry exports.
+	 *
+	 * @action gform_post_export_entries
+	 *
+	 * @param object $form        Form data.
+	 * @param string $start_date  Form start date.
+	 * @param string $end_date    Form completion date.
+	 * @param array  $fields      Form fields data.
+	 */
 	public function callback_gform_post_export_entries( $form, $start_date, $end_date, $fields ) {
 		unset( $fields );
 		$this->log(
-			// translators: Placeholder refers to a form title (e.g. "Contact Form")
+			/* translators: %s: a form title (e.g. "Contact Form") */
 			__( '"%s" form entries exported', 'stream' ),
 			array(
 				'form_title' => $form['title'],
@@ -484,13 +550,20 @@ class Connector_GravityForms extends Connector {
 		);
 	}
 
+	/**
+	 * Logs form imports.
+	 *
+	 * @action gform_forms_post_import
+	 *
+	 * @param array $forms  List of form data.
+	 */
 	public function callback_gform_forms_post_import( $forms ) {
 		$forms_total  = count( $forms );
 		$forms_ids    = wp_list_pluck( $forms, 'id' );
 		$forms_titles = wp_list_pluck( $forms, 'title' );
 
 		$this->log(
-			// translators: Placeholder refers to a number of forms (e.g. "42")
+			/* translators: %d: a number of forms (e.g. "42") */
 			_n( '%d form imported', '%d forms imported', $forms_total, 'stream' ),
 			array(
 				'count'  => $forms_total,
@@ -503,11 +576,19 @@ class Connector_GravityForms extends Connector {
 		);
 	}
 
+	/**
+	 * Logs form exports
+	 *
+	 * @action gform_export_separator
+	 *
+	 * @param string $dummy    Unused.
+	 * @param int    $form_id  Form ID.
+	 */
 	public function callback_gform_export_separator( $dummy, $form_id ) {
 		$form = $this->get_form( $form_id );
 
 		$this->log(
-			// translators: Placeholder refers to a form title (e.g. "Contact Form")
+			/* translators: %s: a form title (e.g. "Contact Form") */
 			__( '"%s" form exported', 'stream' ),
 			array(
 				'form_title' => $form['title'],
@@ -521,12 +602,18 @@ class Connector_GravityForms extends Connector {
 		return $dummy;
 	}
 
+	/**
+	 * Log bulk form exports
+	 *
+	 * @param string $dummy  Unused.
+	 * @param array  $forms  Form data.
+	 */
 	public function callback_gform_export_options( $dummy, $forms ) {
 		$ids    = wp_list_pluck( $forms, 'id' );
 		$titles = wp_list_pluck( $forms, 'title' );
 
 		$this->log(
-			// translators: Placeholder refers to a number of forms (e.g. "42")
+			/* translators: %d: a number of forms (e.g. "42") */
 			_n( 'Export process started for %d form', 'Export process started for %d forms', count( $forms ), 'stream' ),
 			array(
 				'count'  => count( $forms ),
@@ -541,12 +628,20 @@ class Connector_GravityForms extends Connector {
 		return $dummy;
 	}
 
+	/**
+	 * Logs lead deletions.
+	 *
+	 * @action gform_delete_lead
+	 *
+	 * @param int $lead_id  Lead ID.
+	 * @return void
+	 */
 	public function callback_gform_delete_lead( $lead_id ) {
 		$lead = $this->get_lead( $lead_id );
 		$form = $this->get_form( $lead['form_id'] );
 
 		$this->log(
-			// translators: Placeholders refer to an ID, and a form title (e.g. "42", "Contact Form")
+			/* translators: %1$d: to an ID, %2$s: a form title (e.g. "42", "Contact Form") */
 			__( 'Lead #%1$d from "%2$s" deleted', 'stream' ),
 			array(
 				'lead_id'    => $lead_id,
@@ -559,6 +654,18 @@ class Connector_GravityForms extends Connector {
 		);
 	}
 
+	/**
+	 * Logs note creation on lead.
+	 *
+	 * @action gform_post_note_added
+	 *
+	 * @param int    $note_id    Note ID.
+	 * @param int    $lead_id    Lead ID.
+	 * @param int    $user_id    User ID of note author.
+	 * @param string $user_name  Username of note author.
+	 * @param string $note       Note object.
+	 * @param string $note_type  Note type.
+	 */
 	public function callback_gform_post_note_added( $note_id, $lead_id, $user_id, $user_name, $note, $note_type ) {
 		unset( $user_id );
 		unset( $user_name );
@@ -569,7 +676,7 @@ class Connector_GravityForms extends Connector {
 		$form = $this->get_form( $lead['form_id'] );
 
 		$this->log(
-			// translators: Placeholders refer to an ID, another ID, and a form title (e.g. "42", "7", "Contact Form")
+			/* translators: %1$d: an ID, %2$d: another ID, %3$s: a form title (e.g. "42", "7", "Contact Form") */
 			__( 'Note #%1$d added to lead #%2$d on "%3$s" form', 'stream' ),
 			array(
 				'note_id'    => $note_id,
@@ -583,12 +690,20 @@ class Connector_GravityForms extends Connector {
 		);
 	}
 
+	/**
+	 * Logs note deletion
+	 *
+	 * @action gform_pre_note_deleted
+	 *
+	 * @param int $note_id  Note ID.
+	 * @param int $lead_id  Lead ID.
+	 */
 	public function callback_gform_pre_note_deleted( $note_id, $lead_id ) {
 		$lead = $this->get_lead( $lead_id );
 		$form = $this->get_form( $lead['form_id'] );
 
 		$this->log(
-			// translators: Placeholders refer to an ID, another ID, and a form title (e.g. "42", "7", "Contact Form")
+			/* translators: %2$d an ID, another ID, and a form title (e.g. "42", "7", "Contact Form") */
 			__( 'Note #%1$d deleted from lead #%2$d on "%3$s" form', 'stream' ),
 			array(
 				'note_id'    => $note_id,
@@ -602,6 +717,15 @@ class Connector_GravityForms extends Connector {
 		);
 	}
 
+	/**
+	 * Logs form status updates.
+	 *
+	 * @action gform_update_status
+	 *
+	 * @param int    $lead_id  Lead ID.
+	 * @param string $status   New form status.
+	 * @param string $prev     Old form status.
+	 */
 	public function callback_gform_update_status( $lead_id, $status, $prev = '' ) {
 		$lead = $this->get_lead( $lead_id );
 		$form = $this->get_form( $lead['form_id'] );
@@ -623,7 +747,7 @@ class Connector_GravityForms extends Connector {
 
 		$this->log(
 			sprintf(
-				// translators: Placeholders refer to an ID, a status, and a form title (e.g. "42", "activated", "Contact Form")
+				/* translators: %1$d: an ID, %2$s: a status, %3$s: a form title (e.g. "42", "activated", "Contact Form") */
 				__( 'Lead #%1$d %2$s on "%3$s" form', 'stream' ),
 				$lead_id,
 				$actions[ $status ],
@@ -645,9 +769,10 @@ class Connector_GravityForms extends Connector {
 	/**
 	 * Callback fired when an entry is read/unread
 	 *
-	 * @param  int $lead_id
-	 * @param  int $status
-	 * @return void
+	 * @action update_is_read
+	 *
+	 * @param int    $lead_id  Lead ID.
+	 * @param string $status   Status.
 	 */
 	public function callback_gform_update_is_read( $lead_id, $status ) {
 		$lead   = $this->get_lead( $lead_id );
@@ -656,7 +781,7 @@ class Connector_GravityForms extends Connector {
 
 		$this->log(
 			sprintf(
-				// translators: Placeholders refer to an ID, a status, and a form title (e.g. "42", "unread", "Contact Form")
+				/* translators: %1$d: a lead ID, %2$s: a status, %3$s: a form ID, %4$s: a form title (e.g. "42", "unread", "Contact Form") */
 				__( 'Entry #%1$d marked as %2$s on form #%3$d ("%4$s")', 'stream' ),
 				$lead_id,
 				$status,
@@ -678,9 +803,10 @@ class Connector_GravityForms extends Connector {
 	/**
 	 * Callback fired when an entry is starred/unstarred
 	 *
-	 * @param  int $lead_id
-	 * @param  int $status
-	 * @return void
+	 * @action gform_update_is_starred
+	 *
+	 * @param int $lead_id  Lead ID.
+	 * @param int $status   Status.
 	 */
 	public function callback_gform_update_is_starred( $lead_id, $status ) {
 		$lead   = $this->get_lead( $lead_id );
@@ -690,7 +816,7 @@ class Connector_GravityForms extends Connector {
 
 		$this->log(
 			sprintf(
-				// translators: Placeholders refer to an ID, a status, and a form title (e.g. "42", "starred", "Contact Form")
+				/* translators: %1$d: an ID, %2$s: a status, %3$d: a form title (e.g. "42", "starred", "Contact Form") */
 				__( 'Entry #%1$d %2$s on form #%3$d ("%4$s")', 'stream' ),
 				$lead_id,
 				$status,
@@ -712,8 +838,9 @@ class Connector_GravityForms extends Connector {
 	/**
 	 * Callback fired when a form is deleted
 	 *
-	 * @param  int $form_id Form ID
-	 * @return void
+	 * @action gform_before_delete_form
+	 *
+	 * @param int $form_id  Form ID.
 	 */
 	public function callback_gform_before_delete_form( $form_id ) {
 		$this->log_form_action( $form_id, 'deleted' );
@@ -722,8 +849,9 @@ class Connector_GravityForms extends Connector {
 	/**
 	 * Callback fired when a form is trashed
 	 *
-	 * @param  int $form_id Form ID
-	 * @return void
+	 * @action gform_post_form_trashed
+	 *
+	 * @param int $form_id  Form ID.
 	 */
 	public function callback_gform_post_form_trashed( $form_id ) {
 		$this->log_form_action( $form_id, 'trashed' );
@@ -732,8 +860,9 @@ class Connector_GravityForms extends Connector {
 	/**
 	 * Callback fired when a form is restored
 	 *
-	 * @param  int $form_id Form ID
-	 * @return void
+	 * @action gform_post_form_restored
+	 *
+	 * @param int $form_id  Form ID.
 	 */
 	public function callback_gform_post_form_restored( $form_id ) {
 		$this->log_form_action( $form_id, 'untrashed' );
@@ -742,8 +871,9 @@ class Connector_GravityForms extends Connector {
 	/**
 	 * Callback fired when a form is activated
 	 *
-	 * @param  int $form_id Form ID
-	 * @return void
+	 * @action gform_post_form_activated
+	 *
+	 * @param int $form_id  Form ID.
 	 */
 	public function callback_gform_post_form_activated( $form_id ) {
 		$this->log_form_action( $form_id, 'activated' );
@@ -752,8 +882,9 @@ class Connector_GravityForms extends Connector {
 	/**
 	 * Callback fired when a form is deactivated
 	 *
-	 * @param  int $form_id Form ID
-	 * @return void
+	 * @action gform_post_form_deactivated
+	 *
+	 * @param  int $form_id  Form ID.
 	 */
 	public function callback_gform_post_form_deactivated( $form_id ) {
 		$this->log_form_action( $form_id, 'deactivated' );
@@ -762,8 +893,9 @@ class Connector_GravityForms extends Connector {
 	/**
 	 * Callback fired when a form is duplicated
 	 *
-	 * @param  int $form_id Form ID
-	 * @return void
+	 * @action gform_post_form_duplicated
+	 *
+	 * @param  int $form_id  Form ID.
 	 */
 	public function callback_gform_post_form_duplicated( $form_id ) {
 		$this->log_form_action( $form_id, 'duplicated' );
@@ -772,8 +904,9 @@ class Connector_GravityForms extends Connector {
 	/**
 	 * Callback fired when a form's views are reset
 	 *
-	 * @param  int $form_id Form ID
-	 * @return void
+	 * @action gform_post_form_views_deleted
+	 *
+	 * @param int $form_id  Form ID.
 	 */
 	public function callback_gform_post_form_views_deleted( $form_id ) {
 		$this->log_form_action( $form_id, 'views_deleted' );
@@ -782,9 +915,8 @@ class Connector_GravityForms extends Connector {
 	/**
 	 * Track status change of forms
 	 *
-	 * @param int    $form_id
-	 * @param string $action
-	 * @return void
+	 * @param int    $form_id  Form ID.
+	 * @param string $action   Action.
 	 */
 	public function log_form_action( $form_id, $action ) {
 		$form = $this->get_form( $form_id );
@@ -805,7 +937,7 @@ class Connector_GravityForms extends Connector {
 
 		$this->log(
 			sprintf(
-				// translators: Placeholders refer to an ID, a form title, and a status (e.g. "42", "Contact Form", "Activated")
+				/* translators: %1$d: an ID, %2$s: a form title, %3$s: a status (e.g. "42", "Contact Form", "Activated") */
 				__( 'Form #%1$d ("%2$s") %3$s', 'stream' ),
 				$form_id,
 				$form['title'],
@@ -825,8 +957,7 @@ class Connector_GravityForms extends Connector {
 	/**
 	 * Helper function to get a single entry
 	 *
-	 * @param  int $lead_id Lead ID
-	 * @return array
+	 * @param int $lead_id  Lead ID.
 	 */
 	private function get_lead( $lead_id ) {
 		return \GFFormsModel::get_lead( $lead_id );
@@ -835,8 +966,7 @@ class Connector_GravityForms extends Connector {
 	/**
 	 * Helper function to get a single form
 	 *
-	 * @param  int $form_id Form ID
-	 * @return array
+	 * @param int $form_id  Form ID.
 	 */
 	private function get_form( $form_id ) {
 		return \GFFormsModel::get_form_meta( $form_id );

--- a/connectors/class-connector-installer.php
+++ b/connectors/class-connector-installer.php
@@ -1,6 +1,15 @@
 <?php
+/**
+ * Connector for installer
+ *
+ * @package WP_Stream
+ */
+
 namespace WP_Stream;
 
+/**
+ * Class - Connector_Installer
+ */
 class Connector_Installer extends Connector {
 
 	/**
@@ -16,12 +25,12 @@ class Connector_Installer extends Connector {
 	 * @var array
 	 */
 	public $actions = array(
-		'upgrader_process_complete', // plugins::installed | themes::installed
-		'activate_plugin', // plugins::activated
-		'deactivate_plugin', // plugins::deactivated
-		'switch_theme', // themes::activated
-		'delete_site_transient_update_themes', // themes::deleted
-		'pre_option_uninstall_plugins', // plugins::deleted
+		'upgrader_process_complete', // plugins::installed | themes::installed.
+		'activate_plugin', // plugins::activated.
+		'deactivate_plugin', // plugins::deactivated.
+		'switch_theme', // themes::activated.
+		'delete_site_transient_update_themes', // themes::deleted.
+		'pre_option_uninstall_plugins', // plugins::deleted.
 		'pre_set_site_transient_update_plugins',
 		'_core_updated_successfully',
 	);
@@ -75,8 +84,8 @@ class Connector_Installer extends Connector {
 	 *
 	 * @filter wp_stream_action_links_{connector}
 	 *
-	 * @param  array  $links     Previous links registered
-	 * @param  object $record    Stream record
+	 * @param  array  $links   Previous links registered.
+	 * @param  object $record  Stream record.
 	 *
 	 * @return array             Action links
 	 */
@@ -112,10 +121,10 @@ class Connector_Installer extends Connector {
 	/**
 	 * Log plugin installations
 	 *
-	 * @action transition_post_status
+	 * @action upgrader_process_complete
 	 *
-	 * @param \WP_Upgrader $upgrader
-	 * @param array        $extra
+	 * @param \WP_Upgrader $upgrader  Upgrader object.
+	 * @param array        $extra     Extra plugin data.
 	 *
 	 * @return bool
 	 */
@@ -130,7 +139,7 @@ class Connector_Installer extends Connector {
 			list( $error ) = reset( $errors );
 		}
 
-		// This would have failed down the road anyway
+		// This would have failed down the road anyway.
 		if ( ! isset( $extra['type'] ) ) {
 			return false;
 		}
@@ -154,7 +163,7 @@ class Connector_Installer extends Connector {
 				$slug    = $upgrader->result['destination_name'];
 				$name    = $data['Name'];
 				$version = $data['Version'];
-			} else { // theme
+			} else { // theme.
 				$slug = $upgrader->theme_info();
 
 				if ( ! $slug ) {
@@ -169,7 +178,7 @@ class Connector_Installer extends Connector {
 			}
 
 			$action = 'installed';
-			// translators: Placeholders refer to a plugin/theme type, a plugin/theme name, and a plugin/theme version (e.g. "plugin", "Stream", "4.2")
+			/* translators: %1$s: a plugin/theme type, %2$s: a plugin/theme name, %3$s: a plugin/theme version (e.g. "plugin", "Stream", "4.2") */
 			$message = _x(
 				'Installed %1$s: %2$s %3$s',
 				'Plugin/theme installation. 1: Type (plugin/theme), 2: Plugin/theme name, 3: Plugin/theme version',
@@ -179,7 +188,7 @@ class Connector_Installer extends Connector {
 			$logs[] = compact( 'slug', 'name', 'version', 'message', 'action' );
 		} elseif ( 'update' === $action ) {
 			$action = 'updated';
-			// translators: Placeholders refer to a plugin/theme type, a plugin/theme name, and a plugin/theme version (e.g. "plugin", "Stream", "4.2")
+			/* translators: %1$s: a plugin/theme type, %2$s: a plugin/theme name, %3$s: a plugin/theme version (e.g. "plugin", "Stream", "4.2") */
 			$message = _x(
 				'Updated %1$s: %2$s %3$s',
 				'Plugin/theme update. 1: Type (plugin/theme), 2: Plugin/theme name, 3: Plugin/theme version',
@@ -203,7 +212,7 @@ class Connector_Installer extends Connector {
 
 					$logs[] = compact( 'slug', 'name', 'old_version', 'version', 'message', 'action' );
 				}
-			} else { // theme
+			} else { // theme.
 				if ( isset( $extra['bulk'] ) && true === $extra['bulk'] ) {
 					$slugs = $extra['themes'];
 				} else {
@@ -252,13 +261,21 @@ class Connector_Installer extends Connector {
 		return true;
 	}
 
+	/**
+	 * Logs plugin activations
+	 *
+	 * @action activate_plugin
+	 *
+	 * @param string $slug          Plugin slug name.
+	 * @param bool   $network_wide  Activated across the multi-site?.
+	 */
 	public function callback_activate_plugin( $slug, $network_wide ) {
 		$_plugins     = $this->get_plugins();
 		$name         = $_plugins[ $slug ]['Name'];
 		$network_wide = $network_wide ? esc_html__( 'network wide', 'stream' ) : null;
 
 		$this->log(
-			// translators: Placeholders refer to a plugin name, and whether it is on a single site or network wide (e.g. "Stream", "network wide") (a single site results in a blank string)
+			/* translators: %1$s: a plugin name, %2$s: whether it is on a single site or network wide (e.g. "Stream", "network wide") (a single site results in a blank string) */
 			_x(
 				'"%1$s" plugin activated %2$s',
 				'1: Plugin name, 2: Single site or network wide',
@@ -271,13 +288,21 @@ class Connector_Installer extends Connector {
 		);
 	}
 
+	/**
+	 * Logs plugin deactivations
+	 *
+	 * @action deactivate_plugin
+	 *
+	 * @param string $slug          Plugin slug name.
+	 * @param bool   $network_wide  Deactivated across the multi-site?.
+	 */
 	public function callback_deactivate_plugin( $slug, $network_wide ) {
 		$_plugins     = $this->get_plugins();
 		$name         = $_plugins[ $slug ]['Name'];
 		$network_wide = $network_wide ? esc_html__( 'network wide', 'stream' ) : null;
 
 		$this->log(
-			// translators: Placeholders refer to a plugin name, and whether it is on a single site or network wide (e.g. "Stream", "network wide") (a single site results in a blank string)
+			/* translators: %1$s: a plugin name, %2$s: whether it is on a single site or network wide (e.g. "Stream", "network wide") (a single site results in a blank string) */
 			_x(
 				'"%1$s" plugin deactivated %2$s',
 				'1: Plugin name, 2: Single site or network wide',
@@ -290,10 +315,16 @@ class Connector_Installer extends Connector {
 		);
 	}
 
+	/**
+	 * Logs theme activations.
+	 *
+	 * @param string $name   Theme name.
+	 * @param string $theme  Unused.
+	 */
 	public function callback_switch_theme( $name, $theme ) {
 		unset( $theme );
 		$this->log(
-			// translators: Placeholder refers to a theme name (e.g. "Twenty Seventeen")
+			/* translators: %s: a theme name (e.g. "Twenty Seventeen") */
 			__( '"%s" theme activated', 'stream' ),
 			compact( 'name' ),
 			null,
@@ -303,10 +334,17 @@ class Connector_Installer extends Connector {
 	}
 
 	/**
+	 * Logs theme deletion.
+	 *
+	 * @action delete_site_transient_update_themes
+	 *
 	 * @todo Core needs a delete_theme hook
 	 */
 	public function callback_delete_site_transient_update_themes() {
-		$backtrace = debug_backtrace(); // @codingStandardsIgnoreLine This is used as a hack to determine a theme was deleted.
+		/**
+		 * This is used as a hack to determine a theme was deleted.
+		 */
+		$backtrace = debug_backtrace(); // @codingStandardsIgnoreLine
 		$delete_theme_call = null;
 
 		foreach ( $backtrace as $call ) {
@@ -321,10 +359,10 @@ class Connector_Installer extends Connector {
 		}
 
 		$name = $delete_theme_call['args'][0];
-		// @todo Can we get the name of the theme? Or has it already been eliminated
+		// @todo Can we get the name of the theme? Or has it already been eliminated.
 
 		$this->log(
-			// translators: Placeholder refers to a theme name (e.g. "Twenty Seventeen")
+			/* translators: Placeholder refers to a theme name (e.g. "Twenty Seventeen") */
 			__( '"%s" theme deleted', 'stream' ),
 			compact( 'name' ),
 			null,
@@ -334,6 +372,10 @@ class Connector_Installer extends Connector {
 	}
 
 	/**
+	 * Logs plugins uninstallations.
+	 *
+	 * @action pre_option_uninstall_plugins
+	 *
 	 * @todo Core needs an uninstall_plugin hook
 	 * @todo This does not work in WP-CLI
 	 */
@@ -365,7 +407,11 @@ class Connector_Installer extends Connector {
 	}
 
 	/**
-	 * @param mixed $value
+	 * Logs bulk plugin deletions.
+	 *
+	 * @filter pre_set_site_transient_update_plugins
+	 *
+	 * @param mixed $value  Unused.
 	 *
 	 * @return mixed
 	 * @todo Core needs a delete_plugin hook
@@ -382,7 +428,7 @@ class Connector_Installer extends Connector {
 			$network_wide = $data['Network'] ? esc_html__( 'network wide', 'stream' ) : '';
 
 			$this->log(
-				// translators: Placeholder refers to a plugin name (e.g. "Stream")
+				/* translators: %s a plugin name (e.g. "Stream") */
 				__( '"%s" plugin deleted', 'stream' ),
 				compact( 'name', 'plugin', 'network_wide' ),
 				null,
@@ -396,6 +442,14 @@ class Connector_Installer extends Connector {
 		return $value;
 	}
 
+	/**
+	 * Logs WordPress core upgrades
+	 *
+	 * @action _core_updated_successfully
+	 *
+	 * @param string $new_version  Version WordPress core has be upgraded to.
+	 * @return void
+	 */
 	public function callback__core_updated_successfully( $new_version ) {
 		global $pagenow, $wp_version;
 
@@ -403,10 +457,10 @@ class Connector_Installer extends Connector {
 		$auto_updated = ( 'update-core.php' !== $pagenow );
 
 		if ( $auto_updated ) {
-			// translators: Placeholder refers to a version number (e.g. "4.2")
+			/* translators: %s: a version number (e.g. "4.2") */
 			$message = esc_html__( 'WordPress auto-updated to %s', 'stream' );
 		} else {
-			// translators: Placeholder refers to a version number (e.g. "4.2")
+			/* translators: %s: a version number (e.g. "4.2") */
 			$message = esc_html__( 'WordPress updated to %s', 'stream' );
 		}
 

--- a/connectors/class-connector-jetpack.php
+++ b/connectors/class-connector-jetpack.php
@@ -185,7 +185,7 @@ class Connector_Jetpack extends Connector {
 					);
 				}
 			} elseif ( \Jetpack::is_module_active( str_replace( 'jetpack-', '', $record->context ) ) ) {
-				$slug = str_replace( 'jetpack-', '', $record->context ); // handling jetpack-comment anomaly
+				$slug = str_replace( 'jetpack-', '', $record->context ); // handling jetpack-comment anomaly.
 
 				if ( apply_filters( 'jetpack_module_configurable_' . $slug, false ) ) {
 					$links[ esc_html__( 'Configure module', 'stream' ) ] = \Jetpack::module_configuration_url( $slug );
@@ -384,7 +384,8 @@ class Connector_Jetpack extends Connector {
 			$context      = 'blogs';
 			$action       = str_replace( 'subsite', '', $method );
 			$is_multisite = ( 0 === strpos( $method, 'subsite' ) );
-			$blog_id      = $is_multisite ? ( isset( $_GET['site_id'] ) ? intval( wp_unslash( $_GET['site_id'] ) ) : null ) : get_current_blog_id(); // phpcs: input var okay, CSRF okay
+			// @codingStandardsIgnoreLine
+			$blog_id      = $is_multisite ? ( isset( $_GET['site_id'] ) ? intval( wp_unslash( $_GET['site_id'] ) ) : null ) : get_current_blog_id();
 
 			if ( empty( $blog_id ) ) {
 				return;

--- a/connectors/class-connector-jetpack.php
+++ b/connectors/class-connector-jetpack.php
@@ -1,6 +1,15 @@
 <?php
+/**
+ * Connector for Jetpack
+ *
+ * @package WP_Stream
+ */
+
 namespace WP_Stream;
 
+/**
+ * Class - Connector_Jetpack
+ */
 class Connector_Jetpack extends Connector {
 	/**
 	 * Connector slug
@@ -133,8 +142,8 @@ class Connector_Jetpack extends Connector {
 	 *
 	 * @filter wp_stream_action_links_{connector}
 	 *
-	 * @param array  $links   Previous links registered
-	 * @param object $record Stream record
+	 * @param array  $links   Previous links registered.
+	 * @param object $record  Stream record.
 	 *
 	 * @return array Action links
 	 */
@@ -187,6 +196,9 @@ class Connector_Jetpack extends Connector {
 		return $links;
 	}
 
+	/**
+	 * Register all context hooks
+	 */
 	public function register() {
 		parent::register();
 
@@ -194,7 +206,7 @@ class Connector_Jetpack extends Connector {
 
 		$this->options = array(
 			'jetpack_options'                   => null,
-			// Sharing module
+			// Sharing module.
 			'hide_gplus'                        => null,
 			'gplus_authors'                     => null,
 			'sharing-options'                   => array(
@@ -206,22 +218,22 @@ class Connector_Jetpack extends Connector {
 				'label'   => esc_html__( 'Twitter site tag', 'stream' ),
 				'context' => 'sharedaddy',
 			),
-			// Stats module
+			// Stats module.
 			'stats_options'                     => array(
 				'label'   => esc_html__( 'WordPress.com Stats', 'stream' ),
 				'context' => 'stats',
 			),
-			// Comments
+			// Comments.
 			'jetpack_comment_form_color_scheme' => array(
 				'label'   => esc_html__( 'Color Scheme', 'stream' ),
 				'context' => 'jetpack-comments',
 			),
-			// Likes
+			// Likes.
 			'disabled_likes'                    => array(
 				'label'   => esc_html__( 'WP.com Site-wide Likes', 'stream' ),
 				'context' => 'likes',
 			),
-			// Mobile
+			// Mobile.
 			'wp_mobile_excerpt'                 => array(
 				'label'   => esc_html__( 'Excerpts appearance', 'stream' ),
 				'context' => 'minileven',
@@ -233,7 +245,7 @@ class Connector_Jetpack extends Connector {
 		);
 
 		$this->options_override = array(
-			// Carousel Module
+			// Carousel Module.
 			'carousel_background_color'        => array(
 				'label'   => esc_html__( 'Background color', 'stream' ),
 				'context' => 'carousel',
@@ -242,7 +254,7 @@ class Connector_Jetpack extends Connector {
 				'label'   => esc_html__( 'Metadata', 'stream' ),
 				'context' => 'carousel',
 			),
-			// Subscriptions
+			// Subscriptions.
 			'stb_enabled'                      => array(
 				'label'   => esc_html__( 'Follow blog comment form button', 'stream' ),
 				'context' => 'subscriptions',
@@ -251,22 +263,22 @@ class Connector_Jetpack extends Connector {
 				'label'   => esc_html__( 'Follow comments form button', 'stream' ),
 				'context' => 'subscriptions',
 			),
-			// Jetpack comments
+			// Jetpack comments.
 			'highlander_comment_form_prompt'   => array(
 				'label'   => esc_html__( 'Greeting Text', 'stream' ),
 				'context' => 'jetpack-comments',
 			),
-			// Infinite Scroll
+			// Infinite Scroll.
 			'infinite_scroll_google_analytics' => array(
 				'label'   => esc_html__( 'Infinite Scroll Google Analytics', 'stream' ),
 				'context' => 'infinite-scroll',
 			),
-			// Protect
+			// Protect.
 			'jetpack_protect_blocked_attempts' => array(
 				'label'   => esc_html__( 'Blocked Attempts', 'stream' ),
 				'context' => 'protect',
 			),
-			// SSO
+			// SSO.
 			'jetpack_sso_require_two_step'     => array(
 				'label'   => esc_html__( 'Require Two-Step Authentication', 'stream' ),
 				'context' => 'sso',
@@ -275,7 +287,7 @@ class Connector_Jetpack extends Connector {
 				'label'   => esc_html__( 'Match by Email', 'stream' ),
 				'context' => 'sso',
 			),
-			// Related posts
+			// Related posts.
 			'jetpack_relatedposts'             => array(
 				'show_headline'   => array(
 					'label'   => esc_html__( 'Show Related Posts Headline', 'stream' ),
@@ -286,7 +298,7 @@ class Connector_Jetpack extends Connector {
 					'context' => 'related-posts',
 				),
 			),
-			// Site verification
+			// Site verification.
 			'verification_services_codes'      => array(
 				'google'    => array(
 					'label'   => esc_html__( 'Google Webmaster Tools Token', 'stream' ),
@@ -301,7 +313,7 @@ class Connector_Jetpack extends Connector {
 					'context' => 'verification-tools',
 				),
 			),
-			// Tiled galleries
+			// Tiled galleries.
 			'tiled_galleries'                  => array(
 				'label'   => esc_html__( 'Tiled Galleries', 'stream' ),
 				'context' => 'tiled-gallery',
@@ -316,7 +328,7 @@ class Connector_Jetpack extends Connector {
 	 * - Registration/Disconnection of blogs
 	 * - Authorization/unlinking of users
 	 *
-	 * @param array $entry
+	 * @param array $entry  Entry data.
 	 */
 	public function callback_jetpack_log_entry( array $entry ) {
 		if ( isset( $entry['code'] ) ) {
@@ -343,7 +355,7 @@ class Connector_Jetpack extends Connector {
 			$action      = $method . 'd';
 			$meta        = compact( 'module_slug' );
 			$message     = sprintf(
-				// translators: Placeholders refer to a module name, and a status (e.g. "Photon", "activated")
+				/* translators: %1$s: a module name, %2$s a status (e.g. "Photon", "activated") */
 				__( '%1$s module %2$s', 'stream' ),
 				$module_name,
 				( 'activated' === $action ) ? esc_html__( 'activated', 'stream' ) : esc_html__( 'deactivated', 'stream' )
@@ -362,7 +374,7 @@ class Connector_Jetpack extends Connector {
 			$action     = $method;
 			$meta       = compact( 'user_id', 'user_email', 'user_login' );
 			$message    = sprintf(
-				// translators: Placeholders refer to a user display name, a status, and the connection either "from" or "to" (e.g. "Jane Doe", "unlinked", "from")
+				/* translators: %1$s: a user display name, %2$s: a status, %3$s: the connection either "from" or "to" (e.g. "Jane Doe", "unlinked", "from") */
 				__( '%1$s\'s account %2$s %3$s Jetpack', 'stream' ),
 				$user->display_name,
 				( 'unlink' === $action ) ? esc_html__( 'unlinked', 'stream' ) : esc_html__( 'linked', 'stream' ),
@@ -380,7 +392,7 @@ class Connector_Jetpack extends Connector {
 
 			if ( ! $is_multisite ) {
 				$message = sprintf(
-					// translators: Placeholder refers to a connection status. Either "connected to" or "disconnected from".
+					/* translators: %s: a connection status. Either "connected to" or "disconnected from". */
 					__( 'Site %s Jetpack', 'stream' ),
 					( 'register' === $action ) ? esc_html__( 'connected to', 'stream' ) : esc_html__( 'disconnected from', 'stream' )
 				);
@@ -394,7 +406,7 @@ class Connector_Jetpack extends Connector {
 				$meta        += compact( 'blog_id', 'blog_name' );
 
 				$message = sprintf(
-					// translators: Placeholder refers to a connection status. Either "connected to" or "disconnected from".
+					/* translators: %1$s: Blog name, %2$s: a connection status. Either "connected to" or "disconnected from". */
 					__( '"%1$s" blog %2$s Jetpack', 'stream' ),
 					$blog_name,
 					( 'register' === $action ) ? esc_html__( 'connected to', 'stream' ) : esc_html__( 'disconnected from', 'stream' )
@@ -418,7 +430,7 @@ class Connector_Jetpack extends Connector {
 	/**
 	 * Track visible/enabled sharing services ( buttons )
 	 *
-	 * @param string $state
+	 * @param string $state  Service state.
 	 */
 	public function callback_sharing_get_services_state( $state ) {
 		$this->log(
@@ -430,14 +442,32 @@ class Connector_Jetpack extends Connector {
 		);
 	}
 
+	/**
+	 * Track Jetpack-specific option changes.
+	 *
+	 * @param string $option Option key.
+	 * @param string $old    Old value.
+	 * @param string $new    New value.
+	 */
 	public function callback_update_option( $option, $old, $new ) {
 		$this->check( $option, $old, $new );
 	}
 
+	/**
+	 * Track Jetpack-specific option creations.
+	 *
+	 * @param string $option Option key.
+	 * @param string $val    Value.
+	 */
 	public function callback_add_option( $option, $val ) {
 		$this->check( $option, null, $val );
 	}
 
+	/**
+	 * Track Jetpack-specific option deletions.
+	 *
+	 * @param string $option Option key.
+	 */
 	public function callback_delete_option( $option ) {
 		$this->check( $option, null, null );
 	}
@@ -453,7 +483,7 @@ class Connector_Jetpack extends Connector {
 		}
 
 		$this->log(
-			// translators: Placeholder refers to a status (e.g. "activated")
+			/* translators: %s: a status (e.g. "activated") */
 			__( 'Monitor notifications %s', 'stream' ),
 			array(
 				'status'    => $active ? esc_html__( 'activated', 'stream' ) : esc_html__( 'deactivated', 'stream' ),
@@ -467,18 +497,39 @@ class Connector_Jetpack extends Connector {
 		);
 	}
 
+	/**
+	 * Logs when user enables "post_by_email"
+	 *
+	 * @action wp_ajax_jetpack_post_by_email_enable
+	 */
 	public function callback_wp_ajax_jetpack_post_by_email_enable() {
 		$this->track_post_by_email( true );
 	}
 
+	/**
+	 * Logs when user regenerates "post_by_email"
+	 *
+	 * @action wp_ajax_jetpack_post_by_email_regenerate
+	 */
 	public function callback_wp_ajax_jetpack_post_by_email_regenerate() {
 		$this->track_post_by_email( null );
 	}
 
+	/**
+	 * Logs when user disables "post_by_email"
+	 *
+	 * @action wp_ajax_jetpack_post_by_email_disable
+	 */
 	public function callback_wp_ajax_jetpack_post_by_email_disable() {
 		$this->track_post_by_email( false );
 	}
 
+	/**
+	 * Tracks changes a user post by email status
+	 *
+	 * @param string $status Status.
+	 * @return void
+	 */
 	public function track_post_by_email( $status ) {
 		if ( true === $status ) {
 			$action = esc_html__( 'enabled', 'stream' );
@@ -491,7 +542,7 @@ class Connector_Jetpack extends Connector {
 		$user = wp_get_current_user();
 
 		$this->log(
-			// translators: Placeholders refer to a user display name, and a status (e.g. "Jane Doe", "enabled")
+			/* translators: %1$s: a user display name, %2$s: a status (e.g. "Jane Doe", "enabled") */
 			__( '%1$s %2$s Post by Email', 'stream' ),
 			array(
 				'user_displayname' => $user->display_name,
@@ -504,6 +555,13 @@ class Connector_Jetpack extends Connector {
 		);
 	}
 
+	/**
+	 * Tracks Jetpack-specific option activity.
+	 *
+	 * @param string $option     Option key.
+	 * @param string $old_value  Old value.
+	 * @param string $new_value  New value.
+	 */
 	public function check( $option, $old_value, $new_value ) {
 		if ( ! array_key_exists( $option, $this->options ) ) {
 			return;
@@ -516,7 +574,7 @@ class Connector_Jetpack extends Connector {
 			$option_title = $data['label'];
 
 			$this->log(
-				// translators: Placeholder refers to a setting name (e.g. "Language")
+				/* translators: %s: a setting name (e.g. "Language") */
 				__( '"%s" setting updated', 'stream' ),
 				compact( 'option_title', 'option', 'old_value', 'new_value' ),
 				null,
@@ -526,6 +584,12 @@ class Connector_Jetpack extends Connector {
 		}
 	}
 
+	/**
+	 * Track Jetpack-specific option activity.
+	 *
+	 * @param string $old_value  Old value.
+	 * @param string $new_value  New value.
+	 */
 	public function check_jetpack_options( $old_value, $new_value ) {
 		$options = array();
 
@@ -544,7 +608,7 @@ class Connector_Jetpack extends Connector {
 				continue;
 			}
 
-			if ( 0 === $option_value ) { // Skip updated array with updated members, we'll be logging those instead
+			if ( 0 === $option_value ) { // Skip updated array with updated members, we'll be logging those instead.
 				continue;
 			}
 
@@ -564,6 +628,13 @@ class Connector_Jetpack extends Connector {
 		}
 	}
 
+	/**
+	 * Logs Google+ profile display status
+	 *
+	 * @param string $old_value  Old status.
+	 * @param string $new_value  New status.
+	 * @return null|bool
+	 */
 	public function check_hide_gplus( $old_value, $new_value ) {
 		$status = ! is_null( $new_value );
 
@@ -572,7 +643,7 @@ class Connector_Jetpack extends Connector {
 		}
 
 		$this->log(
-			// translators: Placeholder refers to a status (e.g. "enabled")
+			/* translators: Placeholder refers to a status (e.g. "enabled") */
 			__( 'G+ profile display %s', 'stream' ),
 			array(
 				'action' => $status ? esc_html__( 'enabled', 'stream' ) : esc_html__( 'disabled', 'stream' ),
@@ -583,6 +654,13 @@ class Connector_Jetpack extends Connector {
 		);
 	}
 
+	/**
+	 * Logs if current user's Google+ account connection status
+	 *
+	 * @param string $old_value  Old status.
+	 * @param string $new_value  New status.
+	 * @return void
+	 */
 	public function check_gplus_authors( $old_value, $new_value ) {
 		unset( $old_value );
 
@@ -590,7 +668,7 @@ class Connector_Jetpack extends Connector {
 		$connected = is_array( $new_value ) && array_key_exists( $user->ID, $new_value );
 
 		$this->log(
-			// translators: Placeholders refer to a user display name, and a status (e.g. "Jane Doe", "connected")
+			/* translators: %1$s: a user display name, %2$s: a status (e.g. "Jane Doe", "connected") */
 			__( '%1$s\'s Google+ account %2$s', 'stream' ),
 			array(
 				'display_name' => $user->display_name,
@@ -603,15 +681,22 @@ class Connector_Jetpack extends Connector {
 		);
 	}
 
+	/**
+	 * Logs sharedaddy resource status.
+	 *
+	 * @param string $old_value  Old status.
+	 * @param string $new_value  New status.
+	 * @return void
+	 */
 	public function check_sharedaddy_disable_resources( $old_value, $new_value ) {
 		if ( $old_value === $new_value ) {
 			return;
 		}
 
-		$status = ! $new_value ? 'enabled' : 'disabled'; // disabled = 1
+		$status = ! $new_value ? 'enabled' : 'disabled'; // disabled = 1.
 
 		$this->log(
-			// translators: Placeholder refers to a status (e.g. "enabled")
+			/* translators: %s: a status (e.g. "enabled") */
 			__( 'Sharing CSS/JS %s', 'stream' ),
 			compact( 'status', 'old_value', 'new_value' ),
 			null,
@@ -623,7 +708,7 @@ class Connector_Jetpack extends Connector {
 	/**
 	 * Override connector log for our own Settings / Actions
 	 *
-	 * @param array $data
+	 * @param array $data  Record data.
 	 *
 	 * @return array|bool
 	 */
@@ -632,7 +717,7 @@ class Connector_Jetpack extends Connector {
 			return $data;
 		}
 
-		// Handling our Settings
+		// Handling our Settings.
 		if ( 'settings' === $data['connector'] && isset( $this->options_override[ $data['args']['option'] ] ) ) {
 			if ( isset( $data['args']['option_key'] ) ) {
 				$overrides = $this->options_override[ $data['args']['option'] ][ $data['args']['option_key'] ];
@@ -663,15 +748,21 @@ class Connector_Jetpack extends Connector {
 		return $data;
 	}
 
+	/**
+	 * Returns an option's status
+	 *
+	 * @param string $key    Option key.
+	 * @param string $value  Option value.
+	 */
 	private function get_settings_def( $key, $value = null ) {
-		// Sharing
+		// Sharing.
 		if ( 0 === strpos( $key, 'publicize_connections::' ) ) {
 			global $publicize_ui;
 
 			$name = str_replace( 'publicize_connections::', '', $key );
 
 			return array(
-				// translators: Placeholders refer to a service, and a status (e.g. "Facebook", "added")
+				/* translators: %1$s: a service, %2$s: a status (e.g. "Facebook", "added") */
 				'message' => esc_html__( '%1$s connection %2$s', 'stream' ),
 				'meta'    => array(
 					'connection' => $publicize_ui->publicize->get_service_label( $name ),
@@ -696,7 +787,7 @@ class Connector_Jetpack extends Connector {
 			}
 
 			return array(
-				// translators: Placeholder refers to a setting name (e.g. "Language")
+				/* translators: %s: a setting name (e.g. "Language") */
 				'message' => esc_html__( '"%s" setting updated', 'stream' ),
 				'meta'    => array(
 					'option_name' => $options[ $name ],

--- a/connectors/class-connector-media.php
+++ b/connectors/class-connector-media.php
@@ -1,6 +1,15 @@
 <?php
+/**
+ * Connector for Media files
+ *
+ * @package WP_Stream
+ */
+
 namespace WP_Stream;
 
+/**
+ * Class - Connector_Media
+ */
 class Connector_Media extends Connector {
 	/**
 	 * Connector slug
@@ -71,7 +80,7 @@ class Connector_Media extends Connector {
 	/**
 	 * Return the file type for an attachment which corresponds with a context label
 	 *
-	 * @param object $file_uri URI of the attachment
+	 * @param object $file_uri  URI of the attachment.
 	 *
 	 * @return string A file type which corresponds with a context label
 	 */
@@ -97,8 +106,8 @@ class Connector_Media extends Connector {
 	 *
 	 * @filter wp_stream_action_links_{connector}
 	 *
-	 * @param array  $links  Previous links registered
-	 * @param object $record Stream record
+	 * @param array  $links   Previous links registered.
+	 * @param object $record  Stream record.
 	 *
 	 * @return array Action links
 	 */
@@ -122,19 +131,19 @@ class Connector_Media extends Connector {
 	 *
 	 * @action add_attachment
 	 *
-	 * @param int $post_id
+	 * @param int $post_id  Post ID.
 	 */
 	public function callback_add_attachment( $post_id ) {
 		$post = get_post( $post_id );
 		if ( $post->post_parent ) {
-			// translators: Placeholders refer to an attachment title, and a post title (e.g. "PIC001", "Hello World")
+			/* translators: %1$s: an attachment title, %2$s: a post title (e.g. "PIC001", "Hello World") */
 			$message = _x(
 				'Attached "%1$s" to "%2$s"',
 				'1: Attachment title, 2: Parent post title',
 				'stream'
 			);
 		} else {
-			// translators: Placeholder refers to an attachment title (e.g. "PIC001")
+			/* translators: %s: an attachment title (e.g. "PIC001") */
 			$message = esc_html__( 'Added "%s" to Media library', 'stream' );
 		}
 
@@ -159,14 +168,14 @@ class Connector_Media extends Connector {
 	 *
 	 * @action edit_attachment
 	 *
-	 * @param int $post_id
+	 * @param int $post_id  Post ID.
 	 */
 	public function callback_edit_attachment( $post_id ) {
 		$post            = get_post( $post_id );
 		$name            = $post->post_title;
 		$attachment_type = $this->get_attachment_type( $post->guid );
 
-		// translators: Placeholder refers to an attachment title (e.g. "PIC001")
+		/* translators: %s: an attachment title (e.g. "PIC001") */
 		$message = esc_html__( 'Updated "%s"', 'stream' );
 
 		$this->log(
@@ -183,7 +192,7 @@ class Connector_Media extends Connector {
 	 *
 	 * @action delete_attachment
 	 *
-	 * @param int $post_id
+	 * @param int $post_id  Post ID.
 	 */
 	public function callback_delete_attachment( $post_id ) {
 		$post            = get_post( $post_id );
@@ -193,7 +202,7 @@ class Connector_Media extends Connector {
 		$url             = $post->guid;
 		$attachment_type = $this->get_attachment_type( $post->guid );
 
-		// translators: Placeholder refers to an attachment title (e.g. "PIC001")
+		/* translators: %s: an attachment title (e.g. "PIC001") */
 		$message = esc_html__( 'Deleted "%s"', 'stream' );
 
 		$this->log(
@@ -210,11 +219,11 @@ class Connector_Media extends Connector {
 	 *
 	 * @action delete_attachment
 	 *
-	 * @param string $dummy
-	 * @param string $filename
-	 * @param string $image
-	 * @param string $mime_type
-	 * @param int    $post_id
+	 * @param string $dummy      Unused.
+	 * @param string $filename   Filename.
+	 * @param string $image      Unused.
+	 * @param string $mime_type  Unused.
+	 * @param int    $post_id    Post ID.
 	 */
 	public function callback_wp_save_image_editor_file( $dummy, $filename, $image, $mime_type, $post_id ) {
 		unset( $dummy );
@@ -227,7 +236,7 @@ class Connector_Media extends Connector {
 		$attachment_type = $this->get_attachment_type( $post->guid );
 
 		$this->log(
-			// translators: Placeholder refers to an attachment title (e.g. "PIC001")
+			/* translators: Placeholder refers to an attachment title (e.g. "PIC001") */
 			__( 'Edited image "%s"', 'stream' ),
 			compact( 'name', 'filename', 'post_id' ),
 			$post_id,
@@ -236,6 +245,17 @@ class Connector_Media extends Connector {
 		);
 	}
 
+	/**
+	 * Logs updates made in the image editor upon saving
+	 *
+	 * @action delete_attachment
+	 *
+	 * @param string $dummy      Unused.
+	 * @param string $filename   Filename.
+	 * @param string $image      Unused.
+	 * @param string $mime_type  Unused.
+	 * @param int    $post_id    Post ID.
+	 */
 	public function callback_wp_save_image_file( $dummy, $filename, $image, $mime_type, $post_id ) {
 		return $this->callback_wp_save_image_editor_file( $dummy, $filename, $image, $mime_type, $post_id );
 	}

--- a/connectors/class-connector-menus.php
+++ b/connectors/class-connector-menus.php
@@ -1,6 +1,15 @@
 <?php
+/**
+ * Connector for Menus
+ *
+ * @package WP_Stream
+ */
+
 namespace WP_Stream;
 
+/**
+ * Class - Connector_Menus
+ */
 class Connector_Menus extends Connector {
 	/**
 	 * Connector slug
@@ -73,6 +82,9 @@ class Connector_Menus extends Connector {
 		return $labels;
 	}
 
+	/**
+	 * Registers connection.
+	 */
 	public function register() {
 		parent::register();
 
@@ -84,8 +96,8 @@ class Connector_Menus extends Connector {
 	 *
 	 * @filter wp_stream_action_links_{connector}
 	 *
-	 * @param  array  $links     Previous links registered
-	 * @param  object $record    Stream record
+	 * @param  array  $links   Previous links registered.
+	 * @param  object $record  Stream record.
 	 *
 	 * @return array             Action links
 	 */
@@ -107,14 +119,14 @@ class Connector_Menus extends Connector {
 	 *
 	 * @action wp_create_nav_menu
 	 *
-	 * @param int   $menu_id
-	 * @param array $menu_data
+	 * @param int   $menu_id    Menu ID.
+	 * @param array $menu_data  Menu data.
 	 */
 	public function callback_wp_create_nav_menu( $menu_id, $menu_data ) {
 		$name = $menu_data['menu-name'];
 
 		$this->log(
-			// translators: Placeholder refers to a menu name (e.g. "Primary Menu")
+			/* translators: %s: a menu name (e.g. "Primary Menu") */
 			__( 'Created new menu "%s"', 'stream' ),
 			compact( 'name', 'menu_id' ),
 			$menu_id,
@@ -128,8 +140,8 @@ class Connector_Menus extends Connector {
 	 *
 	 * @action wp_update_nav_menu
 	 *
-	 * @param int   $menu_id
-	 * @param array $menu_data
+	 * @param int   $menu_id    Menu ID.
+	 * @param array $menu_data  Menu data.
 	 */
 	public function callback_wp_update_nav_menu( $menu_id, $menu_data = array() ) {
 		if ( empty( $menu_data ) ) {
@@ -139,7 +151,7 @@ class Connector_Menus extends Connector {
 		$name = $menu_data['menu-name'];
 
 		$this->log(
-			// translators: Placeholder refers to a menu name (e.g. "Primary Menu")
+			/* translators: %s: a menu name (e.g. "Primary Menu") */
 			_x( 'Updated menu "%s"', 'Menu name', 'stream' ),
 			compact( 'name', 'menu_id', 'menu_data' ),
 			$menu_id,
@@ -153,9 +165,9 @@ class Connector_Menus extends Connector {
 	 *
 	 * @action delete_nav_menu
 	 *
-	 * @param object $term
-	 * @param int    $tt_id
-	 * @param object $deleted_term
+	 * @param object $term          Term.
+	 * @param int    $tt_id         Term ID.
+	 * @param object $deleted_term  Deleted term.
 	 */
 	public function callback_delete_nav_menu( $term, $tt_id, $deleted_term ) {
 		unset( $tt_id );
@@ -164,7 +176,7 @@ class Connector_Menus extends Connector {
 		$menu_id = $term->term_id;
 
 		$this->log(
-			// translators: Placeholder refers to a menu name (e.g. "Primary Menu")
+			/* translators: %s: a menu name (e.g. "Primary Menu") */
 			_x( 'Deleted "%s"', 'Menu name', 'stream' ),
 			compact( 'name', 'menu_id' ),
 			$menu_id,
@@ -178,11 +190,11 @@ class Connector_Menus extends Connector {
 	 *
 	 * @action update_option_theme_mods_{$stylesheet}
 	 *
-	 * @param array $old
-	 * @param array $new
+	 * @param array $old  Old theme data.
+	 * @param array $new  New theme data.
 	 */
 	public function callback_update_option_theme_mods( $old, $new ) {
-		// Disable if we're switching themes
+		// Disable if we're switching themes.
 		if ( did_action( 'after_switch_theme' ) ) {
 			return;
 		}
@@ -190,7 +202,7 @@ class Connector_Menus extends Connector {
 		$key = 'nav_menu_locations';
 
 		if ( ! isset( $new[ $key ] ) ) {
-			return; // Switching themes ?
+			return; // Switching themes ?.
 		}
 
 		if ( $old[ $key ] === $new[ $key ] ) {
@@ -212,7 +224,7 @@ class Connector_Menus extends Connector {
 			if ( empty( $new[ $key ][ $location_id ] ) ) {
 				$action  = 'unassigned';
 				$menu_id = isset( $old[ $key ][ $location_id ] ) ? $old[ $key ][ $location_id ] : 0;
-				// translators: Placeholders refer to a menu name, and a theme location (e.g. "Primary Menu", "primary_nav")
+				/* translators: %1$s: a menu name, %2$s: a theme location (e.g. "Primary Menu", "primary_nav") */
 				$message = _x(
 					'"%1$s" has been unassigned from "%2$s"',
 					'1: Menu name, 2: Theme location',
@@ -221,7 +233,7 @@ class Connector_Menus extends Connector {
 			} else {
 				$action  = 'assigned';
 				$menu_id = isset( $new[ $key ][ $location_id ] ) ? $new[ $key ][ $location_id ] : 0;
-				// translators: Placeholders refer to a menu name, and a theme location (e.g. "Primary Menu", "primary_nav")
+				/* translators: %1$s: a menu name, %2$s a theme location (e.g. "Primary Menu", "primary_nav") */
 				$message = _x(
 					'"%1$s" has been assigned to "%2$s"',
 					'1: Menu name, 2: Theme location',
@@ -232,7 +244,7 @@ class Connector_Menus extends Connector {
 			$menu = get_term( $menu_id, 'nav_menu' );
 
 			if ( ! $menu || is_wp_error( $menu ) ) {
-				continue; // This is a deleted menu
+				continue; // This is a deleted menu.
 			}
 
 			$name = $menu->name;

--- a/connectors/class-connector-mercator.php
+++ b/connectors/class-connector-mercator.php
@@ -1,7 +1,15 @@
 <?php
+/**
+ * Connector for Mercator
+ *
+ * @package WP_Stream
+ */
 
 namespace WP_Stream;
 
+/**
+ * Class - Connector_Mercator
+ */
 class Connector_Mercator extends Connector {
 	/**
 	 * Connector slug
@@ -78,8 +86,8 @@ class Connector_Mercator extends Connector {
 	 *
 	 * @filter wp_stream_action_links_{connector}
 	 *
-	 * @param array  $links
-	 * @param Record $record
+	 * @param  array  $links   Previous links registered.
+	 * @param  object $record  Stream record.
 	 *
 	 * @return array
 	 */
@@ -112,14 +120,14 @@ class Connector_Mercator extends Connector {
 	/**
 	 * Log if domain is made primary.
 	 *
-	 * @param $mapping
+	 * @param object $mapping  Mapping object.
 	 */
 	public function callback_mercator_mapping_made_primary( $mapping ) {
 		$blog_id = $mapping->get_site_id();
 		$blog    = get_site( $blog_id );
 
 		$this->log(
-			// translators: Placeholder refers to site name (e.g. "FooBar Blog")
+			/* translators: %1$s: domain alias, %2$s: site name (e.g. "FooBar Blog") */
 			_x(
 				'"%1$s" domain alias was make primary for "%2$s"',
 				'1. Domain alias 2. Site name',
@@ -138,8 +146,8 @@ class Connector_Mercator extends Connector {
 	/**
 	 * Log if domain alias is updated.
 	 *
-	 * @param $mapping
-	 * @param $old_mapping
+	 * @param object $mapping      Mapping object.
+	 * @param object $old_mapping  Old mapping object from before update.
 	 */
 	public function callback_mercator_mapping_updated( $mapping, $old_mapping ) {
 
@@ -147,7 +155,7 @@ class Connector_Mercator extends Connector {
 		$blog    = get_site( $blog_id );
 
 		$this->log(
-			// translators: Placeholder refers to site name (e.g. "FooBar Blog")
+			/* translators: %1$s: domain alias, %2$s: site name (e.g. "FooBar Blog") */
 			_x(
 				'The domain alias "%1$s" was updated to "%2$s" for site "%3$s"',
 				'1. Old Domain alias 2. Domain alias 2. Site name',
@@ -168,7 +176,7 @@ class Connector_Mercator extends Connector {
 	/**
 	 * Log if domain alias is deleted.
 	 *
-	 * @param $mapping
+	 * @param object $mapping  Mapping of deleted alias.
 	 */
 	public function callback_mercator_mapping_deleted( $mapping ) {
 
@@ -176,7 +184,7 @@ class Connector_Mercator extends Connector {
 		$blog    = get_site( $blog_id );
 
 		$this->log(
-			// translators: Placeholder refers to site name (e.g. "FooBar Blog")
+			/* translators: %1$s: domain alias, %2$s: site name (e.g. "FooBar Blog") */
 			_x(
 				'"%1$s" domain alias was deleted for "%2$s"',
 				'1. Domain alias 2. Site name',
@@ -196,14 +204,14 @@ class Connector_Mercator extends Connector {
 	/**
 	 * Log if domain alias is created.
 	 *
-	 * @param $mapping
+	 * @param object $mapping  Mapping object.
 	 */
 	public function callback_mercator_mapping_created( $mapping ) {
 		$blog_id = $mapping->get_site_id();
 		$blog    = get_site( $blog_id );
 
 		$this->log(
-			// translators: Placeholder refers to site name (e.g. "FooBar Blog")
+			/* translators: %1$s: domain alias, %2$s: site name (e.g. "FooBar Blog") */
 			_x(
 				'"%1$s" domain alias was created for "%2$s"',
 				'1. Domain alias 2. Site name',

--- a/connectors/class-connector-posts.php
+++ b/connectors/class-connector-posts.php
@@ -1,6 +1,15 @@
 <?php
+/**
+ * Connector for Posts
+ *
+ * @package WP_Stream
+ */
+
 namespace WP_Stream;
 
+/**
+ * Class - Connector_Posts
+ */
 class Connector_Posts extends Connector {
 	/**
 	 * Connector slug
@@ -71,8 +80,8 @@ class Connector_Posts extends Connector {
 	 *
 	 * @filter wp_stream_action_links_{connector}
 	 *
-	 * @param array  $links   Previous links registered
-	 * @param Record $record Stream record
+	 * @param array  $links   Previous links registered.
+	 * @param Record $record  Stream record.
 	 *
 	 * @return array Action links
 	 */
@@ -105,12 +114,12 @@ class Connector_Posts extends Connector {
 					sprintf( 'delete-post_%d', $post->ID )
 				);
 
-				// translators: Placeholder refers to a post type singular name (e.g. "Post")
+				/* translators: %s: a post type singular name (e.g. "Post") */
 				$links[ sprintf( esc_html_x( 'Restore %s', 'Post type singular name', 'stream' ), $post_type_name ) ] = $untrash;
-				// translators: Placeholder refers to a post type singular name (e.g. "Post")
+				/* translators: %s: a post type singular name (e.g. "Post") */
 				$links[ sprintf( esc_html_x( 'Delete %s Permenantly', 'Post type singular name', 'stream' ), $post_type_name ) ] = $delete;
 			} else {
-				// translators: Placeholder refers to a post type singular name (e.g. "Post")
+				/* translators: %s a post type singular name (e.g. "Post") */
 				$links[ sprintf( esc_html_x( 'Edit %s', 'Post type singular name', 'stream' ), $post_type_name ) ] = get_edit_post_link( $post->ID );
 
 				$view_link = get_permalink( $post->ID );
@@ -135,8 +144,8 @@ class Connector_Posts extends Connector {
 	 *
 	 * @action registered_post_type
 	 *
-	 * @param string $post_type Post type slug
-	 * @param array  $args      Arguments used to register the post type
+	 * @param string $post_type Post type slug.
+	 * @param array  $args      Arguments used to register the post type.
 	 */
 	public function registered_post_type( $post_type, $args ) {
 		unset( $args );
@@ -152,9 +161,9 @@ class Connector_Posts extends Connector {
 	 *
 	 * @action transition_post_status
 	 *
-	 * @param mixed    $new
-	 * @param mixed    $old
-	 * @param \WP_Post $post
+	 * @param mixed    $new  New status.
+	 * @param mixed    $old  Old status.
+	 * @param \WP_Post $post Post object.
 	 */
 	public function callback_transition_post_status( $new, $old, $post ) {
 		if ( in_array( $post->post_type, $this->get_excluded_post_types(), true ) ) {
@@ -166,14 +175,14 @@ class Connector_Posts extends Connector {
 		} elseif ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return;
 		} elseif ( 'draft' === $new && 'publish' === $old ) {
-			// translators: Placeholders refer to a post title, and a post type singular name (e.g. "Hello World", "Post")
+			/* translators: %1$s: a post title, %2$s: a post type singular name (e.g. "Hello World", "Post") */
 			$summary = _x(
 				'"%1$s" %2$s unpublished',
 				'1: Post title, 2: Post type singular name',
 				'stream'
 			);
 		} elseif ( 'trash' === $old && 'trash' !== $new ) {
-			// translators: Placeholders refer to a post title, and a post type singular name (e.g. "Hello World", "Post")
+			/* translators: %1$s: a post title, %2$s: a post type singular name (e.g. "Hello World", "Post") */
 			$summary = _x(
 				'"%1$s" %2$s restored from trash',
 				'1: Post title, 2: Post type singular name',
@@ -181,56 +190,56 @@ class Connector_Posts extends Connector {
 			);
 			$action  = 'untrashed';
 		} elseif ( 'draft' === $new && 'draft' === $old ) {
-			// translators: Placeholders refer to a post title, and a post type singular name (e.g. "Hello World", "Post")
+			/* translators: %1$s: a post title, %2$s: a post type singular name (e.g. "Hello World", "Post") */
 			$summary = _x(
 				'"%1$s" %2$s draft saved',
 				'1: Post title, 2: Post type singular name',
 				'stream'
 			);
 		} elseif ( 'publish' === $new && 'draft' === $old ) {
-			// translators: Placeholders refer to a post title, and a post type singular name (e.g. "Hello World", "Post")
+			/* translators: %1$s: a post title, %2$s: a post type singular name (e.g. "Hello World", "Post") */
 			$summary = _x(
 				'"%1$s" %2$s published',
 				'1: Post title, 2: Post type singular name',
 				'stream'
 			);
 		} elseif ( 'draft' === $new ) {
-			// translators: Placeholders refer to a post title, and a post type singular name (e.g. "Hello World", "Post")
+			/* translators: %1$s: a post title, %2$s a post type singular name (e.g. "Hello World", "Post") */
 			$summary = _x(
 				'"%1$s" %2$s drafted',
 				'1: Post title, 2: Post type singular name',
 				'stream'
 			);
 		} elseif ( 'pending' === $new ) {
-			// translators: Placeholders refer to a post title, and a post type singular name (e.g. "Hello World", "Post")
+			/* translators: %1$s: a post title, %2$s: a post type singular name (e.g. "Hello World", "Post") */
 			$summary = _x(
 				'"%1$s" %2$s pending review',
 				'1: Post title, 2: Post type singular name',
 				'stream'
 			);
 		} elseif ( 'future' === $new ) {
-			// translators: Placeholders refer to a post title, and a post type singular name (e.g. "Hello World", "Post")
+			/* translators: %1$s: a post title, %2$s: a post type singular name (e.g. "Hello World", "Post") */
 			$summary = _x(
 				'"%1$s" %2$s scheduled for %3$s',
 				'1: Post title, 2: Post type singular name, 3: Scheduled post date',
 				'stream'
 			);
 		} elseif ( 'future' === $old && 'publish' === $new ) {
-			// translators: Placeholders refer to a post title, and a post type singular name (e.g. "Hello World", "Post")
+			/* translators: %1$s: a post title, %2$s: a post type singular name (e.g. "Hello World", "Post") */
 			$summary = _x(
 				'"%1$s" scheduled %2$s published',
 				'1: Post title, 2: Post type singular name',
 				'stream'
 			);
 		} elseif ( 'private' === $new ) {
-			// translators: Placeholders refer to a post title, and a post type singular name (e.g. "Hello World", "Post")
+			/* translators: %1$s: a post title, %2$s: a post type singular name (e.g. "Hello World", "Post") */
 			$summary = _x(
 				'"%1$s" %2$s privately published',
 				'1: Post title, 2: Post type singular name',
 				'stream'
 			);
 		} elseif ( 'trash' === $new ) {
-			// translators: Placeholders refer to a post title, and a post type singular name (e.g. "Hello World", "Post")
+			/* translators: %1$s: a post title, %2$s: a post type singular name (e.g. "Hello World", "Post") */
 			$summary = _x(
 				'"%1$s" %2$s trashed',
 				'1: Post title, 2: Post type singular name',
@@ -238,7 +247,7 @@ class Connector_Posts extends Connector {
 			);
 			$action  = 'trashed';
 		} else {
-			// translators: Placeholders refer to a post title, and a post type singular name (e.g. "Hello World", "Post")
+			/* translators: %1$s: a post title, %2$s: a post type singular name (e.g. "Hello World", "Post") */
 			$summary = _x(
 				'"%1$s" %2$s updated',
 				'1: Post title, 2: Post type singular name',
@@ -262,7 +271,7 @@ class Connector_Posts extends Connector {
 					'post_type'      => 'revision',
 					'post_status'    => 'inherit',
 					'post_parent'    => $post->ID,
-					'posts_per_page' => 1, // VIP safe
+					'posts_per_page' => 1, // VIP safe.
 					'orderby'        => 'post_date',
 					'order'          => 'DESC',
 				)
@@ -298,17 +307,17 @@ class Connector_Posts extends Connector {
 	 *
 	 * @action deleted_post
 	 *
-	 * $param integer $post_id
+	 * @param integer $post_id  Post ID.
 	 */
 	public function callback_deleted_post( $post_id ) {
 		$post = get_post( $post_id );
 
-		// We check if post is an instance of WP_Post as it doesn't always resolve in unit testing
+		// We check if post is an instance of WP_Post as it doesn't always resolve in unit testing.
 		if ( ! ( $post instanceof \WP_Post ) || in_array( $post->post_type, $this->get_excluded_post_types(), true ) ) {
 			return;
 		}
 
-		// Ignore auto-drafts that are deleted by the system, see issue-293
+		// Ignore auto-drafts that are deleted by the system, see issue-293.
 		if ( 'auto-draft' === $post->post_status ) {
 			return;
 		}
@@ -316,7 +325,7 @@ class Connector_Posts extends Connector {
 		$post_type_name = strtolower( $this->get_post_type_name( $post->post_type ) );
 
 		$this->log(
-			// translators: Placeholders refer to a post title, and a post type singular name (e.g. "Hello World", "Post")
+			/* translators: %1$s: a post title, %2$s: a post type singular name (e.g. "Hello World", "Post") */
 			_x(
 				'"%1$s" %2$s deleted from trash',
 				'1: Post title, 2: Post type singular name',
@@ -351,12 +360,12 @@ class Connector_Posts extends Connector {
 	/**
 	 * Gets the singular post type label
 	 *
-	 * @param string $post_type_slug
+	 * @param string $post_type_slug  Post type slug.
 	 *
 	 * @return string Post type label
 	 */
 	public function get_post_type_name( $post_type_slug ) {
-		$name = esc_html__( 'Post', 'stream' ); // Default
+		$name = esc_html__( 'Post', 'stream' ); // Default.
 
 		if ( post_type_exists( $post_type_slug ) ) {
 			$post_type = get_post_type_object( $post_type_slug );
@@ -369,8 +378,8 @@ class Connector_Posts extends Connector {
 	/**
 	 * Get an adjacent post revision ID
 	 *
-	 * @param int  $revision_id
-	 * @param bool $previous
+	 * @param int  $revision_id  Revision ID.
+	 * @param bool $previous     Has there been any revision before this one?.
 	 *
 	 * @return int $revision_id
 	 */

--- a/connectors/class-connector-settings.php
+++ b/connectors/class-connector-settings.php
@@ -1,6 +1,15 @@
 <?php
+/**
+ * Connector for Settings
+ *
+ * @package WP_Stream
+ */
+
 namespace WP_Stream;
 
+/**
+ * Class - Connector_Settings
+ */
 class Connector_Settings extends Connector {
 	/**
 	 * Prefix for the highlight URL hash
@@ -97,7 +106,7 @@ class Connector_Settings extends Connector {
 		parent::register();
 
 		$this->labels = array(
-			// General
+			// General.
 			'blogname'                      => esc_html__( 'Site Title', 'stream' ),
 			'blogdescription'               => esc_html__( 'Tagline', 'stream' ),
 			'gmt_offset'                    => esc_html__( 'Timezone', 'stream' ),
@@ -111,7 +120,7 @@ class Connector_Settings extends Connector {
 			'date_format'                   => esc_html__( 'Date Format', 'stream' ),
 			'time_format'                   => esc_html__( 'Time Format', 'stream' ),
 			'start_of_week'                 => esc_html__( 'Week Starts On', 'stream' ),
-			// Writing
+			// Writing.
 			'use_smilies'                   => esc_html__( 'Formatting', 'stream' ),
 			'use_balanceTags'               => esc_html__( 'Formatting', 'stream' ),
 			'default_category'              => esc_html__( 'Default Post Category', 'stream' ),
@@ -122,7 +131,7 @@ class Connector_Settings extends Connector {
 			'default_email_category'        => esc_html__( 'Default Mail Category', 'stream' ),
 			'default_link_category'         => esc_html__( 'Default Link Category', 'stream' ),
 			'ping_sites'                    => esc_html__( 'Update Services', 'stream' ),
-			// Reading
+			// Reading.
 			'show_on_front'                 => esc_html__( 'Front page displays', 'stream' ),
 			'page_on_front'                 => esc_html__( 'Front page displays', 'stream' ),
 			'page_for_posts'                => esc_html__( 'Front page displays', 'stream' ),
@@ -130,7 +139,7 @@ class Connector_Settings extends Connector {
 			'posts_per_rss'                 => esc_html__( 'Syndication feeds show the most recent', 'stream' ),
 			'rss_use_excerpt'               => esc_html__( 'For each article in a feed, show', 'stream' ),
 			'blog_public'                   => esc_html__( 'Search Engine Visibility', 'stream' ),
-			// Discussion
+			// Discussion.
 			'default_pingback_flag'         => esc_html__( 'Default article settings', 'stream' ),
 			'default_ping_status'           => esc_html__( 'Default article settings', 'stream' ),
 			'default_comment_status'        => esc_html__( 'Default article settings', 'stream' ),
@@ -154,7 +163,7 @@ class Connector_Settings extends Connector {
 			'show_avatars'                  => esc_html__( 'Show Avatars', 'stream' ),
 			'avatar_rating'                 => esc_html__( 'Maximum Rating', 'stream' ),
 			'avatar_default'                => esc_html__( 'Default Avatar', 'stream' ),
-			// Media
+			// Media.
 			'thumbnail_size_w'              => esc_html__( 'Thumbnail size', 'stream' ),
 			'thumbnail_size_h'              => esc_html__( 'Thumbnail size', 'stream' ),
 			'thumbnail_crop'                => esc_html__( 'Thumbnail size', 'stream' ),
@@ -163,11 +172,11 @@ class Connector_Settings extends Connector {
 			'large_size_w'                  => esc_html__( 'Large size', 'stream' ),
 			'large_size_h'                  => esc_html__( 'Large size', 'stream' ),
 			'uploads_use_yearmonth_folders' => esc_html__( 'Uploading Files', 'stream' ),
-			// Permalinks
+			// Permalinks.
 			'permalink_structure'           => esc_html__( 'Permalink Settings', 'stream' ),
 			'category_base'                 => esc_html__( 'Category base', 'stream' ),
 			'tag_base'                      => esc_html__( 'Tag base', 'stream' ),
-			// Network
+			// Network.
 			'registrationnotification'      => esc_html__( 'Registration notification', 'stream' ),
 			'registration'                  => esc_html__( 'Allow new registrations', 'stream' ),
 			'add_new_users'                 => esc_html__( 'Add New Users', 'stream' ),
@@ -191,11 +200,11 @@ class Connector_Settings extends Connector {
 			'WPLANG'                        => esc_html__( 'Network Language', 'stream' ),
 			'blog_count'                    => esc_html__( 'Blog Count', 'stream' ),
 			'user_count'                    => esc_html__( 'User Count', 'stream' ),
-			// Other
+			// Other.
 			'wp_stream_db'                  => esc_html__( 'Stream Database Version', 'stream' ),
 		);
 
-		// These option labels are special and need to change based on multisite context
+		// These option labels are special and need to change based on multisite context.
 		if ( is_network_admin() ) {
 			$this->labels['admin_email']     = esc_html__( 'Network Admin Email', 'stream' );
 			$this->labels['new_admin_email'] = esc_html__( 'Network Admin Email', 'stream' );
@@ -207,10 +216,12 @@ class Connector_Settings extends Connector {
 	}
 
 	/**
+	 * Logs changes to the theme modifications.
+	 *
 	 * @action update_option_theme_mods_{name}
 	 *
-	 * @param mixed $old_value
-	 * @param mixed $new_value
+	 * @param mixed $old_value  Old setting value.
+	 * @param mixed $new_value  New setting value.
 	 */
 	public function log_theme_modification( $old_value, $new_value ) {
 		$this->callback_updated_option( 'theme_mods', $old_value, $new_value );
@@ -272,8 +283,8 @@ class Connector_Settings extends Connector {
 	/**
 	 * Return context by option name and key
 	 *
-	 * @param string $option_name
-	 * @param string $key
+	 * @param string $option_name  Option name.
+	 * @param string $key          Option key.
 	 *
 	 * @return string Context slug
 	 */
@@ -308,8 +319,8 @@ class Connector_Settings extends Connector {
 	/**
 	 * Find out if the option key should be ignored and not logged
 	 *
-	 * @param string $option_name
-	 * @param string $key
+	 * @param string $option_name  Option name.
+	 * @param string $key          Option key.
 	 *
 	 * @return bool Whether option key is ignored or not
 	 */
@@ -331,7 +342,7 @@ class Connector_Settings extends Connector {
 	/**
 	 * Find out if the option should be ignored and not logged
 	 *
-	 * @param string $option_name
+	 * @param string $option_name  Option name.
 	 *
 	 * @return bool Whether the option is ignored or not
 	 */
@@ -356,7 +367,7 @@ class Connector_Settings extends Connector {
 	/**
 	 * Find out if array keys in the option should be logged separately
 	 *
-	 * @param mixed $value
+	 * @param mixed $value  Option value.
 	 *
 	 * @return bool Whether the option should be treated as a group
 	 */
@@ -375,7 +386,7 @@ class Connector_Settings extends Connector {
 	/**
 	 * Return translated labels for all default Settings fields found in WordPress.
 	 *
-	 * @param string $field_key
+	 * @param string $field_key  Field key.
 	 *
 	 * @return array Field label translations
 	 */
@@ -400,29 +411,29 @@ class Connector_Settings extends Connector {
 	/**
 	 * Return translated labels for all serialized Settings found in WordPress.
 	 *
-	 * @param string $option_name
-	 * @param string $field_key
+	 * @param string $option_name  Option name.
+	 * @param string $field_key    Field key.
 	 *
 	 * @return string Field key translation or key itself if not found
 	 */
 	public function get_serialized_field_label( $option_name, $field_key ) {
 		$labels = array(
 			'theme_mods' => array(
-				// Custom Background
+				// Custom Background.
 				'background_image'        => esc_html__( 'Background Image', 'stream' ),
 				'background_position_x'   => esc_html__( 'Background Position', 'stream' ),
 				'background_repeat'       => esc_html__( 'Background Repeat', 'stream' ),
 				'background_attachment'   => esc_html__( 'Background Attachment', 'stream' ),
 				'background_color'        => esc_html__( 'Background Color', 'stream' ),
-				// Custom Header
+				// Custom Header.
 				'header_image'            => esc_html__( 'Header Image', 'stream' ),
 				'header_textcolor'        => esc_html__( 'Text Color', 'stream' ),
 				'header_background_color' => esc_html__( 'Header and Sidebar Background Color', 'stream' ),
-				// Featured Content
+				// Featured Content.
 				'featured_content_layout' => esc_html__( 'Layout', 'stream' ),
-				// Custom Sidebar
+				// Custom Sidebar.
 				'sidebar_textcolor'       => esc_html__( 'Header and Sidebar Text Color', 'stream' ),
-				// Custom Colors
+				// Custom Colors.
 				'color_scheme'            => esc_html__( 'Color Scheme', 'stream' ),
 				'main_text_color'         => esc_html__( 'Main Text Color', 'stream' ),
 				'secondary_text_color'    => esc_html__( 'Secondary Text Color', 'stream' ),
@@ -451,8 +462,8 @@ class Connector_Settings extends Connector {
 	 *
 	 * @filter wp_stream_action_links_{connector}
 	 *
-	 * @param array  $links   Previous links registered
-	 * @param Record $record Stream record
+	 * @param array  $links   Previous links registered.
+	 * @param Record $record  Stream record.
 	 *
 	 * @return array             Action links
 	 */
@@ -544,7 +555,7 @@ class Connector_Settings extends Connector {
 			);
 
 			if ( ! empty( $applicable_rules ) ) {
-				// The first applicable rule wins
+				// The first applicable rule wins.
 				$rule         = array_shift( $applicable_rules );
 				$menu_slug    = $rule['menu_slug'];
 				$submenu_slug = ( is_object( $rule['submenu_slug'] ) && $rule['submenu_slug'] instanceof Closure ? $rule['submenu_slug']( $record ) : $rule['submenu_slug'] );
@@ -567,7 +578,7 @@ class Connector_Settings extends Connector {
 						$url        = apply_filters( 'wp_stream_action_link_url', $url, $record );
 						$field_name = $record->get_meta( 'option_key', true );
 
-						// translators: Placeholder refers to a context (e.g. "Editor")
+						/* translators: %s: a context (e.g. "Editor") */
 						$text = sprintf( esc_html__( 'Edit %s Settings', 'stream' ), $context_labels[ $record->context ] );
 
 						if ( '' === $field_name ) {
@@ -592,9 +603,9 @@ class Connector_Settings extends Connector {
 	 *
 	 * @action update_option
 	 *
-	 * @param string $option
-	 * @param mixed  $old_value
-	 * @param mixed  $value
+	 * @param string $option     Option name.
+	 * @param mixed  $value      Option new value.
+	 * @param mixed  $old_value  Option old value.
 	 */
 	public function callback_update_option( $option, $value, $old_value ) {
 		if ( ( defined( '\WP_CLI' ) && \WP_CLI || did_action( 'customize_save' ) ) && array_key_exists( $option, $this->labels ) ) {
@@ -607,7 +618,7 @@ class Connector_Settings extends Connector {
 	 *
 	 * @action whitelist_options
 	 *
-	 * @param array $options
+	 * @param array $options  Options.
 	 *
 	 * @return array
 	 */
@@ -622,8 +633,8 @@ class Connector_Settings extends Connector {
 	 *
 	 * @action update_option_permalink_structure
 	 *
-	 * @param mixed $old_value
-	 * @param mixed $value
+	 * @param mixed $old_value  Option old value.
+	 * @param mixed $value      Option new value.
 	 */
 	public function callback_update_option_permalink_structure( $old_value, $value ) {
 		$this->callback_updated_option( 'permalink_structure', $old_value, $value );
@@ -634,9 +645,9 @@ class Connector_Settings extends Connector {
 	 *
 	 * @action update_site_option
 	 *
-	 * @param string $option
-	 * @param mixed  $old_value
-	 * @param mixed  $value
+	 * @param string $option     Option name.
+	 * @param mixed  $value      Option new value.
+	 * @param mixed  $old_value  Option old value.
 	 */
 	public function callback_update_site_option( $option, $value, $old_value ) {
 		$this->callback_updated_option( $option, $value, $old_value );
@@ -647,8 +658,8 @@ class Connector_Settings extends Connector {
 	 *
 	 * @action update_option_category_base
 	 *
-	 * @param mixed $old_value
-	 * @param mixed $value
+	 * @param mixed $old_value  Option old value.
+	 * @param mixed $value      Option new value.
 	 */
 	public function callback_update_option_category_base( $old_value, $value ) {
 		$this->callback_updated_option( 'category_base', $old_value, $value );
@@ -659,8 +670,8 @@ class Connector_Settings extends Connector {
 	 *
 	 * @action update_option_tag_base
 	 *
-	 * @param mixed $old_value
-	 * @param mixed $value
+	 * @param mixed $old_value  Option old value.
+	 * @param mixed $value      Option new value.
 	 */
 	public function callback_update_option_tag_base( $old_value, $value ) {
 		$this->callback_updated_option( 'tag_base', $old_value, $value );
@@ -671,9 +682,9 @@ class Connector_Settings extends Connector {
 	 *
 	 * @action updated_option
 	 *
-	 * @param string $option
-	 * @param mixed  $old_value
-	 * @param mixed  $value
+	 * @param string $option     Option name.
+	 * @param mixed  $old_value  Option old value.
+	 * @param mixed  $value      Option new value.
 	 */
 	public function callback_updated_option( $option, $old_value, $value ) {
 		global $whitelist_options, $new_whitelist_options;
@@ -732,7 +743,7 @@ class Connector_Settings extends Connector {
 
 		foreach ( $changed_options as $properties ) {
 			$this->log(
-				// translators: Placeholder refers to a setting name (e.g. "Language")
+				/* translators: %s: a setting name (e.g. "Language") */
 				__( '"%s" setting was updated', 'stream' ),
 				$properties,
 				null,
@@ -752,7 +763,7 @@ class Connector_Settings extends Connector {
 		<script>
 			(function ($) {
 				$(function () {
-					var hashPrefix = <?php echo wp_stream_json_encode( self::HIGHLIGHT_FIELD_URL_HASH_PREFIX ); // xss ok ?>,
+					var hashPrefix = <?php echo wp_stream_json_encode( self::HIGHLIGHT_FIELD_URL_HASH_PREFIX ); // xss ok. ?>,
 						hashFieldName = "",
 						fieldNames = [],
 						$select2Choices = {},
@@ -818,9 +829,9 @@ class Connector_Settings extends Connector {
 	 * @deprecated Use is_option_group()
 	 * @see is_option_group()
 	 *
-	 * @param string $key
-	 * @param mixed  $old_value
-	 * @param mixed  $value
+	 * @param string $key        Key.
+	 * @param mixed  $old_value  Old value.
+	 * @param mixed  $value      New value.
 	 *
 	 * @return bool Whether the option should be treated as a group
 	 */
@@ -832,7 +843,7 @@ class Connector_Settings extends Connector {
 	/**
 	 * Sanitize values, so that we don't store complex data, such as arrays or objects
 	 *
-	 * @param mixed $value
+	 * @param mixed $value  Raw input value.
 	 * @return string
 	 */
 	public function sanitize_value( $value ) {

--- a/connectors/class-connector-taxonomies.php
+++ b/connectors/class-connector-taxonomies.php
@@ -1,6 +1,15 @@
 <?php
+/**
+ * Connector for Taxonomies
+ *
+ * @package WP_Stream
+ */
+
 namespace WP_Stream;
 
+/**
+ * Class - Connector_Taxonomies
+ */
 class Connector_Taxonomies extends Connector {
 	/**
 	 * Connector slug
@@ -86,13 +95,14 @@ class Connector_Taxonomies extends Connector {
 	 *
 	 * @filter wp_stream_action_links_{connector}
 	 *
-	 * @param array  $links  Previous links registered
-	 * @param Record $record Stream record
+	 * @param array  $links   Previous links registered.
+	 * @param Record $record  Stream record.
 	 *
 	 * @return array Action links
 	 */
 	public function action_links( $links, $record ) {
-		$term = get_term_by( 'term_taxonomy_id', $record->object_id, $record->context ); // wpcom_vip_get_term_by() does not indicate support for `term_taxonomy_id`
+		// wpcom_vip_get_term_by() does not indicate support for `term_taxonomy_id`.
+		$term = get_term_by( 'term_taxonomy_id', $record->object_id, $record->context );
 		if ( $record->object_id && 'deleted' !== $record->action && $term ) {
 			if ( ! is_wp_error( $term ) ) {
 				$tax_obj   = get_taxonomy( $term->taxonomy );
@@ -104,7 +114,7 @@ class Connector_Taxonomies extends Connector {
 
 				$term_id = empty( $term_id ) ? $term->term_id : $term_id;
 
-				// translators: Placeholder refers to a term singular name (e.g. "Tag")
+				/* translators: %s a term singular name (e.g. "Tag") */
 				$links[ sprintf( _x( 'Edit %s', 'Term singular name', 'stream' ), $tax_label ) ] = get_edit_term_link( $term_id, $term->taxonomy );
 				$links[ esc_html__( 'View', 'stream' ) ] = wp_stream_is_vip() ? \wpcom_vip_get_term_link( $term_id, $term->taxonomy ) : get_term_link( $term_id, $term->taxonomy );
 			}
@@ -118,9 +128,9 @@ class Connector_Taxonomies extends Connector {
 	 *
 	 * @action registered_taxonomy
 	 *
-	 * @param string       $taxonomy          Taxonomy slug
-	 * @param array|string $object_type Object type or array of object types
-	 * @param array|string $args        Array or string of taxonomy registration arguments
+	 * @param string       $taxonomy     Taxonomy slug.
+	 * @param array|string $object_type  Object type or array of object types.
+	 * @param array|string $args         Array or string of taxonomy registration arguments.
 	 */
 	public function registered_taxonomy( $taxonomy, $object_type, $args ) {
 		unset( $object_type );
@@ -138,9 +148,9 @@ class Connector_Taxonomies extends Connector {
 	 *
 	 * @action created_term
 	 *
-	 * @param integer $term_id
-	 * @param integer $tt_id
-	 * @param string  $taxonomy
+	 * @param integer $term_id   Term ID.
+	 * @param integer $tt_id     Taxonomy term ID.
+	 * @param string  $taxonomy  Taxonomy name.
 	 */
 	public function callback_created_term( $term_id, $tt_id, $taxonomy ) {
 		if ( in_array( $taxonomy, $this->get_excluded_taxonomies(), true ) ) {
@@ -153,7 +163,7 @@ class Connector_Taxonomies extends Connector {
 		$term_parent    = $term->parent;
 
 		$this->log(
-			// translators: Placeholders refer to a term name, and a taxonomy singular label (e.g. "Tags", "Genre")
+			/* translators: %1$s: a term name, %2$s: a taxonomy singular label (e.g. "Tags", "Genre") */
 			_x(
 				'"%1$s" %2$s created',
 				'1: Term name, 2: Taxonomy singular label',
@@ -171,10 +181,10 @@ class Connector_Taxonomies extends Connector {
 	 *
 	 * @action delete_term
 	 *
-	 * @param integer $term_id
-	 * @param integer $tt_id
-	 * @param string  $taxonomy
-	 * @param object  $deleted_term
+	 * @param integer $term_id       Term ID.
+	 * @param integer $tt_id         Taxonomy term ID.
+	 * @param string  $taxonomy      Taxonomy name.
+	 * @param object  $deleted_term  Deleted term object.
 	 */
 	public function callback_delete_term( $term_id, $tt_id, $taxonomy, $deleted_term ) {
 		if ( in_array( $taxonomy, $this->get_excluded_taxonomies(), true ) ) {
@@ -186,7 +196,7 @@ class Connector_Taxonomies extends Connector {
 		$taxonomy_label = strtolower( $this->context_labels[ $taxonomy ] );
 
 		$this->log(
-			// translators: Placeholders refer to a term name, and a taxonomy singular label (e.g. "Tags", "Genre")
+			/* translators: %1$s: a term name, %2$s: a taxonomy singular label (e.g. "Tags", "Genre") */
 			_x(
 				'"%1$s" %2$s deleted',
 				'1: Term name, 2: Taxonomy singular label',
@@ -204,15 +214,24 @@ class Connector_Taxonomies extends Connector {
 	 *
 	 * @action edit_term
 	 *
-	 * @param integer $term_id
-	 * @param integer $tt_id
-	 * @param string  $taxonomy
+	 * @param integer $term_id   Term ID.
+	 * @param integer $tt_id     Taxonomy term ID.
+	 * @param string  $taxonomy  Taxonomy name.
 	 */
 	public function callback_edit_term( $term_id, $tt_id, $taxonomy ) {
 		unset( $tt_id );
 		$this->cached_term_before_update = get_term( $term_id, $taxonomy );
 	}
 
+	/**
+	 * Tracks updated of taxonomy terms
+	 *
+	 * @action edited_term
+	 *
+	 * @param integer $term_id   Term ID.
+	 * @param integer $tt_id     Taxonomy term ID.
+	 * @param string  $taxonomy  Taxonomy name.
+	 */
 	public function callback_edited_term( $term_id, $tt_id, $taxonomy ) {
 		if ( in_array( $taxonomy, $this->get_excluded_taxonomies(), true ) ) {
 			return;
@@ -229,7 +248,7 @@ class Connector_Taxonomies extends Connector {
 		$term_parent    = $term->parent;
 
 		$this->log(
-			// translators: Placeholders refer to a term name, and a taxonomy singular label (e.g. "Tags", "Genre")
+			/* translators: %1$s: a term name, %2$s: a taxonomy singular label (e.g. "Tags", "Genre") */
 			_x(
 				'"%1$s" %2$s updated',
 				'1: Term name, 2: Taxonomy singular label',

--- a/connectors/class-connector-user-switching.php
+++ b/connectors/class-connector-user-switching.php
@@ -1,6 +1,15 @@
 <?php
+/**
+ * Connector for User-Switching
+ *
+ * @package WP_Stream
+ */
+
 namespace WP_Stream;
 
+/**
+ * Class - Connector_User_Switching
+ */
 class Connector_User_Switching extends Connector {
 
 	/**
@@ -100,8 +109,8 @@ class Connector_User_Switching extends Connector {
 	 * This unhooks the Users connector's login and logout actions so they don't appear when a user switches
 	 * user with the User Switching plugin.
 	 *
-	 * @param array      $labels     All registered connector labels
-	 * @param Connectors $connectors The Connectors object instance
+	 * @param array      $labels     All registered connector labels.
+	 * @param Connectors $connectors The Connectors object instance.
 	 */
 	public function callback_wp_stream_after_connectors_registration( array $labels, Connectors $connectors ) {
 		$action = wp_stream_filter_input( INPUT_GET, 'action' );
@@ -144,7 +153,7 @@ class Connector_User_Switching extends Connector {
 
 		$user     = get_userdata( $user_id );
 		$old_user = get_userdata( $old_user_id );
-		// translators: Placeholders refer to a user display name, and a username (e.g. "Jane Doe", "administrator")
+		/* translators: %1$s: a user display name, %2$s: a username (e.g. "Jane Doe", "administrator") */
 		$message = _x(
 			'Switched user to %1$s (%2$s)',
 			'1: User display name, 2: User login',
@@ -175,7 +184,7 @@ class Connector_User_Switching extends Connector {
 	public function callback_switch_back_user( $user_id, $old_user_id ) {
 
 		$user = get_userdata( $user_id );
-		// translators: Placeholders refer to a user display name, and a username (e.g. "Jane Doe", "administrator")
+		/* translators: Placeholders refer to a user display name, and a username (e.g. "Jane Doe", "administrator") */
 		$message = _x(
 			'Switched back to %1$s (%2$s)',
 			'1: User display name, 2: User login',
@@ -229,8 +238,8 @@ class Connector_User_Switching extends Connector {
 	/**
 	 * Unhook the requested action from the Users connector.
 	 *
-	 * @param Connectors $connectors The Connectors instance
-	 * @param string     $action     The name of the action to unhook
+	 * @param Connectors $connectors The Connectors instance.
+	 * @param string     $action     The name of the action to unhook.
 	 */
 	protected function unhook_user_action( Connectors $connectors, $action ) {
 		foreach ( $connectors->connectors as $connector ) {

--- a/connectors/class-connector-users.php
+++ b/connectors/class-connector-users.php
@@ -1,6 +1,15 @@
 <?php
+/**
+ * Connector for users
+ *
+ * @package WP_Stream
+ */
+
 namespace WP_Stream;
 
+/**
+ * Class - Connector_Users
+ */
 class Connector_Users extends Connector {
 
 	/**
@@ -12,8 +21,10 @@ class Connector_Users extends Connector {
 
 	/**
 	 * Stores users object before the user being deleted.
+	 *
+	 * @var WP_User
 	 */
-	protected $_users_object_pre_deleted = array();
+	protected $_users_object_pre_deleted = array(); // @codingStandardsIgnoreLine
 
 	/**
 	 * Actions registered for this connector
@@ -79,8 +90,8 @@ class Connector_Users extends Connector {
 	 *
 	 * @filter wp_stream_action_links_{connector}
 	 *
-	 * @param array  $links   Previous links registered
-	 * @param Record $record Stream record
+	 * @param array  $links   Previous links registered.
+	 * @param Record $record  Stream record.
 	 *
 	 * @return array Action links
 	 */
@@ -98,7 +109,7 @@ class Connector_Users extends Connector {
 	/**
 	 * Get an array of role lables assigned to a specific user.
 	 *
-	 * @param  object|int $user User object or user ID to get roles for
+	 * @param  object|int $user User object or user ID to get roles for.
 	 *
 	 * @return array $labels    An array of role labels
 	 */
@@ -130,17 +141,17 @@ class Connector_Users extends Connector {
 	 *
 	 * @action user_register
 	 *
-	 * @param int $user_id Newly registered user ID
+	 * @param int $user_id  Newly registered user ID.
 	 */
 	public function callback_user_register( $user_id ) {
 		$current_user    = wp_get_current_user();
 		$registered_user = get_user_by( 'id', $user_id );
 
-		if ( ! $current_user->ID ) { // Non logged-in user registered themselves
+		if ( ! $current_user->ID ) { // Non logged-in user registered themselves.
 			$message     = esc_html__( 'New user registration', 'stream' );
 			$user_to_log = $registered_user->ID;
-		} else { // Current logged-in user created a new user
-			// translators: Placeholders refer to a user display name, and a user role (e.g. "Jane Doe", "subscriber")
+		} else { // Current logged-in user created a new user.
+			/* translators: %1$s: a user display name, %2$s: a user role (e.g. "Jane Doe", "subscriber") */
 			$message     = _x(
 				'New user account created for %1$s (%2$s)',
 				'1: User display name, 2: User role',
@@ -167,14 +178,14 @@ class Connector_Users extends Connector {
 	 *
 	 * @action profile_update
 	 *
-	 * @param int      $user_id   registered user ID
-	 * @param \WP_User $user registered user object
+	 * @param int      $user_id   Registered user ID.
+	 * @param \WP_User $user      Registered user object.
 	 */
 	public function callback_profile_update( $user_id, $user ) {
 		unset( $user_id );
 
 		$this->log(
-			// translators: Placeholder refers to a user display name (e.g. "Jane Doe")
+			/* translators: %s: a user display name (e.g. "Jane Doe") */
 			__( '%s\'s profile was updated', 'stream' ),
 			array(
 				'display_name' => $user->display_name,
@@ -190,9 +201,9 @@ class Connector_Users extends Connector {
 	 *
 	 * @action set_user_role
 	 *
-	 * @param int    $user_id
-	 * @param string $new_role
-	 * @param array  $old_roles
+	 * @param int    $user_id    User ID.
+	 * @param string $new_role   User role.
+	 * @param array  $old_roles  Old user roles.
 	 */
 	public function callback_set_user_role( $user_id, $new_role, $old_roles ) {
 		if ( empty( $old_roles ) ) {
@@ -202,7 +213,7 @@ class Connector_Users extends Connector {
 		global $wp_roles;
 
 		$this->log(
-			// translators: Placeholders refer to a user display name, a user role, and another user role (e.g. "Jane Doe", "editor", "subscriber")
+			/* translators: %1$s: a user display name, %2$s: a user role, %3$s: another user role (e.g. "Jane Doe", "editor", "subscriber") */
 			_x(
 				'%1$s\'s role was changed from %2$s to %3$s',
 				'1: User display name, 2: Old role, 3: New role',
@@ -224,11 +235,11 @@ class Connector_Users extends Connector {
 	 *
 	 * @action password_reset
 	 *
-	 * @param \WP_User $user
+	 * @param \WP_User $user  User.
 	 */
 	public function callback_password_reset( $user ) {
 		$this->log(
-			// translators: Placeholder refers to a user display name (e.g. "Jane Doe")
+			/* translators: %s: a user display name (e.g. "Jane Doe") */
 			__( '%s\'s password was reset', 'stream' ),
 			array(
 				'email' => $user->display_name,
@@ -245,7 +256,7 @@ class Connector_Users extends Connector {
 	 *
 	 * @action retrieve_password
 	 *
-	 * @param string $user_login
+	 * @param string $user_login  User login.
 	 */
 	public function callback_retrieve_password( $user_login ) {
 		if ( wp_stream_filter_var( $user_login, FILTER_VALIDATE_EMAIL ) ) {
@@ -255,7 +266,7 @@ class Connector_Users extends Connector {
 		}
 
 		$this->log(
-			// translators: Placeholder refers to a user display name (e.g. "Jane Doe")
+			/* translators: %s: a user display name (e.g. "Jane Doe") */
 			__( '%s\'s password was requested to be reset', 'stream' ),
 			array(
 				'display_name' => $user->display_name,
@@ -272,10 +283,10 @@ class Connector_Users extends Connector {
 	 *
 	 * @action set_logged_in_cookie
 	 *
-	 * @param string $logged_in_cookie
-	 * @param int    $expire
-	 * @param int    $expiration
-	 * @param int    $user_id
+	 * @param string $logged_in_cookie  Authenticated cookie.
+	 * @param int    $expire            Unused.
+	 * @param int    $expiration        Unused.
+	 * @param int    $user_id           Unused.
 	 */
 	public function callback_set_logged_in_cookie( $logged_in_cookie, $expire, $expiration, $user_id ) {
 		unset( $logged_in_cookie );
@@ -284,7 +295,7 @@ class Connector_Users extends Connector {
 		$user = get_user_by( 'id', $user_id );
 
 		$this->log(
-			// translators: Placeholder refers to a user display name (e.g. "Jane Doe")
+			/* translators: %s: a user display name (e.g. "Jane Doe") */
 			__( '%s logged in', 'stream' ),
 			array(
 				'display_name' => $user->display_name,
@@ -304,13 +315,13 @@ class Connector_Users extends Connector {
 	public function callback_clear_auth_cookie() {
 		$user = wp_get_current_user();
 
-		// For some reason, incognito mode calls clear_auth_cookie on failed login attempts
+		// For some reason, incognito mode calls clear_auth_cookie on failed login attempts.
 		if ( empty( $user ) || ! $user->exists() ) {
 			return;
 		}
 
 		$this->log(
-			// translators: Placeholder refers to a user display name (e.g. "Jane Doe")
+			/* translators: %s: a user display name (e.g. "Jane Doe") */
 			__( '%s logged out', 'stream' ),
 			array(
 				'display_name' => $user->display_name,
@@ -330,7 +341,7 @@ class Connector_Users extends Connector {
 	 * was already removed from DB.
 	 *
 	 * @action delete_user
-	 * @param int $user_id User ID that maybe deleted
+	 * @param int $user_id  User ID that maybe deleted.
 	 */
 	public function callback_delete_user( $user_id ) {
 		if ( ! isset( $this->_users_object_pre_deleted[ $user_id ] ) ) {
@@ -342,13 +353,13 @@ class Connector_Users extends Connector {
 	 * Log deleted user.
 	 *
 	 * @action deleted_user
-	 * @param int $user_id Deleted user ID
+	 * @param int $user_id  Deleted user ID.
 	 */
 	public function callback_deleted_user( $user_id ) {
 		$user = wp_get_current_user();
 
 		if ( isset( $this->_users_object_pre_deleted[ $user_id ] ) ) {
-			// translators: Placeholders refer to a user display name, and a user role (e.g. "Jane Doe", "subscriber")
+			/* translators: %1$s: a user display name, %2$s: a user role (e.g. "Jane Doe", "subscriber") */
 			$message      = _x(
 				'%1$s\'s account was deleted (%2$s)',
 				'1: User display name, 2: User roles',
@@ -358,7 +369,7 @@ class Connector_Users extends Connector {
 			$deleted_user = $this->_users_object_pre_deleted[ $user_id ];
 			unset( $this->_users_object_pre_deleted[ $user_id ] );
 		} else {
-			// translators: Placeholders refer to a user display name, and a user role (e.g. "Jane Doe", "subscriber")
+			/* translators: %d: a user display name, and a user role (e.g. "Jane Doe", "subscriber") */
 			$message      = esc_html__( 'User account #%d was deleted', 'stream' );
 			$display_name = $user_id;
 			$deleted_user = $user_id;

--- a/connectors/class-connector-widgets.php
+++ b/connectors/class-connector-widgets.php
@@ -1,6 +1,15 @@
 <?php
+/**
+ * Connector for Widgets
+ *
+ * @package WP_Stream
+ */
+
 namespace WP_Stream;
 
+/**
+ * Class - Connector_Widgets
+ */
 class Connector_Widgets extends Connector {
 
 	/**
@@ -90,8 +99,8 @@ class Connector_Widgets extends Connector {
 	 *
 	 * @filter wp_stream_action_links_{connector}
 	 *
-	 * @param array  $links   Previous links registered
-	 * @param Record $record Stream record
+	 * @param array  $links   Previous links registered.
+	 * @param Record $record  Stream record.
 	 *
 	 * @return array Action links
 	 */
@@ -101,10 +110,10 @@ class Connector_Widgets extends Connector {
 			global $wp_registered_sidebars;
 
 			if ( array_key_exists( $sidebar, $wp_registered_sidebars ) ) {
-				$links[ esc_html__( 'Edit Widget Area', 'stream' ) ] = admin_url( 'widgets.php#' . $sidebar ); // xss ok (@todo fix WPCS rule)
+				$links[ esc_html__( 'Edit Widget Area', 'stream' ) ] = admin_url( 'widgets.php#' . $sidebar ); // xss ok (@todo fix WPCS rule).
 			}
-			// @todo Also old_sidebar_id and new_sidebar_id
-			// @todo Add Edit Widget link
+			// @todo Also old_sidebar_id and new_sidebar_id.
+			// @todo Add Edit Widget link.
 		}
 
 		return $links;
@@ -115,13 +124,13 @@ class Connector_Widgets extends Connector {
 	 *
 	 * @action update_option_sidebars_widgets
 	 *
-	 * @param array $old Old sidebars widgets
-	 * @param array $new New sidebars widgets
+	 * @param array $old  Old sidebars widgets.
+	 * @param array $new  New sidebars widgets.
 	 *
 	 * @return void
 	 */
 	public function callback_update_option_sidebars_widgets( $old, $new ) {
-		// Disable listener if we're switching themes
+		// Disable listener if we're switching themes.
 		if ( did_action( 'after_switch_theme' ) ) {
 			return;
 		}
@@ -151,8 +160,10 @@ class Connector_Widgets extends Connector {
 	}
 
 	/**
-	 * @param array $old
-	 * @param array $new
+	 * Processes tracked widget actions
+	 *
+	 * @param array $old  Old sidebar widgets.
+	 * @param array $new  New sidebar widgets.
 	 */
 	protected function handle_sidebars_widgets_changes( $old, $new ) {
 		unset( $old['array_version'] );
@@ -173,8 +184,8 @@ class Connector_Widgets extends Connector {
 	/**
 	 * Track deactivation of widgets from sidebars
 	 *
-	 * @param array $old Old sidebars widgets
-	 * @param array $new New sidebars widgets
+	 * @param array $old  Old sidebars widgets.
+	 * @param array $new  New sidebars widgets.
 	 * @return void
 	 */
 	protected function handle_deactivated_widgets( $old, $new ) {
@@ -197,19 +208,19 @@ class Connector_Widgets extends Connector {
 			$sidebar_name = isset( $labels[ $sidebar_id ] ) ? $labels[ $sidebar_id ] : $sidebar_id;
 
 			if ( $name && $title ) {
-				// translators: Placeholders refer to a widget name, a widget title, and a sidebar name (e.g. "Archives", "Browse", "Footer Area 1")
+				/* translators: %1$s: a widget name, %2$s: a widget title, %3$s: a sidebar name (e.g. "Archives", "Browse", "Footer Area 1") */
 				$message = _x( '%1$s widget named "%2$s" from "%3$s" deactivated', '1: Name, 2: Title, 3: Sidebar Name', 'stream' );
 			} elseif ( $name ) {
-				// Empty title, but we have the name
-				// translators: Placeholders refer to a widget name, and a sidebar name (e.g. "Archives", "Footer Area 1")
+				// Empty title, but we have the name.
+				/* translators: %1$s: a widget name, %3$s: a sidebar name (e.g. "Archives", "Footer Area 1") */
 				$message = _x( '%1$s widget from "%3$s" deactivated', '1: Name, 3: Sidebar Name', 'stream' );
 			} elseif ( $title ) {
-				// Likely a single widget since no name is available
-				// translators: Placeholders refer to a widget title, and a sidebar name (e.g. "Browse", "Footer Area 1")
+				// Likely a single widget since no name is available.
+				/* translators: %1$s: a widget title, %2$s: a sidebar name (e.g. "Browse", "Footer Area 1") */
 				$message = _x( 'Unknown widget type named "%2$s" from "%3$s" deactivated', '2: Title, 3: Sidebar Name', 'stream' );
 			} else {
-				// Neither a name nor a title are available, so use the widget ID
-				// translators: Placeholders refer to a widget ID, and a sidebar name (e.g. "42", "Footer Area 1")
+				// Neither a name nor a title are available, so use the widget ID.
+				/* translators: %4$s: a widget ID, %3$s: a sidebar name (e.g. "42", "Footer Area 1") */
 				$message = _x( '%4$s widget from "%3$s" deactivated', '4: Widget ID, 3: Sidebar Name', 'stream' );
 			}
 
@@ -228,8 +239,8 @@ class Connector_Widgets extends Connector {
 	/**
 	 * Track reactivation of widgets from sidebars
 	 *
-	 * @param array $old Old sidebars widgets
-	 * @param array $new New sidebars widgets
+	 * @param array $old  Old sidebars widgets.
+	 * @param array $new  New sidebars widgets.
 	 * @return void
 	 */
 	protected function handle_reactivated_widgets( $old, $new ) {
@@ -250,19 +261,19 @@ class Connector_Widgets extends Connector {
 			$title  = $this->get_widget_title( $widget_id );
 
 			if ( $name && $title ) {
-				// translators: Placeholders refer to a widget name, and a widget title (e.g. "Archives", "Browse")
+				/* translators: %1$s: a widget name, %2$s: a widget title (e.g. "Archives", "Browse") */
 				$message = _x( '%1$s widget named "%2$s" reactivated', '1: Name, 2: Title', 'stream' );
 			} elseif ( $name ) {
-				// Empty title, but we have the name
-				// translators: Placeholder refers to a widget name (e.g. "Archives")
+				// Empty title, but we have the name.
+				/* translators: %1$s: a widget name (e.g. "Archives") */
 				$message = _x( '%1$s widget reactivated', '1: Name', 'stream' );
 			} elseif ( $title ) {
-				// Likely a single widget since no name is available
-				// translators: Placeholder refers to a widget title (e.g. "Browse")
+				// Likely a single widget since no name is available.
+				/* translators: %2$s: a widget title (e.g. "Browse") */
 				$message = _x( 'Unknown widget type named "%2$s" reactivated', '2: Title', 'stream' );
 			} else {
-				// Neither a name nor a title are available, so use the widget ID
-				// translators: Placeholder refers to a widget ID (e.g. "42")
+				// Neither a name nor a title are available, so use the widget ID.
+				/* translators: %3$s: a widget ID (e.g. "42") */
 				$message = _x( '%3$s widget reactivated', '3: Widget ID', 'stream' );
 			}
 
@@ -281,8 +292,8 @@ class Connector_Widgets extends Connector {
 	/**
 	 * Track deletion of widgets from sidebars
 	 *
-	 * @param array $old Old sidebars widgets
-	 * @param array $new New sidebars widgets
+	 * @param array $old  Old sidebars widgets.
+	 * @param array $new  New sidebars widgets.
 	 * @return void
 	 */
 	protected function handle_widget_removal( $old, $new ) {
@@ -310,19 +321,19 @@ class Connector_Widgets extends Connector {
 			$sidebar_name = isset( $labels[ $sidebar_id ] ) ? $labels[ $sidebar_id ] : $sidebar_id;
 
 			if ( $name && $title ) {
-				// translators: Placeholders refer to a widget name, a widget title, and a sidebar name (e.g. "Archives", "Browse", "Footer Area 1")
+				/* translators: %1$s: a widget name, %2$s: a widget title, %3$s: a sidebar name (e.g. "Archives", "Browse", "Footer Area 1") */
 				$message = _x( '%1$s widget named "%2$s" removed from "%3$s"', '1: Name, 2: Title, 3: Sidebar Name', 'stream' );
 			} elseif ( $name ) {
-				// Empty title, but we have the name
-				// translators: Placeholders refer to a widget name, and a sidebar name (e.g. "Archives", "Footer Area 1")
+				// Empty title, but we have the name.
+				/* translators: %1$s: a widget name, %3$s: a sidebar name (e.g. "Archives", "Footer Area 1") */
 				$message = _x( '%1$s widget removed from "%3$s"', '1: Name, 3: Sidebar Name', 'stream' );
 			} elseif ( $title ) {
-				// Likely a single widget since no name is available
-				// translators: Placeholders refer to a widget title, and a sidebar name (e.g. "Browse", "Footer Area 1")
+				// Likely a single widget since no name is available.
+				/* translators: %2$s: a widget title, %3$s: a sidebar name (e.g. "Browse", "Footer Area 1") */
 				$message = _x( 'Unknown widget type named "%2$s" removed from "%3$s"', '2: Title, 3: Sidebar Name', 'stream' );
 			} else {
-				// Neither a name nor a title are available, so use the widget ID
-				// translators: Placeholders refer to a widget ID, and a sidebar name (e.g. "42", "Footer Area 1")
+				// Neither a name nor a title are available, so use the widget ID.
+				/* translators: %4$s: a widget ID, %3$s: a sidebar name (e.g. "42", "Footer Area 1") */
 				$message = _x( '%4$s widget removed from "%3$s"', '4: Widget ID, 3: Sidebar Name', 'stream' );
 			}
 
@@ -341,8 +352,8 @@ class Connector_Widgets extends Connector {
 	/**
 	 * Track reactivation of widgets from sidebars
 	 *
-	 * @param array $old Old sidebars widgets
-	 * @param array $new New sidebars widgets
+	 * @param array $old  Old sidebars widgets.
+	 * @param array $new  New sidebars widgets.
 	 * @return void
 	 */
 	protected function handle_widget_addition( $old, $new ) {
@@ -367,19 +378,19 @@ class Connector_Widgets extends Connector {
 			$sidebar_name = isset( $labels[ $sidebar_id ] ) ? $labels[ $sidebar_id ] : $sidebar_id;
 
 			if ( $name && $title ) {
-				// translators: Placeholders refer to a widget name, a widget title, and a sidebar name (e.g. "Archives", "Browse", "Footer Area 1")
+				/* translators: %1$s: a widget name, %2$s: a widget title, %3$s: a sidebar name (e.g. "Archives", "Browse", "Footer Area 1") */
 				$message = _x( '%1$s widget named "%2$s" added to "%3$s"', '1: Name, 2: Title, 3: Sidebar Name', 'stream' );
 			} elseif ( $name ) {
-				// Empty title, but we have the name
-				// translators: Placeholders refer to a widget name, and a sidebar name (e.g. "Archives", "Footer Area 1")
+				// Empty title, but we have the name.
+				/* translators: %1$s: a widget name, %3$s: a sidebar name (e.g. "Archives", "Footer Area 1") */
 				$message = _x( '%1$s widget added to "%3$s"', '1: Name, 3: Sidebar Name', 'stream' );
 			} elseif ( $title ) {
-				// Likely a single widget since no name is available
-				// translators: Placeholders refer to a widget title, and a sidebar name (e.g. "Browse", "Footer Area 1")
+				// Likely a single widget since no name is available.
+				/* translators: %2$s: a widget title, %3$s: a sidebar name (e.g. "Browse", "Footer Area 1") */
 				$message = _x( 'Unknown widget type named "%2$s" added to "%3$s"', '2: Title, 3: Sidebar Name', 'stream' );
 			} else {
-				// Neither a name nor a title are available, so use the widget ID
-				// translators: Placeholders refer to a widget ID, and a sidebar name (e.g. "42", "Footer Area 1")
+				// Neither a name nor a title are available, so use the widget ID.
+				/* translators: %4$s: a widget ID, %3$s: a sidebar name (e.g. "42", "Footer Area 1") */
 				$message = _x( '%4$s widget added to "%3$s"', '4: Widget ID, 3: Sidebar Name', 'stream' );
 			}
 
@@ -398,8 +409,8 @@ class Connector_Widgets extends Connector {
 	/**
 	 * Track reordering of widgets
 	 *
-	 * @param array $old Old sidebars widgets
-	 * @param array $new New sidebars widgets
+	 * @param array $old  Old sidebars widgets.
+	 * @param array $new  New sidebars widgets.
 	 * @return void
 	 */
 	protected function handle_widget_reordering( $old, $new ) {
@@ -410,7 +421,7 @@ class Connector_Widgets extends Connector {
 				continue;
 			}
 
-			// Use intersect to ignore widget additions and removals
+			// Use intersect to ignore widget additions and removals.
 			$all_widget_ids       = array_unique( array_merge( $old[ $sidebar_id ], $new[ $sidebar_id ] ) );
 			$common_widget_ids    = array_intersect( $old[ $sidebar_id ], $new[ $sidebar_id ] );
 			$uncommon_widget_ids  = array_diff( $all_widget_ids, $common_widget_ids );
@@ -423,7 +434,7 @@ class Connector_Widgets extends Connector {
 				$sidebar_name   = isset( $labels[ $sidebar_id ] ) ? $labels[ $sidebar_id ] : $sidebar_id;
 				$old_widget_ids = $old[ $sidebar_id ];
 
-				// translators: Placeholder refers to a sidebar name (e.g. "Footer Area 1")
+				/* translators: %s: a sidebar name (e.g. "Footer Area 1") */
 				$message = _x( 'Widgets reordered in "%s"', 'Sidebar name', 'stream' );
 				$message = sprintf( $message, $sidebar_name );
 
@@ -442,8 +453,8 @@ class Connector_Widgets extends Connector {
 	/**
 	 * Track movement of widgets to other sidebars
 	 *
-	 * @param array $old Old sidebars widgets
-	 * @param array $new New sidebars widgets
+	 * @param array $old  Old sidebars widgets.
+	 * @param array $new  New sidebars widgets.
 	 * @return void
 	 */
 	protected function handle_widget_moved( $old, $new ) {
@@ -457,7 +468,7 @@ class Connector_Widgets extends Connector {
 			$new_widget_ids = array_diff( $new[ $new_sidebar_id ], $old[ $new_sidebar_id ] );
 
 			foreach ( $new_widget_ids as $widget_id ) {
-				// Now find the sidebar that the widget was originally located in, as long it is not wp_inactive_widgets
+				// Now find the sidebar that the widget was originally located in, as long it is not wp_inactive_widgets.
 				$old_sidebar_id = null;
 				foreach ( $old as $sidebar_id => $old_widget_ids ) {
 					if ( in_array( $widget_id, $old_widget_ids, true ) ) {
@@ -479,19 +490,19 @@ class Connector_Widgets extends Connector {
 				$new_sidebar_name = isset( $labels[ $new_sidebar_id ] ) ? $labels[ $new_sidebar_id ] : $new_sidebar_id;
 
 				if ( $name && $title ) {
-					// translators: Placeholders refer to a widget name, a widget title, a sidebar name, and another sidebar name (e.g. "Archives", "Browse", "Footer Area 1", "Footer Area 2")
+					/* translators: %1$s: a widget name, %2$s: a widget title, %4$s: a sidebar name, %5$s: another sidebar name (e.g. "Archives", "Browse", "Footer Area 1", "Footer Area 2") */
 					$message = _x( '%1$s widget named "%2$s" moved from "%4$s" to "%5$s"', '1: Name, 2: Title, 4: Old Sidebar Name, 5: New Sidebar Name', 'stream' );
 				} elseif ( $name ) {
-					// Empty title, but we have the name
-					// translators: Placeholders refer to a widget name, a sidebar name, and another sidebar name (e.g. "Archives", "Footer Area 1", "Footer Area 2")
+					// Empty title, but we have the name.
+					/* translators: %1$s: a widget name, %4$s: a sidebar name, %5$s: another sidebar name (e.g. "Archives", "Footer Area 1", "Footer Area 2") */
 					$message = _x( '%1$s widget moved from "%4$s" to "%5$s"', '1: Name, 4: Old Sidebar Name, 5: New Sidebar Name', 'stream' );
 				} elseif ( $title ) {
-					// Likely a single widget since no name is available
-					// translators: Placeholders refer to a widget title, a sidebar name, and another sidebar name (e.g. "Browse", "Footer Area 1", "Footer Area 2")
+					// Likely a single widget since no name is available.
+					/* translators: %2$s: a widget title, %4$s: a sidebar name, %5$s: another sidebar name (e.g. "Browse", "Footer Area 1", "Footer Area 2") */
 					$message = _x( 'Unknown widget type named "%2$s" moved from "%4$s" to "%5$s"', '2: Title, 4: Old Sidebar Name, 5: New Sidebar Name', 'stream' );
 				} else {
-					// Neither a name nor a title are available, so use the widget ID
-					// translators: Placeholders refer to a widget ID, a sidebar name, and another sidebar name (e.g. "42", "Footer Area 1", "Footer Area 2")
+					// Neither a name nor a title are available, so use the widget ID.
+					/* translators: %3$s: a widget ID, %4$s: a sidebar name, %5$s: another sidebar name (e.g. "42", "Footer Area 1", "Footer Area 2") */
 					$message = _x( '%3$s widget moved from "%4$s" to "%5$s"', '3: Widget ID, 4: Old Sidebar Name, 5: New Sidebar Name', 'stream' );
 				}
 
@@ -515,9 +526,9 @@ class Connector_Widgets extends Connector {
 	 *
 	 * @action updated_option
 	 *
-	 * @param string $option_name
-	 * @param array  $old_value
-	 * @param array  $new_value
+	 * @param string $option_name  Option key.
+	 * @param array  $old_value    Old value.
+	 * @param array  $new_value    New value.
 	 */
 	public function callback_updated_option( $option_name, $old_value, $new_value ) {
 		if ( ! preg_match( '/^widget_(.+)$/', $option_name, $matches ) || ! is_array( $new_value ) ) {
@@ -588,9 +599,9 @@ class Connector_Widgets extends Connector {
 				$deletes[] = compact( 'name', 'title', 'widget_id', 'sidebar_id', 'instance' );
 			}
 		} else {
-			// Doing our best guess for tracking changes to old single widgets, assuming their options start with 'widget_'
+			// Doing our best guess for tracking changes to old single widgets, assuming their options start with 'widget_'.
 			$widget_id    = $widget_id_base;
-			$name         = $widget_id; // There aren't names available for single widgets
+			$name         = $widget_id; // There aren't names available for single widgets.
 			$title        = ! empty( $new_value['title'] ) ? $new_value['title'] : null;
 			$sidebar_id   = $this->get_widget_sidebar_id( $widget_id );
 			$old_instance = $old_value;
@@ -605,19 +616,19 @@ class Connector_Widgets extends Connector {
 		 */
 		foreach ( $updates as $update ) {
 			if ( $update['name'] && $update['title'] ) {
-				// translators: Placeholders refer to a widget name, a widget title, and a sidebar name (e.g. "Archives", "Browse", "Footer Area 1")
+				/* translators: %1$s: a widget name, %2$s: a widget title, %3$s: a sidebar name (e.g. "Archives", "Browse", "Footer Area 1") */
 				$message = _x( '%1$s widget named "%2$s" in "%3$s" updated', '1: Name, 2: Title, 3: Sidebar Name', 'stream' );
 			} elseif ( $update['name'] ) {
-				// Empty title, but we have the name
-				// translators: Placeholders refer to a widget name, and a sidebar name (e.g. "Archives", "Footer Area 1")
+				// Empty title, but we have the name.
+				/* translators: %1$s: a widget name, %3$s: a sidebar name (e.g. "Archives", "Footer Area 1") */
 				$message = _x( '%1$s widget in "%3$s" updated', '1: Name, 3: Sidebar Name', 'stream' );
 			} elseif ( $update['title'] ) {
-				// Likely a single widget since no name is available
-				// translators: Placeholders refer to a widget title, and a sidebar name (e.g. "Browse", "Footer Area 1")
+				// Likely a single widget since no name is available.
+				/* translators: %2$s: a widget title, %3$s: a sidebar name (e.g. "Browse", "Footer Area 1") */
 				$message = _x( 'Unknown widget type named "%2$s" in "%3$s" updated', '2: Title, 3: Sidebar Name', 'stream' );
 			} else {
-				// Neither a name nor a title are available, so use the widget ID
-				// translators: Placeholders refer to a widget ID, and a sidebar name (e.g. "42", "Footer Area 1")
+				// Neither a name nor a title are available, so use the widget ID.
+				/* translators: %4$s: a widget ID, %3$s: a sidebar name (e.g. "42", "Footer Area 1") */
 				$message = _x( '%4$s widget in "%3$s" updated', '4: Widget ID, 3: Sidebar Name', 'stream' );
 			}
 
@@ -643,25 +654,25 @@ class Connector_Widgets extends Connector {
 		 * actions would be useful to log.
 		 */
 		if ( $this->verbose_widget_created_deleted_actions ) {
-			// We should only do these if not captured by an update to the sidebars_widgets option
+			// We should only do these if not captured by an update to the sidebars_widgets option.
 			/**
 			 * Log created actions
 			 */
 			foreach ( $creates as $create ) {
 				if ( $create['name'] && $create['title'] ) {
-					// translators: Placeholders refer to a widget name, and a widget title (e.g. "Archives", "Browse")
+					/* translators: %1$s: a widget name, %2$s: a widget title (e.g. "Archives", "Browse") */
 					$message = _x( '%1$s widget named "%2$s" created', '1: Name, 2: Title', 'stream' );
 				} elseif ( $create['name'] ) {
-					// Empty title, but we have the name
-					// translators: Placeholder refers to a widget name (e.g. "Archives")
+					// Empty title, but we have the name.
+					/* translators: %1$s: a widget name (e.g. "Archives") */
 					$message = _x( '%1$s widget created', '1: Name', 'stream' );
 				} elseif ( $create['title'] ) {
-					// Likely a single widget since no name is available
-					// translators: Placeholder refers to a widget title (e.g. "Browse")
+					// Likely a single widget since no name is available.
+					/* translators: %2$s: a widget title (e.g. "Browse") */
 					$message = _x( 'Unknown widget type named "%2$s" created', '2: Title', 'stream' );
 				} else {
-					// Neither a name nor a title are available, so use the widget ID
-					// translators: Placeholder refers to a widget ID (e.g. "42")
+					// Neither a name nor a title are available, so use the widget ID.
+					/* translators: %3$s: a widget ID (e.g. "42") */
 					$message = _x( '%3$s widget created', '3: Widget ID', 'stream' );
 				}
 
@@ -683,19 +694,19 @@ class Connector_Widgets extends Connector {
 			 */
 			foreach ( $deletes as $delete ) {
 				if ( $delete['name'] && $delete['title'] ) {
-					// translators: Placeholders refer to a widget name, and a widget title (e.g. "Archives", "Browse")
+					/* translators: %1$s: a widget name, %2$s: a widget title (e.g. "Archives", "Browse") */
 					$message = _x( '%1$s widget named "%2$s" deleted', '1: Name, 2: Title', 'stream' );
 				} elseif ( $delete['name'] ) {
-					// Empty title, but we have the name
-					// translators: Placeholder refers to a widget name (e.g. "Archives")
+					// Empty title, but we have the name.
+					/* translators: %1$s: a widget name (e.g. "Archives") */
 					$message = _x( '%1$s widget deleted', '1: Name', 'stream' );
 				} elseif ( $delete['title'] ) {
-					// Likely a single widget since no name is available
-					// translators: Placeholder refers to a widget title (e.g. "Browse")
+					// Likely a single widget since no name is available.
+					/* translators: %2$s: a widget title (e.g. "Browse") */
 					$message = _x( 'Unknown widget type named "%2$s" deleted', '2: Title', 'stream' );
 				} else {
-					// Neither a name nor a title are available, so use the widget ID
-					// translators: Placeholder refers to a widget ID (e.g. "42")
+					// Neither a name nor a title are available, so use the widget ID.
+					/* translators: %3$s: a widget ID (e.g. "42") */
 					$message = _x( '%3$s widget deleted', '3: Widget ID', 'stream' );
 				}
 
@@ -715,7 +726,9 @@ class Connector_Widgets extends Connector {
 	}
 
 	/**
-	 * @param string $widget_id
+	 * Returns widget title.
+	 *
+	 * @param string $widget_id  Widget instance ID.
 	 *
 	 * @return string
 	 */
@@ -725,7 +738,9 @@ class Connector_Widgets extends Connector {
 	}
 
 	/**
-	 * @param string $widget_id
+	 * Returns widget name.
+	 *
+	 * @param string $widget_id  Widget instance ID.
 	 *
 	 * @return string|null
 	 */
@@ -735,7 +750,9 @@ class Connector_Widgets extends Connector {
 	}
 
 	/**
-	 * @param $widget_id
+	 * Parses widget instance ID and widget type data.
+	 *
+	 * @param string $widget_id  Widget instance ID.
 	 *
 	 * @return array|null
 	 */
@@ -751,7 +768,9 @@ class Connector_Widgets extends Connector {
 	}
 
 	/**
-	 * @param string $widget_id
+	 * Returns widget object.
+	 *
+	 * @param string $widget_id  Widget instance ID.
 	 *
 	 * @return \WP_Widget|null
 	 */
@@ -781,7 +800,7 @@ class Connector_Widgets extends Connector {
 	/**
 	 * Returns widget instance settings
 	 *
-	 * @param string $widget_id Widget ID, ex: pages-1
+	 * @param string $widget_id  Widget ID, ex: pages-1.
 	 *
 	 * @return array|null Widget instance
 	 */
@@ -798,7 +817,7 @@ class Connector_Widgets extends Connector {
 				$instance = $settings[ $multi_number ];
 			}
 		} else {
-			// Single widgets, try our best guess at the option used
+			// Single widgets, try our best guess at the option used.
 			$potential_instance = get_option( "widget_{$widget_id}" );
 
 			if ( ! empty( $potential_instance ) && ! empty( $potential_instance['title'] ) ) {
@@ -830,7 +849,7 @@ class Connector_Widgets extends Connector {
 	/**
 	 * Return the sidebar of a certain widget, based on widget_id
 	 *
-	 * @param string $widget_id Widget id, ex: pages-1
+	 * @param string $widget_id  Widget id, ex: pages-1.
 	 *
 	 * @return string Sidebar id
 	 */

--- a/connectors/class-connector-woocommerce.php
+++ b/connectors/class-connector-woocommerce.php
@@ -1,6 +1,15 @@
 <?php
+/**
+ * Connector for WooCommerce
+ *
+ * @package WP_Stream
+ */
+
 namespace WP_Stream;
 
+/**
+ * Class - Connector_WooCommerce
+ */
 class Connector_Woocommerce extends Connector {
 	/**
 	 * Context name
@@ -35,6 +44,11 @@ class Connector_Woocommerce extends Connector {
 		'woocommerce_tax_rate_deleted',
 	);
 
+	/**
+	 * Taxonomies tracked by this connector.
+	 *
+	 * @var array
+	 */
 	public $taxonomies = array(
 		'product_type',
 		'product_cat',
@@ -43,6 +57,11 @@ class Connector_Woocommerce extends Connector {
 		'shop_order_status',
 	);
 
+	/**
+	 * Post-types tracked by this connector.
+	 *
+	 * @var array
+	 */
 	public $post_types = array(
 		'product',
 		'product_variation',
@@ -58,6 +77,9 @@ class Connector_Woocommerce extends Connector {
 
 	private $plugin_version = null;
 
+	/**
+	 * Register connection
+	 */
 	public function register() {
 		parent::register();
 
@@ -208,8 +230,8 @@ class Connector_Woocommerce extends Connector {
 	 *
 	 * @filter wp_stream_action_links_{connector}
 	 *
-	 * @param array  $links   Previous links registered
-	 * @param Record $record Stream record
+	 * @param array  $links   Previous links registered.
+	 * @param Record $record  Stream record.
 	 *
 	 * @return array Action links
 	 */
@@ -219,7 +241,7 @@ class Connector_Woocommerce extends Connector {
 			if ( $edit_post_link ) {
 				$posts_connector = new Connector_Posts();
 				$post_type_name  = $posts_connector->get_post_type_name( get_post_type( $record->object_id ) );
-				// translators: Placeholder refers to a post type singular name (e.g. "Post")
+				/* translators: %s: a post type singular name (e.g. "Post") */
 				$links[ sprintf( esc_html_x( 'Edit %s', 'Post type singular name', 'stream' ), $post_type_name ) ] = $edit_post_link;
 			}
 
@@ -236,7 +258,7 @@ class Connector_Woocommerce extends Connector {
 		$option_section = $record->get_meta( 'section', true );
 
 		if ( $option_key && $option_tab ) {
-			// translators: Placeholder refers to a context (e.g. "Attribute")
+			/* translators: %s a context (e.g. "Attribute") */
 			$text = sprintf( esc_html__( 'Edit WooCommerce %s', 'stream' ), $context_labels[ $record->context ] );
 			$url  = add_query_arg(
 				array(
@@ -244,7 +266,7 @@ class Connector_Woocommerce extends Connector {
 					'tab'     => $option_tab,
 					'section' => $option_section,
 				),
-				admin_url( 'admin.php' ) // Not self_admin_url here, as WooCommerce doesn't exist in Network Admin
+				admin_url( 'admin.php' ) // Not self_admin_url here, as WooCommerce doesn't exist in Network Admin.
 			);
 
 			$links[ $text ] = $url . '#wp-stream-highlight:' . $option_key;
@@ -259,7 +281,7 @@ class Connector_Woocommerce extends Connector {
 	 *
 	 * @filter wp_stream_posts_exclude_post_types
 	 *
-	 * @param array $post_types Ignored post types
+	 * @param array $post_types  Ignored post types.
 	 *
 	 * @return array Filtered post types
 	 */
@@ -275,7 +297,7 @@ class Connector_Woocommerce extends Connector {
 	 *
 	 * @filter wp_stream_commnent_exclude_comment_types
 	 *
-	 * @param array $comment_types Ignored post types
+	 * @param array $comment_types  Ignored post types.
 	 *
 	 * @return array Filtered post types
 	 */
@@ -290,27 +312,27 @@ class Connector_Woocommerce extends Connector {
 	 *
 	 * @action transition_post_status
 	 *
-	 * @param string   $new
-	 * @param string   $old
-	 * @param \WP_Post $post
+	 * @param string   $new   New status.
+	 * @param string   $old   Old status.
+	 * @param \WP_Post $post  Post object.
 	 */
 	public function callback_transition_post_status( $new, $old, $post ) {
-		// Only track orders
+		// Only track orders.
 		if ( 'shop_order' !== $post->post_type ) {
 			return;
 		}
 
-		// Don't track customer actions
+		// Don't track customer actions.
 		if ( ! is_admin() ) {
 			return;
 		}
 
-		// Don't track minor status change actions
+		// Don't track minor status change actions.
 		if ( in_array( wp_stream_filter_input( INPUT_GET, 'action' ), array( 'mark_processing', 'mark_on-hold', 'mark_completed' ), true ) || defined( 'DOING_AJAX' ) ) {
 			return;
 		}
 
-		// Don't log updates when more than one happens at the same time
+		// Don't log updates when more than one happens at the same time.
 		if ( $post->ID === $this->order_update_logged ) {
 			return;
 		}
@@ -318,7 +340,7 @@ class Connector_Woocommerce extends Connector {
 		if ( in_array( $new, array( 'auto-draft', 'draft', 'inherit' ), true ) ) {
 			return;
 		} elseif ( 'auto-draft' === $old && 'publish' === $new ) {
-			// translators: Placeholder refers to an order title (e.g. "Order #42")
+			/* translators: %s: an order title (e.g. "Order #42") */
 			$message = esc_html_x(
 				'%s created',
 				'Order title',
@@ -326,7 +348,7 @@ class Connector_Woocommerce extends Connector {
 			);
 			$action  = 'created';
 		} elseif ( 'trash' === $new ) {
-			// translators: Placeholder refers to an order title (e.g. "Order #42")
+			/* translators: %s: an order title (e.g. "Order #42") */
 			$message = esc_html_x(
 				'%s trashed',
 				'Order title',
@@ -334,7 +356,7 @@ class Connector_Woocommerce extends Connector {
 			);
 			$action  = 'trashed';
 		} elseif ( 'trash' === $old && 'publish' === $new ) {
-			// translators: Placeholder refers to an order title (e.g. "Order #42")
+			/* translators: %s: an order title (e.g. "Order #42") */
 			$message = esc_html_x(
 				'%s restored from the trash',
 				'Order title',
@@ -342,7 +364,7 @@ class Connector_Woocommerce extends Connector {
 			);
 			$action  = 'untrashed';
 		} else {
-			// translators: Placeholder refers to an order title (e.g. "Order #42")
+			/* translators: %s: an order title (e.g. "Order #42") */
 			$message = esc_html_x(
 				'%s updated',
 				'Order title',
@@ -380,17 +402,17 @@ class Connector_Woocommerce extends Connector {
 	 *
 	 * @action deleted_post
 	 *
-	 * @param int $post_id
+	 * @param int $post_id  Post ID.
 	 */
 	public function callback_deleted_post( $post_id ) {
 		$post = get_post( $post_id );
 
-		// We check if post is an instance of WP_Post as it doesn't always resolve in unit testing
+		// We check if post is an instance of WP_Post as it doesn't always resolve in unit testing.
 		if ( ! ( $post instanceof \WP_Post ) || 'shop_order' !== $post->post_type ) {
 			return;
 		}
 
-		// Ignore auto-drafts that are deleted by the system, see issue-293
+		// Ignore auto-drafts that are deleted by the system, see issue-293.
 		if ( 'auto-draft' === $post->post_status ) {
 			return;
 		}
@@ -400,7 +422,7 @@ class Connector_Woocommerce extends Connector {
 		$order_type_name = esc_html__( 'order', 'stream' );
 
 		$this->log(
-			// translators: Placeholder refers to an order title (e.g. "Order #42")
+			/* translators: %s: an order title (e.g. "Order #42") */
 			_x(
 				'"%s" deleted from trash',
 				'Order title',
@@ -421,17 +443,17 @@ class Connector_Woocommerce extends Connector {
 	 *
 	 * @action woocommerce_order_status_changed
 	 *
-	 * @param int    $order_id
-	 * @param string $old
-	 * @param string $new
+	 * @param int    $order_id  Order ID.
+	 * @param string $old       Old status.
+	 * @param string $new       New status.
 	 */
 	public function callback_woocommerce_order_status_changed( $order_id, $old, $new ) {
-		// Don't track customer actions
+		// Don't track customer actions.
 		if ( ! is_admin() ) {
 			return;
 		}
 
-		// Don't track new statuses
+		// Don't track new statuses.
 		if ( empty( $old ) ) {
 			return;
 		}
@@ -446,7 +468,7 @@ class Connector_Woocommerce extends Connector {
 			$old_status_name = $old_status->name;
 		}
 
-		// translators: Placeholders refer to an order title, and order status, and another order status (e.g. "Order #42", "processing", "complete")
+		/* translators: %1$s: an order title, %2$s: order status, %3$s: another order status (e.g. "Order #42", "processing", "complete") */
 		$message = esc_html_x(
 			'%1$s status changed from %2$s to %3$s',
 			'1. Order title, 2. Old status, 3. New status',
@@ -479,12 +501,12 @@ class Connector_Woocommerce extends Connector {
 	 *
 	 * @action woocommerce_attribute_added
 	 *
-	 * @param int   $attribute_id
-	 * @param array $attribute
+	 * @param int   $attribute_id  Attribute ID.
+	 * @param array $attribute     Attribute data.
 	 */
 	public function callback_woocommerce_attribute_added( $attribute_id, $attribute ) {
 		$this->log(
-			// translators: Placeholder refers to a term name (e.g. "color")
+			/* translators: %s: a term name (e.g. "color") */
 			_x(
 				'"%s" product attribute created',
 				'Term name',
@@ -502,12 +524,12 @@ class Connector_Woocommerce extends Connector {
 	 *
 	 * @action woocommerce_attribute_updated
 	 *
-	 * @param int   $attribute_id
-	 * @param array $attribute
+	 * @param int   $attribute_id  Attribute ID.
+	 * @param array $attribute     Attribute data.
 	 */
 	public function callback_woocommerce_attribute_updated( $attribute_id, $attribute ) {
 		$this->log(
-			// translators: Placeholder refers to a term name (e.g. "color")
+			/* translators: %s a term name (e.g. "color") */
 			_x(
 				'"%s" product attribute updated',
 				'Term name',
@@ -525,12 +547,12 @@ class Connector_Woocommerce extends Connector {
 	 *
 	 * @action woocommerce_attribute_updated
 	 *
-	 * @param int    $attribute_id
-	 * @param string $attribute_name
+	 * @param int    $attribute_id    Attribute ID.
+	 * @param string $attribute_name  Attribute name.
 	 */
 	public function callback_woocommerce_attribute_deleted( $attribute_id, $attribute_name ) {
 		$this->log(
-			// translators: Placeholder refers to a term name (e.g. "color")
+			/* translators: %s: a term name (e.g. "color") */
 			_x(
 				'"%s" product attribute deleted',
 				'Term name',
@@ -550,12 +572,12 @@ class Connector_Woocommerce extends Connector {
 	 *
 	 * @action woocommerce_tax_rate_added
 	 *
-	 * @param int   $tax_rate_id
-	 * @param array $tax_rate
+	 * @param int   $tax_rate_id  Tax Rate ID.
+	 * @param array $tax_rate     Tax Rate data.
 	 */
 	public function callback_woocommerce_tax_rate_added( $tax_rate_id, $tax_rate ) {
 		$this->log(
-			// translators: Placeholder refers to a tax rate name (e.g. "GST")
+			/* translators: %4$s: a tax rate name (e.g. "GST") */
 			_x(
 				'"%4$s" tax rate created',
 				'Tax rate name',
@@ -573,12 +595,12 @@ class Connector_Woocommerce extends Connector {
 	 *
 	 * @action woocommerce_tax_rate_updated
 	 *
-	 * @param int   $tax_rate_id
-	 * @param array $tax_rate
+	 * @param int   $tax_rate_id  Tax Rate ID.
+	 * @param array $tax_rate     Tax Rate data.
 	 */
 	public function callback_woocommerce_tax_rate_updated( $tax_rate_id, $tax_rate ) {
 		$this->log(
-			// translators: Placeholder refers to a tax rate name (e.g. "GST")
+			/* translators: %4$s: a tax rate name (e.g. "GST") */
 			_x(
 				'"%4$s" tax rate updated',
 				'Tax rate name',
@@ -596,7 +618,7 @@ class Connector_Woocommerce extends Connector {
 	 *
 	 * @action woocommerce_tax_rate_updated
 	 *
-	 * @param int $tax_rate_id
+	 * @param int $tax_rate_id  Tax Rate ID.
 	 */
 	public function callback_woocommerce_tax_rate_deleted( $tax_rate_id ) {
 		global $wpdb;
@@ -611,7 +633,7 @@ class Connector_Woocommerce extends Connector {
 		);
 
 		$this->log(
-			// translators: Placeholder refers to a tax rate name (e.g. "GST")
+			/* translators: %4$s: a tax rate name (e.g. "GST") */
 			_x(
 				'"%s" tax rate deleted',
 				'Tax rate name',
@@ -631,7 +653,7 @@ class Connector_Woocommerce extends Connector {
 	 *
 	 * @filter wp_stream_record_array
 	 *
-	 * @param array $recordarr Record data to be inserted
+	 * @param array $recordarr  Record data to be inserted.
 	 *
 	 * @return array Filtered record data
 	 */
@@ -641,7 +663,7 @@ class Connector_Woocommerce extends Connector {
 				continue;
 			}
 
-			// Change connector::posts records
+			// Change connector::posts records.
 			if ( 'posts' === $record['connector'] && in_array( $record['context'], $this->post_types, true ) ) {
 				$recordarr[ $key ]['connector'] = $this->name;
 			} elseif ( 'taxonomies' === $record['connector'] && in_array( $record['context'], $this->taxonomies, true ) ) {
@@ -658,6 +680,13 @@ class Connector_Woocommerce extends Connector {
 		return $recordarr;
 	}
 
+	/**
+	 * Track WooCommerce-specific option changes.
+	 *
+	 * @param string $option_key   Option key.
+	 * @param string $old_value    Old value.
+	 * @param string $value        New value.
+	 */
 	public function callback_updated_option( $option_key, $old_value, $value ) {
 		$options = array( $option_key );
 
@@ -673,7 +702,7 @@ class Connector_Woocommerce extends Connector {
 			}
 
 			$this->log(
-				// translators: Placeholders refer to a setting name and a setting type (e.g. "Direct Deposit", "Payment Method")
+				/* translators: %1$s: a setting name, %2$s: a setting type (e.g. "Direct Deposit", "Payment Method") */
 				__( '"%1$s" %2$s updated', 'stream' ),
 				array(
 					'label'     => $this->settings[ $option ]['title'],
@@ -692,6 +721,9 @@ class Connector_Woocommerce extends Connector {
 		}
 	}
 
+	/**
+	 * Loads the WooCommerce admin settings.
+	 */
 	public function get_woocommerce_settings_fields() {
 		if ( ! defined( 'WC_VERSION' ) || ! class_exists( 'WC_Admin_Settings' ) ) {
 			return false;
@@ -714,8 +746,10 @@ class Connector_Woocommerce extends Connector {
 			$settings_pages = array();
 
 			foreach ( \WC_Admin_Settings::get_settings_pages() as $page ) {
-				// Get ID / Label of the page, since they're protected, by hacking into
-				// the callback filter for 'woocommerce_settings_tabs_array'
+				/**
+				 * Get ID / Label of the page, since they're protected, by hacking into
+				 * the callback filter for 'woocommerce_settings_tabs_array'.
+				 */
 				$info       = $page->add_settings_page( array() );
 				$page_id    = key( $info );
 				$page_label = current( $info );
@@ -727,7 +761,7 @@ class Connector_Woocommerce extends Connector {
 
 				$settings_pages[ $page_id ] = $page_label;
 
-				// Remove non-fields ( sections, titles and whatever )
+				// Remove non-fields ( sections, titles and whatever ).
 				$fields = array();
 
 				foreach ( $sections as $section_key => $section_label ) {
@@ -750,11 +784,11 @@ class Connector_Woocommerce extends Connector {
 					}
 				}
 
-				// Store fields in the global array to be searched later
+				// Store fields in the global array to be searched later.
 				$settings = array_merge( $settings, $fields );
 			}
 
-			// Provide additional context for each of the settings pages
+			// Provide additional context for each of the settings pages.
 			array_walk(
 				$settings_pages,
 				function( &$value ) {
@@ -762,7 +796,7 @@ class Connector_Woocommerce extends Connector {
 				}
 			);
 
-			// Load Payment Gateway Settings
+			// Load Payment Gateway Settings.
 			$payment_gateway_settings = array();
 			$payment_gateways         = $woocommerce->payment_gateways();
 
@@ -781,7 +815,7 @@ class Connector_Woocommerce extends Connector {
 
 			$settings = array_merge( $settings, $payment_gateway_settings );
 
-			// Load Shipping Method Settings
+			// Load Shipping Method Settings.
 			$shipping_method_settings = array();
 			$shipping_methods         = $woocommerce->shipping();
 
@@ -800,7 +834,7 @@ class Connector_Woocommerce extends Connector {
 
 			$settings = array_merge( $settings, $shipping_method_settings );
 
-			// Load Email Settings
+			// Load Email Settings.
 			$email_settings = array();
 			$emails         = $woocommerce->mailer();
 
@@ -819,14 +853,14 @@ class Connector_Woocommerce extends Connector {
 
 			$settings = array_merge( $settings, $email_settings );
 
-			// Tools page
+			// Tools page.
 			$tools_page = array(
 				'tools' => esc_html__( 'Tools', 'stream' ),
 			);
 
 			$settings_pages = array_merge( $settings_pages, $tools_page );
 
-			// Cache the results
+			// Cache the results.
 			$settings_cache = array(
 				'settings'       => $settings,
 				'settings_pages' => $settings_pages,

--- a/connectors/class-connector-wordpress-seo.php
+++ b/connectors/class-connector-wordpress-seo.php
@@ -1,6 +1,15 @@
 <?php
+/**
+ * Connector for WordPress SEO
+ *
+ * @package WP_Stream
+ */
+
 namespace WP_Stream;
 
+/**
+ * Class - Connector_WordPress_SEO
+ */
 class Connector_WordPress_SEO extends Connector {
 
 	/**
@@ -104,13 +113,13 @@ class Connector_WordPress_SEO extends Connector {
 	 *
 	 * @filter wp_stream_action_links_{connector}
 	 *
-	 * @param array  $links  Previous links registered
-	 * @param Record $record Stream record
+	 * @param array  $links   Previous links registered.
+	 * @param Record $record  Stream record.
 	 *
 	 * @return array Action links
 	 */
 	public function action_links( $links, $record ) {
-		// Options
+		// Options.
 		$option = $record->get_meta( 'option', true );
 		if ( $option ) {
 			$key = $record->get_meta( 'option_key', true );
@@ -158,12 +167,12 @@ class Connector_WordPress_SEO extends Connector {
 						sprintf( 'delete-post_%d', $post->ID )
 					);
 
-					// translators: Placeholder refers to a post type singular name (e.g. "Post")
+					/* translators: %s: a post type singular name (e.g. "Post") */
 					$links[ sprintf( esc_html_x( 'Restore %s', 'Post type singular name', 'stream' ), $post_type_name ) ] = $untrash;
-					// translators: Placeholder refers to a post type singular name (e.g. "Post")
+					/* translators: %s: a post type singular name (e.g. "Post") */
 					$links[ sprintf( esc_html_x( 'Delete %s Permenantly', 'Post type singular name', 'stream' ), $post_type_name ) ] = $delete;
 				} else {
-					// translators: Placeholder refers to a post type singular name (e.g. "Post")
+					/* translators: %s: a post type singular name (e.g. "Post") */
 					$links[ sprintf( esc_html_x( 'Edit %s', 'Post type singular name', 'stream' ), $post_type_name ) ] = get_edit_post_link( $post->ID );
 
 					$view_link = get_permalink( $post->ID );
@@ -182,6 +191,9 @@ class Connector_WordPress_SEO extends Connector {
 		return $links;
 	}
 
+	/**
+	 * Register connection
+	 */
 	public function register() {
 		if ( is_network_admin() && ! is_plugin_active_for_network( 'wordpress-seo/wordpress-seo-main.php' ) ) {
 			return;
@@ -200,26 +212,39 @@ class Connector_WordPress_SEO extends Connector {
 		add_filter( 'wp_stream_log_data', array( $this, 'log_override' ) );
 	}
 
+	/**
+	 * Register admin scripts.
+	 *
+	 * @param string $hook  Current hook.
+	 */
 	public function admin_enqueue_scripts( $hook ) {
 		if ( 0 === strpos( $hook, 'seo_page_' ) ) {
 			$stream = wp_stream_get_instance();
 			$src    = $stream->locations['url'] . '/ui/js/wpseo-admin.js';
-			wp_enqueue_script( 'stream-connector-wpseo', $src, array( 'jquery' ), $stream->get_version() );
+			wp_enqueue_script(
+				'stream-connector-wpseo',
+				$src,
+				array( 'jquery' ),
+				$stream->get_version(),
+				false
+			);
 		}
 	}
 
 	/**
 	 * Track importing settings from other plugins
+	 *
+	 * @action wpseo_handle_import
 	 */
 	public function callback_wpseo_handle_import() {
 		$imports = array(
-			'importheadspace'   => esc_html__( 'HeadSpace2', 'stream' ), // type = checkbox
-			'importaioseo'      => esc_html__( 'All-in-One SEO', 'stream' ), // type = checkbox
-			'importaioseoold'   => esc_html__( 'OLD All-in-One SEO', 'stream' ), // type = checkbox
-			'importwoo'         => esc_html__( 'WooThemes SEO framework', 'stream' ), // type = checkbox
-			'importrobotsmeta'  => esc_html__( 'Robots Meta (by Yoast)', 'stream' ), // type = checkbox
-			'importrssfooter'   => esc_html__( 'RSS Footer (by Yoast)', 'stream' ), // type = checkbox
-			'importbreadcrumbs' => esc_html__( 'Yoast Breadcrumbs', 'stream' ), // type = checkbox
+			'importheadspace'   => esc_html__( 'HeadSpace2', 'stream' ), // type = checkbox.
+			'importaioseo'      => esc_html__( 'All-in-One SEO', 'stream' ), // type = checkbox.
+			'importaioseoold'   => esc_html__( 'OLD All-in-One SEO', 'stream' ), // type = checkbox.
+			'importwoo'         => esc_html__( 'WooThemes SEO framework', 'stream' ), // type = checkbox.
+			'importrobotsmeta'  => esc_html__( 'Robots Meta (by Yoast)', 'stream' ), // type = checkbox.
+			'importrssfooter'   => esc_html__( 'RSS Footer (by Yoast)', 'stream' ), // type = checkbox.
+			'importbreadcrumbs' => esc_html__( 'Yoast Breadcrumbs', 'stream' ), // type = checkbox.
 		);
 
 		$opts = wp_stream_filter_input( INPUT_POST, 'wpseo' );
@@ -228,7 +253,7 @@ class Connector_WordPress_SEO extends Connector {
 			if ( isset( $opts[ $key ] ) ) {
 				$this->log(
 					sprintf(
-						// translators: Placeholders refer to an import method, and an extra string (sometimes blank) (e.g. "HeadSpace2", ", and deleted old data")
+						/* translators: %1$s: an import method, %2$s: an extra string (sometimes blank) (e.g. "HeadSpace2", ", and deleted old data") */
 						__( 'Imported settings from %1$s%2$s', 'stream' ),
 						$name,
 						isset( $opts['deleteolddata'] ) ? esc_html__( ', and deleted old data', 'stream' ) : ''
@@ -245,13 +270,18 @@ class Connector_WordPress_SEO extends Connector {
 		}
 	}
 
+	/**
+	 * Track importing settings
+	 *
+	 * @callback wpseo_import
+	 */
 	public function callback_wpseo_import() {
 		$opts = wp_stream_filter_input( INPUT_POST, 'wpseo' );
 
 		if ( wp_stream_filter_input( INPUT_POST, 'wpseo_export' ) ) {
 			$this->log(
 				sprintf(
-					// translators: Placeholder refers to an extra string (sometimes blank) (e.g. ", including taxonomy meta")
+					/* translators: %s: an extra string (sometimes blank) (e.g. ", including taxonomy meta") */
 					__( 'Exported settings%s', 'stream' ),
 					isset( $opts['include_taxonomy_meta'] ) ? esc_html__( ', including taxonomy meta', 'stream' ) : ''
 				),
@@ -262,15 +292,15 @@ class Connector_WordPress_SEO extends Connector {
 				'wpseo_import',
 				'exported'
 			);
-		} elseif ( isset( $_FILES['settings_import_file']['name'] ) ) { // phpcs: input var okay
+		} elseif ( isset( $_FILES['settings_import_file']['name'] ) ) { // phpcs: input var okay.
 			$this->log(
 				sprintf(
-					// translators: Placeholder refers to a filename (e.g. "test.xml")
+					/* translators: %s: a filename (e.g. "test.xml") */
 					__( 'Tried importing settings from "%s"', 'stream' ),
-					sanitize_text_field( wp_unslash( $_FILES['settings_import_file']['name'] ) ) // phpcs: input var okay
+					sanitize_text_field( wp_unslash( $_FILES['settings_import_file']['name'] ) ) // phpcs: input var okay.
 				),
 				array(
-					'file' => sanitize_text_field( wp_unslash( $_FILES['settings_import_file']['name'] ) ), // phpcs: input var okay
+					'file' => sanitize_text_field( wp_unslash( $_FILES['settings_import_file']['name'] ) ), // phpcs: input var okay.
 				),
 				null,
 				'wpseo_import',
@@ -279,6 +309,11 @@ class Connector_WordPress_SEO extends Connector {
 		}
 	}
 
+	/**
+	 * Tracks creation of SEO-related files.
+	 *
+	 * @action seo_page_wpseo_files
+	 */
 	public function callback_seo_page_wpseo_files() {
 		if ( wp_stream_filter_input( INPUT_POST, 'create_robots' ) ) {
 			$message = esc_html__( 'Tried creating robots.txt file', 'stream' );
@@ -299,19 +334,58 @@ class Connector_WordPress_SEO extends Connector {
 		}
 	}
 
+	/**
+	 * Tracks the creation of WordPress SEO post meta
+	 *
+	 * @action added_post_meta
+	 *
+	 * @param int    $meta_id     Meta ID.
+	 * @param int    $object_id   Object ID.
+	 * @param string $meta_key    Meta key.
+	 * @param string $meta_value  Meta value.
+	 */
 	public function callback_added_post_meta( $meta_id, $object_id, $meta_key, $meta_value ) {
 		unset( $meta_id );
 		$this->meta( $object_id, $meta_key, $meta_value );
 	}
+
+	/**
+	 * Tracks the updates to WordPress SEO post meta
+	 *
+	 * @action updated_post_meta
+	 *
+	 * @param int    $meta_id     Meta ID.
+	 * @param int    $object_id   Object ID.
+	 * @param string $meta_key    Meta key.
+	 * @param string $meta_value  Meta value.
+	 */
 	public function callback_updated_post_meta( $meta_id, $object_id, $meta_key, $meta_value ) {
 		unset( $meta_id );
 		$this->meta( $object_id, $meta_key, $meta_value );
 	}
+
+	/**
+	 * Tracks the deletions of WordPress SEO post meta
+	 *
+	 * @action deleted_post_meta
+	 *
+	 * @param int    $meta_id     Meta ID.
+	 * @param int    $object_id   Object ID.
+	 * @param string $meta_key    Meta key.
+	 * @param string $meta_value  Meta value.
+	 */
 	public function callback_deleted_post_meta( $meta_id, $object_id, $meta_key, $meta_value ) {
 		unset( $meta_id );
 		$this->meta( $object_id, $meta_key, $meta_value );
 	}
 
+	/**
+	 * Logs WordPress SEO meta activity
+	 *
+	 * @param int    $object_id   Object ID.
+	 * @param int    $meta_key    Meta key.
+	 * @param string $meta_value  Meta value.
+	 */
 	private function meta( $object_id, $meta_key, $meta_value ) {
 		$prefix = \WPSEO_Meta::$meta_prefix;
 
@@ -339,7 +413,7 @@ class Connector_WordPress_SEO extends Connector {
 
 		$this->log(
 			sprintf(
-				// translators: Placeholders refer to a meta field title, a post title, and a post type (e.g. "Description", "Hello World", "Post")
+				/* translators: %1$s: a meta field title, %2$s: a post title, %3$s: a post type (e.g. "Description", "Hello World", "Post") */
 				__( 'Updated "%1$s" of "%2$s" %3$s', 'stream' ),
 				$field['title'],
 				$post->post_title,
@@ -359,7 +433,7 @@ class Connector_WordPress_SEO extends Connector {
 	/**
 	 * Override connector log for our own Settings / Actions
 	 *
-	 * @param array $data
+	 * @param array $data  Record data.
 	 *
 	 * @return array|bool
 	 */
@@ -384,7 +458,7 @@ class Connector_WordPress_SEO extends Connector {
 
 			$label = $this->settings_labels( $data['args']['option_key'] );
 			if ( ! $label ) {
-				// translators: Placeholder refers to a context (e.g. "Dashboard")
+				/* translators: %s: a context (e.g. "Dashboard") */
 				$data['message'] = esc_html__( '%s settings updated', 'stream' );
 				$label           = $labels[ $page ];
 			}
@@ -398,114 +472,121 @@ class Connector_WordPress_SEO extends Connector {
 		return $data;
 	}
 
+	/**
+	 * Return the labels
+	 *
+	 * @param string $option  Name of option to be retrieved.
+	 *
+	 * @return array|bool.
+	 */
 	private function settings_labels( $option ) {
 		$labels = array(
-			// wp-content/plugins/wordpress-seo/admin/pages/dashboard.php:
-			'yoast_tracking'                         => esc_html_x( "Allow tracking of this WordPress install's anonymous data.", 'wordpress-seo', 'stream' ), // type = checkbox
-			'disableadvanced_meta'                   => esc_html_x( 'Disable the Advanced part of the WordPress SEO meta box', 'wordpress-seo', 'stream' ), // type = checkbox
-			'alexaverify'                            => esc_html_x( 'Alexa Verification ID', 'wordpress-seo', 'stream' ), // type = textinput
-			'msverify'                               => esc_html_x( 'Bing Webmaster Tools', 'wordpress-seo', 'stream' ), // type = textinput
-			'googleverify'                           => esc_html_x( 'Google Webmaster Tools', 'wordpress-seo', 'stream' ), // type = textinput
-			'pinterestverify'                        => esc_html_x( 'Pinterest', 'wordpress-seo', 'stream' ), // type = textinput
-			'yandexverify'                           => esc_html_x( 'Yandex Webmaster Tools', 'wordpress-seo', 'stream' ), // type = textinput
+			// wp-content/plugins/wordpress-seo/admin/pages/dashboard.php:.
+			'yoast_tracking'                         => esc_html_x( "Allow tracking of this WordPress install's anonymous data.", 'wordpress-seo', 'stream' ), // type = checkbox.
+			'disableadvanced_meta'                   => esc_html_x( 'Disable the Advanced part of the WordPress SEO meta box', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'alexaverify'                            => esc_html_x( 'Alexa Verification ID', 'wordpress-seo', 'stream' ), // type = textinput.
+			'msverify'                               => esc_html_x( 'Bing Webmaster Tools', 'wordpress-seo', 'stream' ), // type = textinput.
+			'googleverify'                           => esc_html_x( 'Google Webmaster Tools', 'wordpress-seo', 'stream' ), // type = textinput.
+			'pinterestverify'                        => esc_html_x( 'Pinterest', 'wordpress-seo', 'stream' ), // type = textinput.
+			'yandexverify'                           => esc_html_x( 'Yandex Webmaster Tools', 'wordpress-seo', 'stream' ), // type = textinput.
 
-			// wp-content/plugins/wordpress-seo/admin/pages/advanced.php:
-			'breadcrumbs-enable'                     => esc_html_x( 'Enable Breadcrumbs', 'wordpress-seo', 'stream' ), // type = checkbox
-			'breadcrumbs-sep'                        => esc_html_x( 'Separator between breadcrumbs', 'wordpress-seo', 'stream' ), // type = textinput
-			'breadcrumbs-home'                       => esc_html_x( 'Anchor text for the Homepage', 'wordpress-seo', 'stream' ), // type = textinput
-			'breadcrumbs-prefix'                     => esc_html_x( 'Prefix for the breadcrumb path', 'wordpress-seo', 'stream' ), // type = textinput
-			'breadcrumbs-archiveprefix'              => esc_html_x( 'Prefix for Archive breadcrumbs', 'wordpress-seo', 'stream' ), // type = textinput
-			'breadcrumbs-searchprefix'               => esc_html_x( 'Prefix for Search Page breadcrumbs', 'wordpress-seo', 'stream' ), // type = textinput
-			'breadcrumbs-404crumb'                   => esc_html_x( 'Breadcrumb for 404 Page', 'wordpress-seo', 'stream' ), // type = textinput
-			'breadcrumbs-blog-remove'                => esc_html_x( 'Remove Blog page from Breadcrumbs', 'wordpress-seo', 'stream' ), // type = checkbox
-			'breadcrumbs-boldlast'                   => esc_html_x( 'Bold the last page in the breadcrumb', 'wordpress-seo', 'stream' ), // type = checkbox
-			'post_types-post-maintax'                => esc_html_x( 'Taxonomy to show in breadcrumbs for post types', 'wordpress-seo', 'stream' ), // type = select
+			// wp-content/plugins/wordpress-seo/admin/pages/advanced.php:.
+			'breadcrumbs-enable'                     => esc_html_x( 'Enable Breadcrumbs', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'breadcrumbs-sep'                        => esc_html_x( 'Separator between breadcrumbs', 'wordpress-seo', 'stream' ), // type = textinput.
+			'breadcrumbs-home'                       => esc_html_x( 'Anchor text for the Homepage', 'wordpress-seo', 'stream' ), // type = textinput.
+			'breadcrumbs-prefix'                     => esc_html_x( 'Prefix for the breadcrumb path', 'wordpress-seo', 'stream' ), // type = textinput.
+			'breadcrumbs-archiveprefix'              => esc_html_x( 'Prefix for Archive breadcrumbs', 'wordpress-seo', 'stream' ), // type = textinput.
+			'breadcrumbs-searchprefix'               => esc_html_x( 'Prefix for Search Page breadcrumbs', 'wordpress-seo', 'stream' ), // type = textinput.
+			'breadcrumbs-404crumb'                   => esc_html_x( 'Breadcrumb for 404 Page', 'wordpress-seo', 'stream' ), // type = textinput.
+			'breadcrumbs-blog-remove'                => esc_html_x( 'Remove Blog page from Breadcrumbs', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'breadcrumbs-boldlast'                   => esc_html_x( 'Bold the last page in the breadcrumb', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'post_types-post-maintax'                => esc_html_x( 'Taxonomy to show in breadcrumbs for post types', 'wordpress-seo', 'stream' ), // type = select.
 
-			// wp-content/plugins/wordpress-seo/admin/pages/metas.php:
-			'forcerewritetitle'                      => esc_html_x( 'Force rewrite titles', 'wordpress-seo', 'stream' ), // type = checkbox
-			'noindex-subpages-wpseo'                 => esc_html_x( 'Noindex subpages of archives', 'wordpress-seo', 'stream' ), // type = checkbox
-			'usemetakeywords'                        => _x( 'Use <code>meta</code> keywords tag?', 'wordpress-seo', 'stream' ), // type = checkbox
-			'noodp'                                  => _x( 'Add <code>noodp</code> meta robots tag sitewide', 'wordpress-seo', 'stream' ), // type = checkbox
-			'noydir'                                 => _x( 'Add <code>noydir</code> meta robots tag sitewide', 'wordpress-seo', 'stream' ), // type = checkbox
-			'hide-rsdlink'                           => esc_html_x( 'Hide RSD Links', 'wordpress-seo', 'stream' ), // type = checkbox
-			'hide-wlwmanifest'                       => esc_html_x( 'Hide WLW Manifest Links', 'wordpress-seo', 'stream' ), // type = checkbox
-			'hide-shortlink'                         => esc_html_x( 'Hide Shortlink for posts', 'wordpress-seo', 'stream' ), // type = checkbox
-			'hide-feedlinks'                         => esc_html_x( 'Hide RSS Links', 'wordpress-seo', 'stream' ), // type = checkbox
-			'disable-author'                         => esc_html_x( 'Disable the author archives', 'wordpress-seo', 'stream' ), // type = checkbox
-			'disable-date'                           => esc_html_x( 'Disable the date-based archives', 'wordpress-seo', 'stream' ), // type = checkbox
+			// wp-content/plugins/wordpress-seo/admin/pages/metas.php:.
+			'forcerewritetitle'                      => esc_html_x( 'Force rewrite titles', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'noindex-subpages-wpseo'                 => esc_html_x( 'Noindex subpages of archives', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'usemetakeywords'                        => _x( 'Use <code>meta</code> keywords tag?', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'noodp'                                  => _x( 'Add <code>noodp</code> meta robots tag sitewide', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'noydir'                                 => _x( 'Add <code>noydir</code> meta robots tag sitewide', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'hide-rsdlink'                           => esc_html_x( 'Hide RSD Links', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'hide-wlwmanifest'                       => esc_html_x( 'Hide WLW Manifest Links', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'hide-shortlink'                         => esc_html_x( 'Hide Shortlink for posts', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'hide-feedlinks'                         => esc_html_x( 'Hide RSS Links', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'disable-author'                         => esc_html_x( 'Disable the author archives', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'disable-date'                           => esc_html_x( 'Disable the date-based archives', 'wordpress-seo', 'stream' ), // type = checkbox.
 
-			// wp-content/plugins/wordpress-seo/admin/pages/network.php:
-			'access'                                 => esc_html_x( 'Who should have access to the WordPress SEO settings', 'wordpress-seo', 'stream' ), // type = select
-			'defaultblog'                            => esc_html_x( 'New blogs get the SEO settings from this blog', 'wordpress-seo', 'stream' ), // type = textinput
-			'restoreblog'                            => esc_html_x( 'Blog ID', 'wordpress-seo', 'stream' ), // type = textinput
+			// wp-content/plugins/wordpress-seo/admin/pages/network.php:.
+			'access'                                 => esc_html_x( 'Who should have access to the WordPress SEO settings', 'wordpress-seo', 'stream' ), // type = select.
+			'defaultblog'                            => esc_html_x( 'New blogs get the SEO settings from this blog', 'wordpress-seo', 'stream' ), // type = textinput.
+			'restoreblog'                            => esc_html_x( 'Blog ID', 'wordpress-seo', 'stream' ), // type = textinput.
 
-			// wp-content/plugins/wordpress-seo/admin/pages/permalinks.php:
-			'stripcategorybase'                      => _x( 'Strip the category base (usually <code>/category/</code>) from the category URL.', 'wordpress-seo', 'stream' ), // type = checkbox
-			'trailingslash'                          => esc_html_x( "Enforce a trailing slash on all category and tag URL's", 'wordpress-seo', 'stream' ), // type = checkbox
-			'cleanslugs'                             => esc_html_x( 'Remove stop words from slugs.', 'wordpress-seo', 'stream' ), // type = checkbox
-			'redirectattachment'                     => esc_html_x( "Redirect attachment URL's to parent post URL.", 'wordpress-seo', 'stream' ), // type = checkbox
-			'cleanreplytocom'                        => _x( 'Remove the <code>?replytocom</code> variables.', 'wordpress-seo', 'stream' ), // type = checkbox
-			'cleanpermalinks'                        => esc_html_x( "Redirect ugly URL's to clean permalinks. (Not recommended in many cases!)", 'wordpress-seo', 'stream' ), // type = checkbox
-			'force_transport'                        => esc_html_x( 'Force Transport', 'wordpress-seo', 'stream' ), // type = select
-			'cleanpermalink-googlesitesearch'        => esc_html_x( "Prevent cleaning out Google Site Search URL's.", 'wordpress-seo', 'stream' ), // type = checkbox
-			'cleanpermalink-googlecampaign'          => esc_html_x( 'Prevent cleaning out Google Analytics Campaign & Google AdWords Parameters.', 'wordpress-seo', 'stream' ), // type = checkbox
-			'cleanpermalink-extravars'               => esc_html_x( 'Other variables not to clean', 'wordpress-seo', 'stream' ), // type = textinput
+			// wp-content/plugins/wordpress-seo/admin/pages/permalinks.php:.
+			'stripcategorybase'                      => _x( 'Strip the category base (usually <code>/category/</code>) from the category URL.', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'trailingslash'                          => esc_html_x( "Enforce a trailing slash on all category and tag URL's", 'wordpress-seo', 'stream' ), // type = checkbox.
+			'cleanslugs'                             => esc_html_x( 'Remove stop words from slugs.', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'redirectattachment'                     => esc_html_x( "Redirect attachment URL's to parent post URL.", 'wordpress-seo', 'stream' ), // type = checkbox.
+			'cleanreplytocom'                        => _x( 'Remove the <code>?replytocom</code> variables.', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'cleanpermalinks'                        => esc_html_x( "Redirect ugly URL's to clean permalinks. (Not recommended in many cases!)", 'wordpress-seo', 'stream' ), // type = checkbox.
+			'force_transport'                        => esc_html_x( 'Force Transport', 'wordpress-seo', 'stream' ), // type = select.
+			'cleanpermalink-googlesitesearch'        => esc_html_x( "Prevent cleaning out Google Site Search URL's.", 'wordpress-seo', 'stream' ), // type = checkbox.
+			'cleanpermalink-googlecampaign'          => esc_html_x( 'Prevent cleaning out Google Analytics Campaign & Google AdWords Parameters.', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'cleanpermalink-extravars'               => esc_html_x( 'Other variables not to clean', 'wordpress-seo', 'stream' ), // type = textinput.
 
-			// wp-content/plugins/wordpress-seo/admin/pages/social.php:
-			'opengraph'                              => esc_html_x( 'Add Open Graph meta data', 'wordpress-seo', 'stream' ), // type = checkbox
-			'facebook_site'                          => esc_html_x( 'Facebook Page URL', 'wordpress-seo', 'stream' ), // type = textinput
-			'instagram_url'                          => esc_html_x( 'Instagram URL', 'wordpress-seo', 'stream' ), // type = textinput
-			'linkedin_url'                           => esc_html_x( 'LinkedIn URL', 'wordpress-seo', 'stream' ), // type = textinput
-			'myspace_url'                            => esc_html_x( 'MySpace URL', 'wordpress-seo', 'stream' ), // type = textinput
-			'pinterest_url'                          => esc_html_x( 'Pinterest URL', 'wordpress-seo', 'stream' ), // type = textinput
-			'youtube_url'                            => esc_html_x( 'YouTube URL', 'wordpress-seo', 'stream' ), // type = textinput
-			'google_plus_url'                        => esc_html_x( 'Google+ URL', 'wordpress-seo', 'stream' ), // type = textinput
-			'og_frontpage_image'                     => esc_html_x( 'Image URL', 'wordpress-seo', 'stream' ), // type = textinput
-			'og_frontpage_desc'                      => esc_html_x( 'Description', 'wordpress-seo', 'stream' ), // type = textinput
-			'og_frontpage_title'                     => esc_html_x( 'Title', 'wordpress-seo', 'stream' ), // type = textinput
-			'og_default_image'                       => esc_html_x( 'Image URL', 'wordpress-seo', 'stream' ), // type = textinput
-			'twitter'                                => esc_html_x( 'Add Twitter card meta data', 'wordpress-seo', 'stream' ), // type = checkbox
-			'twitter_site'                           => esc_html_x( 'Site Twitter Username', 'wordpress-seo', 'stream' ), // type = textinput
-			'twitter_card_type'                      => esc_html_x( 'The default card type to use', 'wordpress-seo', 'stream' ), // type = select
-			'googleplus'                             => esc_html_x( 'Add Google+ specific post meta data (excluding author metadata)', 'wordpress-seo', 'stream' ), // type = checkbox
-			'plus-publisher'                         => esc_html_x( 'Google Publisher Page', 'wordpress-seo', 'stream' ), // type = textinput
-			'fbadminapp'                             => esc_html_x( 'Facebook App ID', 'wordpress-seo', 'stream' ), // type = textinput
+			// wp-content/plugins/wordpress-seo/admin/pages/social.php:.
+			'opengraph'                              => esc_html_x( 'Add Open Graph meta data', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'facebook_site'                          => esc_html_x( 'Facebook Page URL', 'wordpress-seo', 'stream' ), // type = textinput.
+			'instagram_url'                          => esc_html_x( 'Instagram URL', 'wordpress-seo', 'stream' ), // type = textinput.
+			'linkedin_url'                           => esc_html_x( 'LinkedIn URL', 'wordpress-seo', 'stream' ), // type = textinput.
+			'myspace_url'                            => esc_html_x( 'MySpace URL', 'wordpress-seo', 'stream' ), // type = textinput.
+			'pinterest_url'                          => esc_html_x( 'Pinterest URL', 'wordpress-seo', 'stream' ), // type = textinput.
+			'youtube_url'                            => esc_html_x( 'YouTube URL', 'wordpress-seo', 'stream' ), // type = textinput.
+			'google_plus_url'                        => esc_html_x( 'Google+ URL', 'wordpress-seo', 'stream' ), // type = textinput.
+			'og_frontpage_image'                     => esc_html_x( 'Image URL', 'wordpress-seo', 'stream' ), // type = textinput.
+			'og_frontpage_desc'                      => esc_html_x( 'Description', 'wordpress-seo', 'stream' ), // type = textinput.
+			'og_frontpage_title'                     => esc_html_x( 'Title', 'wordpress-seo', 'stream' ), // type = textinput.
+			'og_default_image'                       => esc_html_x( 'Image URL', 'wordpress-seo', 'stream' ), // type = textinput.
+			'twitter'                                => esc_html_x( 'Add Twitter card meta data', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'twitter_site'                           => esc_html_x( 'Site Twitter Username', 'wordpress-seo', 'stream' ), // type = textinput.
+			'twitter_card_type'                      => esc_html_x( 'The default card type to use', 'wordpress-seo', 'stream' ), // type = select.
+			'googleplus'                             => esc_html_x( 'Add Google+ specific post meta data (excluding author metadata)', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'plus-publisher'                         => esc_html_x( 'Google Publisher Page', 'wordpress-seo', 'stream' ), // type = textinput.
+			'fbadminapp'                             => esc_html_x( 'Facebook App ID', 'wordpress-seo', 'stream' ), // type = textinput.
 
-			// wp-content/plugins/wordpress-seo/admin/pages/xml-sitemaps.php:
-			'enablexmlsitemap'                       => esc_html_x( 'Check this box to enable XML sitemap functionality.', 'wordpress-seo', 'stream' ), // type = checkbox
-			'disable_author_sitemap'                 => esc_html_x( 'Disable author/user sitemap', 'wordpress-seo', 'stream' ), // type = checkbox
-			'disable_author_noposts'                 => esc_html_x( 'Users with zero posts', 'wordpress-seo', 'stream' ), // type = checkbox
-			'user_role-administrator-not_in_sitemap' => esc_html_x( 'Filter specific user roles - Administrator', 'wordpress-seo', 'stream' ), // type = checkbox
-			'user_role-editor-not_in_sitemap'        => esc_html_x( 'Filter specific user roles - Editor', 'wordpress-seo', 'stream' ), // type = checkbox
-			'user_role-author-not_in_sitemap'        => esc_html_x( 'Filter specific user roles - Author', 'wordpress-seo', 'stream' ), // type = checkbox
-			'user_role-contributor-not_in_sitemap'   => esc_html_x( 'Filter specific user roles - Contributor', 'wordpress-seo', 'stream' ), // type = checkbox
-			'user_role-subscriber-not_in_sitemap'    => esc_html_x( 'Filter specific user roles - Subscriber', 'wordpress-seo', 'stream' ), // type = checkbox
-			'xml_ping_yahoo'                         => esc_html_x( 'Ping Yahoo!', 'wordpress-seo', 'stream' ), // type = checkbox
-			'xml_ping_ask'                           => esc_html_x( 'Ping Ask.com', 'wordpress-seo', 'stream' ), // type = checkbox
-			'entries-per-page'                       => esc_html_x( 'Max entries per sitemap page', 'wordpress-seo', 'stream' ), // type = textinput
-			'excluded-posts'                         => esc_html_x( 'Posts to exclude', 'wordpress-seo', 'stream' ), // type = textinput
-			'post_types-post-not_in_sitemap'         => _x( 'Post Types Posts (<code>post</code>)', 'wordpress-seo', 'stream' ), // type = checkbox
-			'post_types-page-not_in_sitemap'         => _x( 'Post Types Pages (<code>page</code>)', 'wordpress-seo', 'stream' ), // type = checkbox
-			'post_types-attachment-not_in_sitemap'   => _x( 'Post Types Media (<code>attachment</code>)', 'wordpress-seo', 'stream' ), // type = checkbox
-			'taxonomies-category-not_in_sitemap'     => _x( 'Taxonomies Categories (<code>category</code>)', 'wordpress-seo', 'stream' ), // type = checkbox
-			'taxonomies-post_tag-not_in_sitemap'     => _x( 'Taxonomies Tags (<code>post_tag</code>)', 'wordpress-seo', 'stream' ), // type = checkbox
+			// wp-content/plugins/wordpress-seo/admin/pages/xml-sitemaps.php:.
+			'enablexmlsitemap'                       => esc_html_x( 'Check this box to enable XML sitemap functionality.', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'disable_author_sitemap'                 => esc_html_x( 'Disable author/user sitemap', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'disable_author_noposts'                 => esc_html_x( 'Users with zero posts', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'user_role-administrator-not_in_sitemap' => esc_html_x( 'Filter specific user roles - Administrator', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'user_role-editor-not_in_sitemap'        => esc_html_x( 'Filter specific user roles - Editor', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'user_role-author-not_in_sitemap'        => esc_html_x( 'Filter specific user roles - Author', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'user_role-contributor-not_in_sitemap'   => esc_html_x( 'Filter specific user roles - Contributor', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'user_role-subscriber-not_in_sitemap'    => esc_html_x( 'Filter specific user roles - Subscriber', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'xml_ping_yahoo'                         => esc_html_x( 'Ping Yahoo!', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'xml_ping_ask'                           => esc_html_x( 'Ping Ask.com', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'entries-per-page'                       => esc_html_x( 'Max entries per sitemap page', 'wordpress-seo', 'stream' ), // type = textinput.
+			'excluded-posts'                         => esc_html_x( 'Posts to exclude', 'wordpress-seo', 'stream' ), // type = textinput.
+			'post_types-post-not_in_sitemap'         => _x( 'Post Types Posts (<code>post</code>)', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'post_types-page-not_in_sitemap'         => _x( 'Post Types Pages (<code>page</code>)', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'post_types-attachment-not_in_sitemap'   => _x( 'Post Types Media (<code>attachment</code>)', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'taxonomies-category-not_in_sitemap'     => _x( 'Taxonomies Categories (<code>category</code>)', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'taxonomies-post_tag-not_in_sitemap'     => _x( 'Taxonomies Tags (<code>post_tag</code>)', 'wordpress-seo', 'stream' ), // type = checkbox.
 
-			// Added manually
+			// Added manually.
 			'rssbefore'                              => esc_html_x( 'Content to put before each post in the feed', 'wordpress-seo', 'stream' ),
 			'rssafter'                               => esc_html_x( 'Content to put after each post', 'wordpress-seo', 'stream' ),
 		);
 
 		$ast_labels = array(
-			'title-'        => esc_html_x( 'Title template', 'wordpress-seo', 'stream' ), // type = textinput
-			'metadesc-'     => esc_html_x( 'Meta description template', 'wordpress-seo', 'stream' ), // type = textarea
-			'metakey-'      => esc_html_x( 'Meta keywords template', 'wordpress-seo', 'stream' ), // type = textinput
-			'noindex-'      => esc_html_x( 'Meta Robots', 'wordpress-seo', 'stream' ), // type = checkbox
-			'noauthorship-' => esc_html_x( 'Authorship', 'wordpress-seo', 'stream' ), // type = checkbox
-			'showdate-'     => esc_html_x( 'Show date in snippet preview?', 'wordpress-seo', 'stream' ), // type = checkbox
-			'hideeditbox-'  => esc_html_x( 'WordPress SEO Meta Box', 'wordpress-seo', 'stream' ), // type = checkbox
-			'bctitle-'      => esc_html_x( 'Breadcrumbs Title', 'wordpress-seo', 'stream' ), // type = textinput
-			'post_types-'   => esc_html_x( 'Post types', 'wordpress-seo', 'stream' ), // type = checkbox
-			'taxonomies-'   => esc_html_x( 'Taxonomies', 'wordpress-seo', 'stream' ), // type = checkbox
+			'title-'        => esc_html_x( 'Title template', 'wordpress-seo', 'stream' ), // type = textinput.
+			'metadesc-'     => esc_html_x( 'Meta description template', 'wordpress-seo', 'stream' ), // type = textarea.
+			'metakey-'      => esc_html_x( 'Meta keywords template', 'wordpress-seo', 'stream' ), // type = textinput.
+			'noindex-'      => esc_html_x( 'Meta Robots', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'noauthorship-' => esc_html_x( 'Authorship', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'showdate-'     => esc_html_x( 'Show date in snippet preview?', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'hideeditbox-'  => esc_html_x( 'WordPress SEO Meta Box', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'bctitle-'      => esc_html_x( 'Breadcrumbs Title', 'wordpress-seo', 'stream' ), // type = textinput.
+			'post_types-'   => esc_html_x( 'Post types', 'wordpress-seo', 'stream' ), // type = checkbox.
+			'taxonomies-'   => esc_html_x( 'Taxonomies', 'wordpress-seo', 'stream' ), // type = checkbox.
 		);
 
 		if ( $option ) {


### PR DESCRIPTION
Partially fixes #1090 
Related to #1095 

# Summary
Similar to what's being done with the `classes` directory, but with the `connectors` directory.
Documentation is being updated/completed file-by-file.

## File checklist
- [x] `connectors/class-connector-acf.php`
- [x] `connectors/class-connector-bbpress.php`
- [x] `connectors/class-connector-blog.php`
- [x] `connectors/class-connector-buddypress.php`
- [x] `connectors/class-connector-comments.php`
- [x] `connectors/class-connector-edd.php`
- [x] `connectors/class-connector-editor.php`
- [x] `connectors/class-connector-gravityforms.php`
- [x] `connectors/class-connector-installer.php`
- [x] `connectors/class-connector-media.php`
- [x] `connectors/class-connector-menus.php`
- [x] `connectors/class-connector-mercator.php`
- [x] `connectors/class-connector-posts.php`
- [x] `connectors/class-connector-settings.php`
- [x] `connectors/class-connector-taxonomies.php`
- [x] `connectors/class-connector-user-switching.php`
- [x] `connectors/class-connector-users.php`
- [x] `connectors/class-connector-widgets.php`
- [x] `connectors/class-connector-woocommerce.php`
- [x] `connectors/class-connector-wordpress-seo.php`

# Possible Blockers
I may have broken some of the connector callback log messages in my cleaning up of the `/* translators */` notes.