### PR TITLE
Media connector test implemented.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "composer/installers",
-            "version": "v1.9.0",
+            "version": "v1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/installers.git",
-                "reference": "b93bcf0fa1fccb0b7d176b0967d969691cd74cca"
+                "reference": "1a0357fccad9d1cc1ea0c9a05b8847fbccccb78d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/b93bcf0fa1fccb0b7d176b0967d969691cd74cca",
-                "reference": "b93bcf0fa1fccb0b7d176b0967d969691cd74cca",
+                "url": "https://api.github.com/repos/composer/installers/zipball/1a0357fccad9d1cc1ea0c9a05b8847fbccccb78d",
+                "reference": "1a0357fccad9d1cc1ea0c9a05b8847fbccccb78d",
                 "shasum": ""
             },
             "require": {
@@ -28,17 +28,18 @@
                 "shama/baton": "*"
             },
             "require-dev": {
-                "composer/composer": "1.6.* || 2.0.*@dev",
-                "composer/semver": "1.0.* || 2.0.*@dev",
-                "phpunit/phpunit": "^4.8.36",
-                "sebastian/comparator": "^1.2.4",
+                "composer/composer": "1.6.* || ^2.0",
+                "composer/semver": "^1 || ^3",
+                "phpstan/phpstan": "^0.12.55",
+                "phpstan/phpstan-phpunit": "^0.12.16",
+                "symfony/phpunit-bridge": "^4.2 || ^5",
                 "symfony/process": "^2.3"
             },
             "type": "composer-plugin",
             "extra": {
                 "class": "Composer\\Installers\\Plugin",
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "1.x-dev"
                 }
             },
             "autoload": {
@@ -76,6 +77,7 @@
                 "Porto",
                 "RadPHP",
                 "SMF",
+                "Starbug",
                 "Thelia",
                 "Whmcs",
                 "WolfCMS",
@@ -116,6 +118,7 @@
                 "phpbb",
                 "piwik",
                 "ppi",
+                "processwire",
                 "puppet",
                 "pxcms",
                 "reindex",
@@ -133,7 +136,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/installers/issues",
-                "source": "https://github.com/composer/installers/tree/v1.9.0"
+                "source": "https://github.com/composer/installers/tree/v1.10.0"
             },
             "funding": [
                 {
@@ -141,11 +144,15 @@
                     "type": "custom"
                 },
                 {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/composer/composer",
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-04-07T06:57:05+00:00"
+            "time": "2021-01-14T11:07:16+00:00"
         }
     ],
     "packages-dev": [
@@ -279,16 +286,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "1.10.19",
+            "version": "1.10.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "196601d50c08c3fae389a417a7689367fcf37cef"
+                "reference": "e55d297525f0ecc805c813a0f63a40114fd670f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/196601d50c08c3fae389a417a7689367fcf37cef",
-                "reference": "196601d50c08c3fae389a417a7689367fcf37cef",
+                "url": "https://api.github.com/repos/composer/composer/zipball/e55d297525f0ecc805c813a0f63a40114fd670f6",
+                "reference": "e55d297525f0ecc805c813a0f63a40114fd670f6",
                 "shasum": ""
             },
             "require": {
@@ -358,7 +365,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/composer/issues",
-                "source": "https://github.com/composer/composer/tree/1.10.19"
+                "source": "https://github.com/composer/composer/tree/1.10.20"
             },
             "funding": [
                 {
@@ -374,7 +381,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-12-04T08:14:16+00:00"
+            "time": "2021-01-27T14:41:06+00:00"
         },
         {
             "name": "composer/semver",
@@ -1079,20 +1086,20 @@
         },
         {
             "name": "johnpbloch/wordpress",
-            "version": "5.6.0",
+            "version": "5.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnpbloch/wordpress.git",
-                "reference": "3055975734646c8d0b8caf7b5af168ced6ec4309"
+                "reference": "d7a597988102967cdfc28851b6b897d018613823"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnpbloch/wordpress/zipball/3055975734646c8d0b8caf7b5af168ced6ec4309",
-                "reference": "3055975734646c8d0b8caf7b5af168ced6ec4309",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress/zipball/d7a597988102967cdfc28851b6b897d018613823",
+                "reference": "d7a597988102967cdfc28851b6b897d018613823",
                 "shasum": ""
             },
             "require": {
-                "johnpbloch/wordpress-core": "5.6.0",
+                "johnpbloch/wordpress-core": "5.6.1",
                 "johnpbloch/wordpress-core-installer": "^1.0 || ^2.0",
                 "php": ">=5.6.20"
             },
@@ -1121,20 +1128,20 @@
                 "source": "http://core.trac.wordpress.org/browser",
                 "wiki": "http://codex.wordpress.org/"
             },
-            "time": "2020-12-08T22:34:35+00:00"
+            "time": "2021-02-03T21:27:41+00:00"
         },
         {
             "name": "johnpbloch/wordpress-core",
-            "version": "5.6.0",
+            "version": "5.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnpbloch/wordpress-core.git",
-                "reference": "f074617dd69f466302836d1ae5de75c0bd7b6dfd"
+                "reference": "82592ec73d42cf784da38adb0028a24dbacab1b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/f074617dd69f466302836d1ae5de75c0bd7b6dfd",
-                "reference": "f074617dd69f466302836d1ae5de75c0bd7b6dfd",
+                "url": "https://api.github.com/repos/johnpbloch/wordpress-core/zipball/82592ec73d42cf784da38adb0028a24dbacab1b4",
+                "reference": "82592ec73d42cf784da38adb0028a24dbacab1b4",
                 "shasum": ""
             },
             "require": {
@@ -1142,7 +1149,7 @@
                 "php": ">=5.6.20"
             },
             "provide": {
-                "wordpress/core-implementation": "5.6.0"
+                "wordpress/core-implementation": "5.6.1"
             },
             "type": "wordpress-core",
             "notification-url": "https://packagist.org/downloads/",
@@ -1169,7 +1176,7 @@
                 "source": "https://core.trac.wordpress.org/browser",
                 "wiki": "https://codex.wordpress.org/"
             },
-            "time": "2020-12-08T22:34:23+00:00"
+            "time": "2021-02-03T21:27:35+00:00"
         },
         {
             "name": "johnpbloch/wordpress-core-installer",
@@ -3145,16 +3152,16 @@
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
-            "version": "v2.10.1",
+            "version": "v2.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "c6716a98fe7bee25d31306e14fb62c3ffa16d70a"
+                "reference": "0775e0c683badad52c03b11c2cd86a9fdecb937a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/c6716a98fe7bee25d31306e14fb62c3ffa16d70a",
-                "reference": "c6716a98fe7bee25d31306e14fb62c3ffa16d70a",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/0775e0c683badad52c03b11c2cd86a9fdecb937a",
+                "reference": "0775e0c683badad52c03b11c2cd86a9fdecb937a",
                 "shasum": ""
             },
             "require": {
@@ -3194,7 +3201,7 @@
                 "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
                 "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
             },
-            "time": "2020-12-12T18:28:57+00:00"
+            "time": "2021-01-08T16:31:05+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -4288,12 +4295,12 @@
             "version": "1.9.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
+                "url": "https://github.com/webmozarts/assert.git",
                 "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "shasum": ""
             },
@@ -4331,8 +4338,8 @@
                 "validate"
             ],
             "support": {
-                "issues": "https://github.com/webmozart/assert/issues",
-                "source": "https://github.com/webmozart/assert/tree/master"
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.9.1"
             },
             "time": "2020-07-08T17:02:28+00:00"
         },
@@ -6476,16 +6483,16 @@
         },
         {
             "name": "wp-phpunit/wp-phpunit",
-            "version": "5.6.0",
+            "version": "5.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-phpunit/wp-phpunit.git",
-                "reference": "7130a214573cc8c12a0f8fe8a74b18b453bce1e9"
+                "reference": "f6b3fb65bccc0ff70b3bc7cc241935597dbd5562"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/7130a214573cc8c12a0f8fe8a74b18b453bce1e9",
-                "reference": "7130a214573cc8c12a0f8fe8a74b18b453bce1e9",
+                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/f6b3fb65bccc0ff70b3bc7cc241935597dbd5562",
+                "reference": "f6b3fb65bccc0ff70b3bc7cc241935597dbd5562",
                 "shasum": ""
             },
             "type": "library",
@@ -6520,7 +6527,7 @@
                 "issues": "https://github.com/wp-phpunit/issues",
                 "source": "https://github.com/wp-phpunit/wp-phpunit"
             },
-            "time": "2020-12-09T18:06:02+00:00"
+            "time": "2021-02-04T18:24:14+00:00"
         },
         {
             "name": "wpackagist-plugin/advanced-custom-fields",

--- a/connectors/class-connector-media.php
+++ b/connectors/class-connector-media.php
@@ -151,7 +151,7 @@ class Connector_Media extends Connector {
 		$url             = $post->guid;
 		$parent_id       = $post->post_parent;
 		$parent          = get_post( $parent_id );
-		$parent_title    = $parent_id ? $parent->post_title : null;
+		$parent_title    = $parent instanceof \WP_Post ? $parent->post_title : 'Unidentifiable post';
 		$attachment_type = $this->get_attachment_type( $post->guid );
 
 		$this->log(

--- a/connectors/class-connector-media.php
+++ b/connectors/class-connector-media.php
@@ -171,18 +171,14 @@ class Connector_Media extends Connector {
 	 * @param int $post_id  Post ID.
 	 */
 	public function callback_edit_attachment( $post_id ) {
-		$post            = get_post( $post_id );
-		$name            = $post->post_title;
-		$attachment_type = $this->get_attachment_type( $post->guid );
-
-		/* translators: %s: an attachment title (e.g. "PIC001") */
-		$message = esc_html__( 'Updated "%s"', 'stream' );
+		$post = get_post( $post_id );
 
 		$this->log(
-			$message,
-			compact( 'name' ),
+			/* translators: %s: an attachment title (e.g. "PIC001") */
+			esc_html__( 'Updated "%s"', 'stream' ),
+			array( 'name' => $post->post_title ),
 			$post_id,
-			$attachment_type,
+			$this->get_attachment_type( $post->guid ),
 			'updated'
 		);
 	}
@@ -195,21 +191,17 @@ class Connector_Media extends Connector {
 	 * @param int $post_id  Post ID.
 	 */
 	public function callback_delete_attachment( $post_id ) {
-		$post            = get_post( $post_id );
-		$parent          = $post->post_parent ? get_post( $post->post_parent ) : null;
-		$parent_id       = $parent ? $parent->ID : null;
-		$name            = $post->post_title;
-		$url             = $post->guid;
-		$attachment_type = $this->get_attachment_type( $post->guid );
-
-		/* translators: %s: an attachment title (e.g. "PIC001") */
-		$message = esc_html__( 'Deleted "%s"', 'stream' );
+		$post      = get_post( $post_id );
+		$parent_id = $post->post_parent ? $post->post_parent : null;
+		$name      = $post->post_title;
+		$url       = $post->guid;
 
 		$this->log(
-			$message,
+			/* translators: %s: an attachment title (e.g. "PIC001") */
+			esc_html__( 'Deleted "%s"', 'stream' ),
 			compact( 'name', 'parent_id', 'url' ),
 			$post_id,
-			$attachment_type,
+			$this->get_attachment_type( $post->guid ),
 			'deleted'
 		);
 	}
@@ -233,14 +225,12 @@ class Connector_Media extends Connector {
 		$name = basename( $filename );
 		$post = get_post( $post_id );
 
-		$attachment_type = $this->get_attachment_type( $post->guid );
-
 		$this->log(
 			/* translators: Placeholder refers to an attachment title (e.g. "PIC001") */
 			__( 'Edited image "%s"', 'stream' ),
 			compact( 'name', 'filename', 'post_id' ),
 			$post_id,
-			$attachment_type,
+			$this->get_attachment_type( $post->guid ),
 			'edited'
 		);
 	}

--- a/tests/tests/connectors/test-class-connector-media.php
+++ b/tests/tests/connectors/test-class-connector-media.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * Tests for Media Connector class callbacks.
+ */
+
+namespace WP_Stream;
+
+class Test_WP_Stream_Connector_Media extends WP_StreamTestCase {
+
+	/**
+	 * Runs before each test
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		// Make partial of Connector_Media class, with mocked "log" function.
+		$this->mock = $this->getMockBuilder( Connector_Media::class )
+			->setMethods( array( 'log' ) )
+			->getMock();
+
+		// Register connector.
+		$this->mock->register();
+
+		// Require image editor classes.
+		require_once ABSPATH . 'wp-includes/class-wp-image-editor.php';
+		require_once ABSPATH . 'wp-includes/class-wp-image-editor-gd.php';
+		require_once ABSPATH . 'wp-admin/includes/image-edit.php';
+	}
+
+	public function test_callback_add_attachment() {
+		// Create post for later use.
+		$post_id = self::factory()->post->create( array( 'post_title' => 'Test post' ) );
+
+		// Expected log calls.
+		$this->mock->expects( $this->exactly( 2 ) )
+			->method( 'log' )
+			->withConsecutive(
+				array(
+					$this->equalTo( esc_html__( 'Added "%s" to Media library', 'stream' ) ),
+					$this->callback(
+						function( $subject ) {
+							$expected = array(
+								'name'         => 'Document one',
+								'parent_title' => null,
+								'parent_id'    => 0,
+							);
+							return $expected === array_intersect_key( $expected, $subject );
+						}
+					),
+					$this->greaterThan( 0 ),
+					$this->equalTo( 'document' ),
+					$this->equalTo( 'uploaded' ),
+				),
+				array(
+					$this->equalTo(
+						_x(
+							'Attached "%1$s" to "%2$s"',
+							'1: Attachment title, 2: Parent post title',
+							'stream'
+						)
+					),
+					$this->callback(
+						function( $subject ) use ( $post_id ) {
+							$expected = array(
+								'name'         => 'Document one',
+								'parent_title' => 'Test post',
+								'parent_id'    => $post_id,
+							);
+							return $expected === array_intersect_key( $expected, $subject );
+						}
+					),
+					$this->greaterThan( 0 ),
+					$this->equalTo( 'document' ),
+					$this->equalTo( 'attached' ),
+				)
+			);
+
+		// Create attachment to trigger callback.
+		self::factory()->post->create(
+			array(
+				'post_title' => 'Document one',
+				'post_type'  => 'attachment',
+			)
+		);
+
+		self::factory()->post->create(
+			array(
+				'post_title'   => 'Document one',
+				'post_type'    => 'attachment',
+				'post_content' => 'some description',
+				'post_parent'  => $post_id
+			)
+		);
+
+		// Check callback test action.
+		$this->assertFalse( 0 === did_action( 'wp_stream_test_callback_add_attachment' ) );
+	}
+
+	public function test_callback_edit_attachment() {
+		// Create attachment for later use.
+		$attachment_id = self::factory()->post->create(
+			array(
+				'post_title' => 'Attachment one',
+				'post_type'  => 'attachment',
+			)
+		);
+
+		// Expected log calls.
+		$this->mock->expects( $this->once() )
+			->method( 'log' )
+			->with(
+				$this->equalTo( esc_html__( 'Updated "%s"', 'stream' ) ),
+				$this->equalTo( array( 'name' => 'Document one' ) ),
+				$this->equalTo( $attachment_id ),
+				$this->equalTo( 'document' ),
+				$this->equalTo( 'updated' )
+			);
+
+		// Update attachment to trigger callback.
+		self::factory()->post->update_object(
+			$attachment_id,
+			array( 'post_title' => 'Document one' )
+		);
+
+
+		// Check callback test action.
+		$this->assertFalse( 0 === did_action( 'wp_stream_test_callback_edit_attachment' ) );
+	}
+
+	public function test_callback_delete_attachment() {
+		// Create attachment for later use.
+		$attachment_id = self::factory()->post->create(
+			array(
+				'post_title' => 'Attachment one',
+				'post_type'  => 'attachment',
+			)
+		);
+
+		// Expected log calls.
+		$this->mock->expects( $this->once() )
+			->method( 'log' )
+			->with(
+				$this->equalTo( esc_html__( 'Deleted "%s"', 'stream' ) ),
+				$this->callback(
+					function( $subject ) {
+						$expected = array(
+							'name'      => 'Attachment one',
+							'parent_id' => null,
+						);
+						return $expected === array_intersect_key( $expected, $subject );
+					}
+				),
+				$this->equalTo( $attachment_id ),
+				$this->equalTo( 'document' ),
+				$this->equalTo( 'deleted' )
+			);
+
+		// Delete attachment to trigger callback.
+		wp_delete_attachment( $attachment_id, true );
+
+		// Check callback test action.
+		$this->assertFalse( 0 === did_action( 'wp_stream_test_callback_delete_attachment' ) );
+	}
+
+	public function test_callback_wp_save_image_editor_file() {
+		// Create attachment for later use.
+		$attachment_id = self::factory()->post->create(
+			array(
+				'post_title' => 'Attachment one',
+				'post_type'  => 'attachment',
+			)
+		);
+
+		// Expected log calls.
+		$this->mock->expects( $this->once() )
+			->method( 'log' )
+			->with(
+				$this->equalTo( __( 'Edited image "%s"', 'stream' ) ),
+				$this->equalTo(
+					array(
+						'name'     => 'file.jpg',
+						'filename' => 'file.jpg',
+						'post_id'  => $attachment_id,
+					)
+				),
+				$this->equalTo( $attachment_id ),
+				$this->equalTo( 'document' ),
+				$this->equalTo( 'edited' )
+			);
+
+		// Simulate editor page save to trigger callback.
+		\wp_save_image_file(
+			'file.jpg',
+			new \WP_Image_Editor_GD( sys_get_temp_dir() . 'file.jpg' ),
+			'image/jpeg',
+			$attachment_id
+		);
+
+		// Check callback test action.
+		$this->assertFalse( 0 === did_action( 'wp_stream_test_callback_wp_save_image_editor_file' ) );
+	}
+}

--- a/tests/tests/connectors/test-class-connector-media.php
+++ b/tests/tests/connectors/test-class-connector-media.php
@@ -32,7 +32,7 @@ class Test_WP_Stream_Connector_Media extends WP_StreamTestCase {
 		$post_id = self::factory()->post->create( array( 'post_title' => 'Test post' ) );
 
 		// Expected log calls.
-		$this->mock->expects( $this->exactly( 2 ) )
+		$this->mock->expects( $this->exactly( 3 ) )
 			->method( 'log' )
 			->withConsecutive(
 				array(
@@ -72,6 +72,28 @@ class Test_WP_Stream_Connector_Media extends WP_StreamTestCase {
 					$this->greaterThan( 0 ),
 					$this->equalTo( 'document' ),
 					$this->equalTo( 'attached' ),
+				),
+				array(
+					$this->equalTo(
+						_x(
+							'Attached "%1$s" to "%2$s"',
+							'1: Attachment title, 2: Parent post title',
+							'stream'
+						)
+					),
+					$this->callback(
+						function( $subject ) {
+							$expected = array(
+								'name'         => 'Document one',
+								'parent_title' => 'Unidentifiable post',
+								'parent_id'    => 42,
+							);
+							return $expected === array_intersect_key( $expected, $subject );
+						}
+					),
+					$this->greaterThan( 0 ),
+					$this->equalTo( 'document' ),
+					$this->equalTo( 'attached' ),
 				)
 			);
 
@@ -92,8 +114,18 @@ class Test_WP_Stream_Connector_Media extends WP_StreamTestCase {
 			)
 		);
 
+		// Create attachment with invalid post parent.
+		self::factory()->post->create(
+			array(
+				'post_title'   => 'Document one',
+				'post_type'    => 'attachment',
+				'post_content' => 'some description',
+				'post_parent'  => 42
+			)
+		);
+
 		// Check callback test action.
-		$this->assertFalse( 0 === did_action( 'wp_stream_test_callback_add_attachment' ) );
+		$this->assertFalse( 0 === did_action( $this->action_prefix . 'callback_add_attachment' ) );
 	}
 
 	public function test_callback_edit_attachment() {
@@ -124,7 +156,7 @@ class Test_WP_Stream_Connector_Media extends WP_StreamTestCase {
 
 
 		// Check callback test action.
-		$this->assertFalse( 0 === did_action( 'wp_stream_test_callback_edit_attachment' ) );
+		$this->assertFalse( 0 === did_action( $this->action_prefix . 'callback_edit_attachment' ) );
 	}
 
 	public function test_callback_delete_attachment() {
@@ -159,7 +191,7 @@ class Test_WP_Stream_Connector_Media extends WP_StreamTestCase {
 		wp_delete_attachment( $attachment_id, true );
 
 		// Check callback test action.
-		$this->assertFalse( 0 === did_action( 'wp_stream_test_callback_delete_attachment' ) );
+		$this->assertFalse( 0 === did_action( $this->action_prefix . 'callback_delete_attachment' ) );
 	}
 
 	public function test_callback_wp_save_image_editor_file() {
@@ -197,6 +229,6 @@ class Test_WP_Stream_Connector_Media extends WP_StreamTestCase {
 		);
 
 		// Check callback test action.
-		$this->assertFalse( 0 === did_action( 'wp_stream_test_callback_wp_save_image_editor_file' ) );
+		$this->assertFalse( 0 === did_action( $this->action_prefix . 'callback_wp_save_image_editor_file' ) );
 	}
 }


### PR DESCRIPTION
Partially fixes #1093 
Fixes #907 

# Summary Checklist
- [x] `add_attachment` callback test implemented and passing. Refactored to avoid breaking on invalid parent posts.
- [x] `delete_attachment` callback test implemented and passing.
- [x] `edit_attachment` callback test implemented and passing.
- [x] `wp_save_image_editor_file` callback test implemented and passing.
- No test created for the `wp_save_image_file` callback because the hook is deprecated in WordPress and `wp_save_image_editor_file` is the replacement.

#907 patch implemented here to avoid future merge conflicts if put in separate PR.