### PR TITLE
Update `readme` for w.org plugins page to match new copy

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -7,18 +7,20 @@ Stable tag: 3.4.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Planes have a black box, WordPress has Stream. When something goes wrong, you need to know how it happened.
-
+With Stream, you’re never left in the dark about changes to your WordPress site.
 
 == Description ==
 
-With Stream, you're never left in the dark about WordPress Admin activity.
+With real-time notifications and third-party integrations, Stream can proactively alert you when something goes wrong with your WordPress site. 
 
-Every logged-in user action is displayed in an activity stream and organized for easy filtering by User, Role, Context, Action or IP address.
+Designed for debugging and compliance purposes, Stream is useful for keeping tabs on your WordPress users: From activating plugins to deleting posts, to login attempts and new user creation, you can see what’s changed, who changed it and when. 
 
-For advanced users, Stream also supports a Multisite view of all activity records on your network, the ability to set exclude rules to ignore certain kinds of user activity, and a WP‑CLI command for querying records.
+The plugin records WordPress user and system action to the Stream logs.  Every logged-in user action is displayed in an activity stream and organized for easy filtering by User, Role, Context, Action or IP address. Admins can highlight entries in the Stream log—such as suspicious user activity—to investigate what’s happening in real time. Stream also allows you to configure email alerts and webhooks for integrations like Slack and IFTTT to notify you and your team when something has gone wrong.
 
-Stream is perfect for keeping tabs on your clients. When something breaks, Stream is there to help. See what changed and who changed it.
+For advanced users, Stream also supports a network view of all activity records on your Multisite, the ability to set exclude rules to ignore certain kinds of user activity, and a WP‑CLI command for querying records. 
+
+With Stream’s powerful logging, you’ll have the valuable information you need to responsibly manage your WordPress sites.
+
 
 = Built-In Tracking Integrations For Popular Plugins: =
 
@@ -30,7 +32,7 @@ Stream is perfect for keeping tabs on your clients. When something breaks, Strea
  * Jetpack
  * User Switching
  * WooCommerce
- * WordPress SEO by Yoast
+ * Yoast SEO
 
 = Built-In Tracking For Core Actions: =
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Stream ===
-Contributors: lukecarbis, fjarrett, stream, xwp, kasparsd
+Contributors: xwp, kasparsd, derekherman, postphotos
 Tags: wp stream, stream, activity, logs, track
 Requires at least: 4.5
 Tested up to: 5.4

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Stream ===
-Contributors: xwp, kasparsd, derekherman, postphotos
+Contributors: xwp
 Tags: wp stream, stream, activity, logs, track
 Requires at least: 4.5
 Tested up to: 5.4
@@ -78,6 +78,8 @@ There are several ways you can get involved to help make Stream better:
 4. **Issue Pull Requests:** If you're a developer, the easiest way to get involved is to help out on [issues already reported](https://github.com/x-team/wp-stream/issues) in GitHub. Be sure to check out the [contributing guide](https://github.com/x-team/wp-stream/blob/master/contributing.md) for developers.
 
 Thank you for wanting to make Stream better for everyone!
+
+Past Contributors: fjarrett, shadyvb, chacha, westonruter, johnregan3, jacobschweitzer, lukecarbis, kasparsd, bordoni, dero, faishal, rob, desaiuditd, DavidCramer, renovate-bot, marcin-lawrowski, JeffMatson, Powdered-Toast-Man, johnolek, johnbillion, greguly, pascal-klaeres, szepeviktor, rheinardkorf, frozzare, khromov, dkotter, bhubbard, stipsan, stephenharris, omniwired, kopepasah, joehoyle, eugenekireev, barryceelen, valendesigns, tlovett1, tareiking, stayallive, sayedtaqui, robbiet480, oscarssanchez, kidunot89, johnwatkins0, javorszky, jamesgol, desrosj, davelozier, davefx, cfoellmann, JustinSainton, JJJ, postphotos
 
 
 == Screenshots ==


### PR DESCRIPTION
Updated readme to match new copy that more accurately describes Stream.