### PR TITLE
Disable process timeout on install command.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
     }
   },
   "scripts": {
+    "pre-install-cmd": [
+      "Composer\\Config::disableProcessTimeout"
+    ],
     "release": [
       "composer install --no-dev --prefer-dist --optimize-autoloader"
     ],


### PR DESCRIPTION
Fixes #1108 

---

In pull request #1109 we added a note to disable the Composer timeout when installing, due to the size of WordPress causing the script to timeout consistently. After discussion, it was determined that adding a higher `process-timeout` to the config may possibly be a better alternative; however, in my research Composer has a static flag to disable the timeout, which I have added to the install command.

IMO, this method is preferred as it only applies to the install command, whereas the `process-timeout` increase would apply to all scripts and processes.
