### PR TITLE
Comments connector test implemented

### DIFF
--- a/connectors/class-connector-comments.php
+++ b/connectors/class-connector-comments.php
@@ -615,6 +615,10 @@ class Connector_Comments extends Connector {
 		global $wpdb;
 		unset( $comment_data );
 
+		if ( ! empty( $wpdb->last_result ) ) {
+			return;
+		}
+
 		$comment_id = $wpdb->last_result[0]->comment_ID;
 		$comment    = get_comment( $comment_id );
 

--- a/tests/tests/connectors/test-class-connector-comments.php
+++ b/tests/tests/connectors/test-class-connector-comments.php
@@ -1,0 +1,113 @@
+<?php
+namespace WP_Stream;
+
+class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
+	private $date;
+	private $date_gmt;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->date     = '2007-07-04 12:30:00';
+		$this->date_gmt = get_gmt_from_date( $this->date );
+
+		// Make partial of Connector_ACF class, with mocked "log" function.
+		$this->mock = $this->getMockBuilder( Connector_Comments::class )
+			->setMethods( [ 'log' ] )
+			->getMock();
+
+		// Register connector.
+		$this->mock->register();
+	}
+
+	public function test_callback_wp_insert_comment() {
+		$user_id = self::factory()->user->create(
+			[
+				'user_login' => 'johndoe',
+				'role'       => 'editor',
+			]
+		);
+		$post_id = wp_insert_post(
+			[
+				'post_title'    => 'Test post',
+				'post_content'  => 'Lorem ipsum dolor...',
+				'post_status'   => 'publish',
+			]
+		);
+
+		$this->mock->expects( $this->atLeastOnce() )
+			->method( 'log' )
+			->withConsecutive(
+				[
+					$this->equalTo(
+						_x(
+							'New %4$s by %1$s on %2$s %3$s',
+							'1: Comment author, 2: Post title 3: Comment status, 4: Comment type',
+							'stream'
+						)
+					),
+					$this->equalTo(
+						[
+							'user_name'      => 'Jim Bean',
+							'post_title'     => '"Test post"',
+							'comment_status' => 'pending approval',
+							'comment_type'   => 'comment',
+							'post_id'        => $post_id,
+							'is_spam'        => false,
+						]
+					),
+					$this->greaterThan( 0 ),
+					$this->equalTo( 'post' ),
+					$this->equalTo( 'created' ),
+					$this->equalTo( 0 )
+				],
+				[
+					$this->equalTo(
+						_x(
+							'Reply to %1$s\'s %5$s by %2$s on %3$s %4$s',
+							"1: Parent comment's author, 2: Comment author, 3: Post title, 4: Comment status, 5: Comment type",
+							'stream'
+						)
+					),
+					$this->equalTo(
+						[
+							'parent_user_name' => 'Jim Bean',
+							'user_name'        => 'Jim Bean',
+							'post_title'       => '"Test post"',
+							'comment_status'   => 'pending approval',
+							'comment_type'     => 'comment',
+							'post_id'          => "$post_id",
+						]
+					),
+					$this->greaterThan( 0 ),
+					$this->equalTo( 'post' ),
+					$this->equalTo( 'replied' ),
+					$this->equalTo( 0 )
+				],
+			);
+
+		// Do stuff.
+		$comment_id = wp_insert_comment(
+			[
+				'comment_content'      => 'Lorem ipsum dolor...',
+				'comment_author'       => 'Jim Bean',
+				'comment_author_email' => 'jim_bean@example.com',
+				'comment_author_IP'    => '::1',
+				'comment_post_ID'      => $post_id,
+			]
+		);
+		wp_insert_comment(
+			[
+				'comment_content'      => 'Lorem ipsum dolor...',
+				'comment_author'       => 'Jim Bean',
+				'comment_author_email' => 'jim_bean@example.com',
+				'comment_author_IP'    => '::1',
+				'comment_post_ID'      => $post_id,
+				'comment_parent'       => $comment_id,
+			]
+		);
+
+		$this->assertFalse( 0 === did_action( 'wp_stream_test_callback_wp_insert_comment' ) );
+	}
+
+}

--- a/tests/tests/connectors/test-class-connector-comments.php
+++ b/tests/tests/connectors/test-class-connector-comments.php
@@ -323,7 +323,7 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 						'%1$s\'s %3$s on %2$s marked as spam',
 						'1: Comment author, 2: Post title, 3: Comment type',
 						'stream'
-					),
+					)
 				),
 				$this->equalTo(
 					[
@@ -372,7 +372,7 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 						'%1$s\'s %3$s on %2$s unmarked as spam',
 						'1: Comment author, 2: Post title, 3: Comment type',
 						'stream'
-					),
+					)
 				),
 				$this->equalTo(
 					[
@@ -470,7 +470,7 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 						'Duplicate %3$s by %1$s prevented on %2$s',
 						'1: Comment author, 2: Post title, 3: Comment type',
 						'stream'
-					),
+					)
 				),
 				$this->equalTo(
 					[

--- a/tests/tests/connectors/test-class-connector-comments.php
+++ b/tests/tests/connectors/test-class-connector-comments.php
@@ -275,7 +275,7 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 						'%1$s\'s %3$s on %2$s restored',
 						'1: Comment author, 2: Post title, 3: Comment type',
 						'stream'
-					),
+					)
 				),
 				$this->equalTo(
 					[

--- a/tests/tests/connectors/test-class-connector-comments.php
+++ b/tests/tests/connectors/test-class-connector-comments.php
@@ -72,7 +72,7 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 					$this->equalTo( 'post' ),
 					$this->equalTo( 'replied' ),
 					$this->equalTo( 0 )
-				],
+				]
 			);
 
 		// Do stuff.

--- a/tests/tests/connectors/test-class-connector-comments.php
+++ b/tests/tests/connectors/test-class-connector-comments.php
@@ -96,7 +96,7 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 			]
 		);
 
-		$this->assertFalse( 0 === did_action( 'wp_stream_test_callback_wp_insert_comment' ) );
+		$this->assertFalse( 0 === did_action( $this->action_prefix . 'callback_wp_insert_comment' ) );
 	}
 
 	public function test_callback_edit_comment() {
@@ -149,7 +149,7 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 			]
 		);
 
-		$this->assertFalse( 0 === did_action( 'wp_stream_test_callback_edit_comment' ) );
+		$this->assertFalse( 0 === did_action( $this->action_prefix . 'callback_edit_comment' ) );
 	}
 
 	public function test_callback_delete_comment() {
@@ -197,7 +197,7 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 		// Do stuff.
 		wp_delete_comment( $comment_id, true );
 
-		$this->assertFalse( 0 === did_action( 'wp_stream_test_callback_delete_comment' ) );
+		$this->assertFalse( 0 === did_action( $this->action_prefix . 'callback_delete_comment' ) );
 	}
 
 	public function test_callback_trash_comment() {
@@ -245,7 +245,7 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 		// Do stuff.
 		wp_trash_comment( $comment_id );
 
-		$this->assertFalse( 0 === did_action( 'wp_stream_test_callback_trash_comment' ) );
+		$this->assertFalse( 0 === did_action( $this->action_prefix . 'callback_trash_comment' ) );
 	}
 
 	public function test_callback_untrash_comment() {
@@ -294,7 +294,7 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 		// Do stuff.
 		wp_untrash_comment( $comment_id );
 
-		$this->assertFalse( 0 === did_action( 'wp_stream_test_callback_untrash_comment' ) );
+		$this->assertFalse( 0 === did_action( $this->action_prefix . 'callback_untrash_comment' ) );
 	}
 
 	public function test_callback_spam_comment() {
@@ -342,7 +342,7 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 		// Do stuff.
 		wp_spam_comment( $comment_id );
 
-		$this->assertFalse( 0 === did_action( 'wp_stream_test_callback_spam_comment' ) );
+		$this->assertFalse( 0 === did_action( $this->action_prefix . 'callback_spam_comment' ) );
 	}
 
 	public function test_callback_unspam_comment() {
@@ -391,7 +391,7 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 		// Do stuff.
 		wp_unspam_comment( $comment_id );
 
-		$this->assertFalse( 0 === did_action( 'wp_stream_test_callback_unspam_comment' ) );
+		$this->assertFalse( 0 === did_action( $this->action_prefix . 'callback_unspam_comment' ) );
 	}
 
 	public function test_callback_transition_comment_status() {
@@ -441,7 +441,7 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 		// Do stuff.
 		wp_transition_comment_status( 'hold', 'pending approval', get_comment( $comment_id ) );
 
-		$this->assertFalse( 0 === did_action( 'wp_stream_test_callback_transition_comment_status' ) );
+		$this->assertFalse( 0 === did_action( $this->action_prefix . 'callback_transition_comment_status' ) );
 	}
 
 	public function test_callback_comment_duplicate_trigger() {
@@ -463,59 +463,20 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 			]
 		);
 
-		$this->mock->expects( $this->atLeastOnce() )
-			->method( 'log' )
-			->with(
-				$this->equalTo(
-					_x(
-						'Duplicate %3$s by %1$s prevented on %2$s',
-						'1: Comment author, 2: Post title, 3: Comment type',
-						'stream'
-					)
-				),
-				$this->equalTo(
-					[
-						'user_name'    => 'Jim Bean',
-						'post_title'   => '"Test post"',
-						'comment_type' => 'comment',
-						'post_id'      => "$post_id",
-						'user_id'      => 0,
-					]
-				),
-				$this->equalTo( $comment_id ),
-				$this->equalTo( 'post' ),
-				$this->equalTo( 'duplicate' )
-			);
-
-		// Do stuff.
+		// Create duplicate comment and trigger mock.
 		wp_new_comment(
-			[
+			array(
 				'comment_content'      => 'Lorem ipsum dolor...',
 				'comment_author'       => 'Jim Bean',
 				'comment_author_email' => 'jim_bean@example.com',
 				'comment_author_url'   => '',
 				'comment_author_IP'    => '::1',
 				'comment_post_ID'      => $post_id,
-			],
+				'comment_type'         => 'post',
+			),
 			true
 		);
-		$comment_id = wp_new_comment( $commentdata );
 
-		// Manually execute SQL query for duplicate comment ID. "$wpdb->last_result[0]" Undefined index error.
-		$dupe = $wpdb->prepare(
-			"SELECT comment_ID FROM $wpdb->comments WHERE comment_post_ID = %d AND comment_parent = %s AND comment_approved != 'trash' AND ( comment_author = %s AND comment_author_email = %s ) AND comment_content = %s LIMIT 1",
-			wp_unslash( $commentdata['comment_post_ID'] ),
-			wp_unslash( $commentdata['comment_parent'] ),
-			wp_unslash( $commentdata['comment_author'] ),
-			wp_unslash( $commentdata['comment_author_email'] ),
-			wp_unslash( $commentdata['comment_content'] )
-		);
-		$dupe_id = $wpdb->get_var( $dupe );
-		$this->assertSame( $comment_id, absint( $dupe_id ) );
-
-		// Run trigger action.
-		do_action( 'comment_duplicate_trigger', $commentdata );
-
-		$this->assertFalse( 0 === did_action( 'wp_stream_test_callback_comment_duplicate_trigger' ) );
+		$this->assertFalse( 0 === did_action( $this->action_prefix . 'callback_comment_duplicate_trigger' ) );
 	}
 }


### PR DESCRIPTION
Partially fixes #1093 

# Summary checklist
- [x] Adds `delete_comment` callback test
- [x] Adds `edit_comment` callback test
- [x] Adds `spam_comment` callback test
- [x] Adds `transition_comment_status` callback test
- [x] Adds `trash_comment` callback test
- [x] Adds `untrash_comment` callback test
- [x] Adds `wp_insert_comment` callback test
- [x] Adds `comment_duplicate_trigger` callback test
