### PR TITLE
Fix CI build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ services:
   - docker
 
 before_install:
-  - docker-compose --file docker-compose.build.yml build
   - nvm install
   - nvm use
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,11 @@ jobs:
   include:
 
     - stage: test
-      name: Test with PHP 5.6
+      name: Default Test
+      after_script:
+        - test -f ./tests/reports/clover.xml && composer test-report || true
+
+    - name: Test with PHP 5.6
       env:
         WORDPRESS_IMAGE_VERSION: php5.6
 
@@ -16,11 +20,20 @@ jobs:
       env:
         WORDPRESS_IMAGE_VERSION: php7.2
 
-    - name: Default Test
-
     - stage: deploy
-      name: Release Package
-      env: WP_RELEASE=1
+      name: Tag Release
+      if: tag IS present
+      before_deploy:
+        - npm run release
+      deploy:
+        provider: releases
+        api_key:
+          secure: HheYiv6c8ipHzMZBTH7xcKrOwCllvJTtfiTffAPK6XubWe3Kudn6IJUv0p1gmRhWXxZ5ciJQ/sgiCRGTRm/bubHs4tS7JOmpmoTdkrXajTxyyDCKpxhtT43nie0vNF+pWqVu2yOjhDR4pwtWjpQdzEKOz0kn0XSMT+vGsKQD50w=
+        overwrite: true
+        skip_cleanup: true
+        file:
+          - stream.zip
+          - stream-$TRAVIS_TAG.zip
 
 services:
   - docker
@@ -37,26 +50,6 @@ script:
   - npm run lint
   - npm run phpunit
   - npm run phpunit-multisite
-
-after_script:
-  - test -f ./tests/reports/clover.xml && composer test-report || true
-
-before_deploy:
-  - npm run release
-
-deploy:
-  provider: releases
-  api_key:
-    secure: HheYiv6c8ipHzMZBTH7xcKrOwCllvJTtfiTffAPK6XubWe3Kudn6IJUv0p1gmRhWXxZ5ciJQ/sgiCRGTRm/bubHs4tS7JOmpmoTdkrXajTxyyDCKpxhtT43nie0vNF+pWqVu2yOjhDR4pwtWjpQdzEKOz0kn0XSMT+vGsKQD50w=
-  overwrite: true
-  skip_cleanup: true
-  file_glob: true
-  file:
-    - stream.zip
-    - stream-$TRAVIS_TAG.zip
-  on:
-    tags: true
-    condition: "$WP_RELEASE = 1"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ jobs:
 
     - stage: test
       name: Test with PHP 5.6
-      before_script: docker-compose build --build-arg PHP_VERSION=5.6 --build-arg XDEBUG_VERSION=2.5.5 wordpress
+      before_script: WORDPRESS_IMAGE_VERSION=php5.6 docker-compose build --build-arg PHP_VERSION=5.6 --build-arg XDEBUG_VERSION=2.5.5 wordpress
 
     - name: Test with PHP 7.2
-      before_script: docker-compose build --build-arg PHP_VERSION=7.2 wordpress
+      before_script: WORDPRESS_IMAGE_VERSION=php7.2 docker-compose build --build-arg PHP_VERSION=7.2 wordpress
 
     - name: Default Test
       before_script: docker-compose build
@@ -44,7 +44,7 @@ before_deploy:
   - npm run release
 
 before_cache:
-  - docker save -o /tmp/docker_images/images.tar wordpress
+  - docker save -o /tmp/docker_images/images.tar $(docker images --quiet "xwpco/*")
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ services:
   - docker
 
 before_install:
+  - docker-compose pull wordpress
   - nvm install
   - nvm use
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,14 @@ jobs:
 
     - stage: test
       name: Test with PHP 5.6
-      before_script: WORDPRESS_IMAGE_VERSION=php5.6 docker-compose build --build-arg PHP_VERSION=5.6 --build-arg XDEBUG_VERSION=2.5.5 wordpress
+      env:
+        WORDPRESS_IMAGE_VERSION: php5.6
 
     - name: Test with PHP 7.2
-      before_script: WORDPRESS_IMAGE_VERSION=php7.2 docker-compose build --build-arg PHP_VERSION=7.2 wordpress
+      env:
+        WORDPRESS_IMAGE_VERSION: php7.2
 
     - name: Default Test
-      before_script: docker-compose build
 
     - stage: deploy
       name: Release Package
@@ -25,7 +26,7 @@ services:
   - docker
 
 before_install:
-  - docker load -i /tmp/docker_images/images.tar || true
+  - docker-compose --file docker-compose.build.yml build
   - nvm install
   - nvm use
 
@@ -42,9 +43,6 @@ after_script:
 
 before_deploy:
   - npm run release
-
-before_cache:
-  - docker save -o /tmp/docker_images/images.tar $(docker images --quiet "xwpco/*")
 
 deploy:
   provider: releases
@@ -67,4 +65,3 @@ cache:
   npm: true
   directories:
     - $HOME/.composer/cache
-    - /tmp/docker_images

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_deploy:
   - npm run release
 
 before_cache:
-  - docker save -o /tmp/docker_images/images.tar $(docker images -a -q)
+  - docker save -o /tmp/docker_images/images.tar wordpress
 
 deploy:
   provider: releases

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,23 @@
+version: '3'
+
+services:
+
+  wordpress_latest:
+    image: xwpco/stream-wordpress:latest
+    build:
+      context: ./local/docker/wordpress
+
+  wordpress_php5.6:
+    image: xwpco/stream-wordpress:php5.6
+    build:
+      context: ./local/docker/wordpress
+      args:
+        PHP_VERSION: "5.6"
+        XDEBUG_VERSION: "2.5.5"
+
+  wordpress_php7.2:
+    image: xwpco/stream-wordpress:php7.2
+    build:
+      context: ./local/docker/wordpress
+      args:
+        PHP_VERSION: "7.2"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       MYSQL_ROOT_PASSWORD: password
 
   wordpress:
+    image: xwpco/stream-wordpress:${WORDPRESS_IMAGE_VERSION:-latest}
     build: ./local/docker/wordpress
     depends_on:
       - mysql

--- a/local/scripts/make-clover-relative.php
+++ b/local/scripts/make-clover-relative.php
@@ -7,9 +7,9 @@
 $clover_xml_file = $argv[1]; // First argument must be path to the XML coverage file.
 $clover_root_dir = sprintf( '%s/', getcwd() );
 
-$xml = file_get_contents( $clover_xml_file );
+$xml = file_get_contents( $clover_xml_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents, used only during dev.
 
-file_put_contents(
+file_put_contents( // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents, used only during dev.
 	$clover_xml_file,
 	str_replace( $clover_root_dir, '', $xml ) // Make coverage path relative to the project root.
 );

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "lint-js": "eslint .",
     "lint-php": "composer lint",
     "lint": "npm run lint-js && npm run lint-php",
+    "build-containers": "docker-compose --file docker-compose.build.yml build",
+    "push-containers": "docker-compose --file docker-compose.build.yml push",
     "stop-all": "docker stop $(docker ps -a -q)",
     "cli": "docker-compose run --rm --user $(id -u) wordpress xwp_wait db_phpunit:3306 -t 60 --",
     "vcli": "vagrant ssh -- docker-compose -f /vagrant/docker-compose.yml run --rm --user $(id -u) wordpress xwp_wait db_phpunit:3306 -t 60 --",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -17,12 +17,16 @@
 		<exclude name="WordPress.Security.EscapeOutput.DeprecatedWhitelistCommentFound" /><!-- TODO: Change these to phpcs:ignore -->
 	</rule>
 
+	<rule ref="Squiz.Commenting.FileComment">
+		<exclude-pattern>*/local/*</exclude-pattern>
+	</rule>
+
 	<exclude-pattern>*.ruleset</exclude-pattern>
 	<exclude-pattern>*/tests/*</exclude-pattern>
 	<exclude-pattern>*/includes/lib/*</exclude-pattern>
 	<exclude-pattern>*/ui/lib/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>*/build/*</exclude-pattern>
-	<exclude-pattern>*/local/*</exclude-pattern>
+	<exclude-pattern>*/local/public/*</exclude-pattern>
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 </ruleset>


### PR DESCRIPTION
- [x] Use Docker Hub to host the WordPress images https://hub.docker.com/repository/docker/xwpco/stream-wordpress

- [x] Add tooling to build and push images to https://hub.docker.com/repository/docker/xwpco/stream-wordpress

- [x] Update Travis config to use those images instead of building them or reading them from file cache which was taking a long time with larger images.