### PR TITLE
Adds connector unregister functionality

### DIFF
--- a/classes/class-connector.php
+++ b/classes/class-connector.php
@@ -55,14 +55,53 @@ abstract class Connector {
 	public $register_frontend = true;
 
 	/**
+	 * Holds connector registration status flag.
+	 *
+	 * @var bool
+	 */
+	private $is_registered = false;
+
+	/**
+	 * Is the connector currently registered?
+	 *
+	 * @return boolean
+	 */
+	public function is_registered() {
+		return $this->is_registered;
+	}
+
+	/**
 	 * Register all context hooks
 	 */
 	public function register() {
+		if ( $this->is_registered ) {
+			return;
+		}
+
 		foreach ( $this->actions as $action ) {
 			add_action( $action, array( $this, 'callback' ), 10, 99 );
 		}
 
 		add_filter( 'wp_stream_action_links_' . $this->name, array( $this, 'action_links' ), 10, 2 );
+
+		$this->is_registered = true;
+	}
+
+	/**
+	 * Unregister all context hooks
+	 */
+	public function unregister() {
+		if ( ! $this->is_registered ) {
+			return;
+		}
+
+		foreach ( $this->actions as $action ) {
+			remove_action( $action, array( $this, 'callback' ), 10, 99 );
+		}
+
+		remove_filter( 'wp_stream_action_links_' . $this->name, array( $this, 'action_links' ), 10, 2 );
+
+		$this->is_registered = false;
 	}
 
 	/**

--- a/classes/class-connectors.php
+++ b/classes/class-connectors.php
@@ -234,4 +234,35 @@ class Connectors {
 		 */
 		do_action( 'wp_stream_after_connectors_registration', $labels, $this );
 	}
+
+	/**
+	 * Unregisters the context hooks for all connectors.
+	 */
+	public function unload_connectors() {
+		foreach ( $this->connectors as $connector ) {
+			$connector->unregister();
+		}
+	}
+
+	/**
+	 * Unregisters the context hooks for a connectors.
+	 *
+	 * @param string $name  Name of the connector.
+	 */
+	public function unload_connector( $name ) {
+		if ( ! empty( $this->connectors[ $name ] ) ) {
+			$this->connectors[ $name ]->unregister();
+		}
+	}
+
+	/**
+	 * Reregisters the context hooks for a connector.
+	 *
+	 * @param string $name  Name of the connector.
+	 */
+	public function reload_connector( $name ) {
+		if ( ! empty( $this->connectors[ $name ] ) ) {
+			$this->connectors[ $name ]->register();
+		}
+	}
 }

--- a/classes/class-connectors.php
+++ b/classes/class-connectors.php
@@ -245,6 +245,15 @@ class Connectors {
 	}
 
 	/**
+	 * Reregisters the context hooks for all connectors.
+	 */
+	public function reload_connectors() {
+		foreach ( $this->connectors as $connector ) {
+			$connector->register();
+		}
+	}
+
+	/**
 	 * Unregisters the context hooks for a connectors.
 	 *
 	 * @param string $name  Name of the connector.

--- a/tests/tests/test-class-connector.php
+++ b/tests/tests/test-class-connector.php
@@ -28,6 +28,20 @@ class Test_Connector extends WP_StreamTestCase {
 		}
 	}
 
+	public function test_unregister() {
+		$this->connector->register();
+
+		foreach ( $this->connector->actions as $tag ) {
+			$this->assertGreaterThan( 0, has_action( $tag ) );
+		}
+
+		$this->connector->unregister();
+
+		foreach ( $this->connector->actions as $tag ) {
+			$this->assertFalse( has_action( $tag ) );
+		}
+	}
+
 	public function test_callback() {
 		global $wp_current_filter;
 		$action = $this->connector->actions[0];

--- a/tests/tests/test-class-connectors.php
+++ b/tests/tests/test-class-connectors.php
@@ -35,4 +35,51 @@ class Test_Connectors extends WP_StreamTestCase {
 
 		$this->assertEmpty( $notices );
 	}
+
+	public function test_unload_connectors() {
+		$this->connectors->load_connectors();
+		$this->assertNotEmpty( $this->connectors->connectors );
+
+		foreach( $this->connectors->connectors as $connector ) {
+			$this->assertTrue( $connector->is_registered() );
+		}
+
+		$this->connectors->unload_connectors();
+		foreach( $this->connectors->connectors as $connector ) {
+			$this->assertFalse( $connector->is_registered() );
+		}
+	}
+
+	public function test_reload_connectors() {
+		$this->connectors->load_connectors();
+		$this->assertNotEmpty( $this->connectors->connectors );
+		$this->connectors->unload_connectors();
+		foreach( $this->connectors->connectors as $connector ) {
+			$this->assertFalse( $connector->is_registered() );
+		}
+
+		$this->connectors->reload_connectors();
+		foreach( $this->connectors->connectors as $connector ) {
+			$this->assertTrue( $connector->is_registered() );
+		}
+	}
+
+	public function test_unload_connector() {
+		$this->connectors->load_connectors();
+		$this->assertNotEmpty( $this->connectors->connectors['posts'] );
+		$this->assertTrue( $this->connectors->connectors['posts']->is_registered() );
+
+		$this->connectors->unload_connector( 'posts' );
+		$this->assertFalse( $this->connectors->connectors['posts']->is_registered() );
+	}
+
+	public function test_reload_connector() {
+		$this->connectors->load_connectors();
+		$this->assertNotEmpty( $this->connectors->connectors['posts'] );
+		$this->connectors->unload_connector( 'posts' );
+		$this->assertFalse( $this->connectors->connectors['posts']->is_registered() );
+
+		$this->connectors->reload_connector( 'posts' );
+		$this->assertTrue( $this->connectors->connectors['posts']->is_registered() );
+	}
 }


### PR DESCRIPTION
# Summary Checklist
- Adds functionality to the `Connector` and `Connectors` for unregistering the connector context hooks.
- Adds test for that functionality.

This functionality was created primarily for better control during tests.