### PR TITLE
Fixes broken date in MySQL 8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - mysql
       - db_phpunit
     ports:
-      - "8080:80"
+      - "80:80"
       - "443:443"
       - "9000:9000" # Xdebug
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
 
   mysql:
-    image: mysql:8
+    image: mysql:5
     command: '--default-authentication-plugin=mysql_native_password'
     volumes:
       - db_data:/var/lib/mysql
@@ -36,13 +36,9 @@ services:
       APACHE_RUN_USER: "#1000" # Ensure Apache can write to the filesystem.
       WP_TESTS_DIR: /var/www/html/wp-content/plugins/stream-src/vendor/wp-phpunit/wp-phpunit
       WP_PHPUNIT__TESTS_CONFIG: /var/www/html/wp-tests-config.php
-      WORDPRESS_DB_HOST: "mysql:3306"
-      WORDPRESS_DEBUG: 1
-      WORDPRESS_DB_USER: wordpress
-      WORDPRESS_DB_PASSWORD: password
 
   db_phpunit:
-    image: mysql:8
+    image: mysql:5
     command: '--default-authentication-plugin=mysql_native_password'
     restart: always
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,8 @@ version: '3'
 services:
 
   mysql:
-    image: mysql:5
+    image: mysql:8
+    command: '--default-authentication-plugin=mysql_native_password'
     volumes:
       - db_data:/var/lib/mysql
     restart: always
@@ -19,7 +20,7 @@ services:
       - mysql
       - db_phpunit
     ports:
-      - "80:80"
+      - "8080:80"
       - "443:443"
       - "9000:9000" # Xdebug
     volumes:
@@ -35,9 +36,14 @@ services:
       APACHE_RUN_USER: "#1000" # Ensure Apache can write to the filesystem.
       WP_TESTS_DIR: /var/www/html/wp-content/plugins/stream-src/vendor/wp-phpunit/wp-phpunit
       WP_PHPUNIT__TESTS_CONFIG: /var/www/html/wp-tests-config.php
+      WORDPRESS_DB_HOST: "mysql:3306"
+      WORDPRESS_DEBUG: 1
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: password
 
   db_phpunit:
-    image: mysql:5.7
+    image: mysql:8
+    command: '--default-authentication-plugin=mysql_native_password'
     restart: always
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
 
   mysql:
     image: mysql:5
-    command: '--default-authentication-plugin=mysql_native_password'
     volumes:
       - db_data:/var/lib/mysql
     restart: always
@@ -38,8 +37,7 @@ services:
       WP_PHPUNIT__TESTS_CONFIG: /var/www/html/wp-tests-config.php
 
   db_phpunit:
-    image: mysql:5
-    command: '--default-authentication-plugin=mysql_native_password'
+    image: mysql:5.7
     restart: always
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -53,12 +53,7 @@ function wp_stream_get_iso_8601_extended_date( $time = false, $offset = 0 ) {
 	$timezone = new DateTimeZone( $offset_string );
 	$date     = new DateTime( gmdate( 'Y-m-d H:i:s.' . $micro_seconds, $microtime ), $timezone );
 
-	return sprintf(
-		'%s%03d%s',
-		$date->format( 'Y-m-d\TH:i:s.' ),
-		floor( $date->format( 'u' ) / 1000 ),
-		$date->format( 'O' )
-	);
+	return $date->format( DateTime::ATOM );
 }
 
 /**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -35,8 +35,8 @@ function wp_stream_filter_var( $var, $filter = null, $options = array() ) {
 /**
  * Converts a time into an ISO 8601 extended formatted string.
  *
- * @param int|bool $time Seconds since unix epoc
- * @param int      $offset Hour offset
+ * @param int|bool $time   Seconds since unix epoch.
+ * @param int      $offset Timezone offset.
  *
  * @return string an ISO 8601 extended formatted time
  */
@@ -48,12 +48,12 @@ function wp_stream_get_iso_8601_extended_date( $time = false, $offset = 0 ) {
 	}
 
 	$micro_seconds = sprintf( '%06d', ( $microtime - floor( $microtime ) ) * 1000000 );
-	$offset_string = sprintf( 'Etc/GMT%s%s', $offset < 0 ? '+' : '-', abs( $offset ) );
+	$offset_string = sprintf( 'Etc/GMT%s%d', $offset < 0 ? '+' : '-', abs( $offset ) );
 
 	$timezone = new DateTimeZone( $offset_string );
 	$date     = new DateTime( gmdate( 'Y-m-d H:i:s.' . $micro_seconds, $microtime ), $timezone );
 
-	return $date->format( DateTime::ATOM );
+	return $date->format( 'Y-m-d\TH:i:sO' );
 }
 
 /**

--- a/tests/tests/test-functions.php
+++ b/tests/tests/test-functions.php
@@ -1,0 +1,14 @@
+<?php
+namespace WP_Stream;
+
+class Test_Functions extends WP_StreamTestCase {
+	public function test_wp_stream_get_iso_8601_extended_date() {
+		$time = '1095379198';
+
+		$date 		 = wp_stream_get_iso_8601_extended_date( $time );
+		$this->assertSame( $date, '2004-09-16T23:59:58+0000' );
+
+		$offset_date = wp_stream_get_iso_8601_extended_date( $time, 5 );
+		$this->assertSame( $offset_date, '2004-09-16T23:59:58+0500' );
+	}
+}


### PR DESCRIPTION
Fixes #1091 

Replaces old `sprintf( ... )` formatting logic with `$date->format( DateTime::ATOM )`  to create the ISO 8601 formatted timestamp to be used in the record. 