### PR TITLE
".load()" calls replaced valid equivalent.

### DIFF
--- a/ui/js/admin.js
+++ b/ui/js/admin.js
@@ -141,7 +141,8 @@ jQuery(
 			}
 		);
 
-		$( window ).load(
+		$( window ).on(
+			'load',
 			function() {
 				$( '.toplevel_page_wp_stream input[type="search"]' ).off( 'mousedown' );
 			}


### PR DESCRIPTION
Fixes #1161 

# Summary
Replaces calls to the deprecated `.load(...)` with valid `on('load', ... )` calls that achieves the same results.
