### PR TITLE
Default options provided to "wp_stream_auto_purge" callbacks.

### DIFF
--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -750,7 +750,7 @@ class Admin {
 		if ( is_multisite() && $this->plugin->is_network_activated() ) {
 			$options = (array) get_site_option( 'wp_stream_network', $defaults );
 		} else {
-			$options = (array) get_option( 'wp_stream', array(), $defaults );
+			$options = (array) get_option( 'wp_stream', $defaults );
 		}
 
 		if ( ! empty( $options['general_keep_records_indefinitely'] ) || ! isset( $options['general_records_ttl'] ) ) {

--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -143,7 +143,7 @@ class Admin {
 		add_filter( 'role_has_cap', array( $this, 'filter_role_caps' ), 10, 3 );
 
 		if ( is_multisite() && $plugin->is_network_activated() && ! is_network_admin() ) {
-			$options = (array) get_site_option( 'wp_stream_network', array() );
+			$options = (array) get_site_option( 'wp_stream_network', $plugin->settings->get_defaults() );
 			$option  = isset( $options['general_site_access'] ) ? absint( $options['general_site_access'] ) : 1;
 
 			$this->disable_access = ( $option ) ? false : true;
@@ -746,10 +746,11 @@ class Admin {
 			return;
 		}
 
+		$defaults = $this->plugin->settings->get_defaults();
 		if ( is_multisite() && $this->plugin->is_network_activated() ) {
-			$options = (array) get_site_option( 'wp_stream_network', array() );
+			$options = (array) get_site_option( 'wp_stream_network', $defaults );
 		} else {
-			$options = (array) get_option( 'wp_stream', array() );
+			$options = (array) get_option( 'wp_stream', array(), $defaults );
 		}
 
 		if ( ! empty( $options['general_keep_records_indefinitely'] ) || ! isset( $options['general_records_ttl'] ) ) {


### PR DESCRIPTION
Fixes #1056

# Checklist
Provides `Settings::default_settings()` as the default value for all `get_site_option( 'wp_stream_network' );` and `get_option( 'wp_stream' );` calls to avoid skipping record purging when no settings are saved in the database, which seems to be the root cause of #1056.
