### PR TITLE
Add .htaccess required for the local WP container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - .:/var/www/html/wp-content/plugins/stream-src # Working directory.
       - ./build:/var/www/html/wp-content/plugins/stream # Built version for testing.
       - ./local/public:/var/www/html # WP core files.
+      - ./local/config/.htaccess:/var/www/html/.htaccess
       - ./local/config/wp-cli.yml:/var/www/html/wp-cli.yml
       - ./local/config/wp-config.php:/var/www/html/wp-config.php
       - ./local/config/wp-tests-config.php:/var/www/html/wp-tests-config.php

--- a/local/config/.htaccess
+++ b/local/config/.htaccess
@@ -1,0 +1,16 @@
+# For a subdirectory multisite
+# BEGIN WordPress
+RewriteEngine On
+RewriteBase /
+RewriteRule ^index.php$ - [L]
+
+# add a trailing slash to /wp-admin
+RewriteRule ^([_0-9a-zA-Z-]+/)?wp-admin$ $1wp-admin/ [R=301,L]
+
+RewriteCond %{REQUEST_FILENAME} -f [OR]
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule ^ - [L]
+RewriteRule ^([_0-9a-zA-Z-]+/)?(wp-(content|admin|includes).*) $2 [L]
+RewriteRule ^([_0-9a-zA-Z-]+/)?(.*\.php)$ $2 [L]
+RewriteRule . index.php [L]
+# END WordPress


### PR DESCRIPTION
Fixes #1135.

Add our own `.htaccess` file for the local development instance. Sync it with the WP container.