### PR TITLE
Blog connector test implemented and connector updated.

### DIFF
--- a/connectors/class-connector-blogs.php
+++ b/connectors/class-connector-blogs.php
@@ -363,7 +363,6 @@ class Connector_Blogs extends Connector {
 	 */
 	public function callback_update_blog_status( $blog_id, $status, $action ) {
 		$blog = get_site( $blog_id );
-
 		$this->log(
 			/* translators: %1$s: a site name, %2$s: a blog status (e.g. "FooBar Blog", "archived") */
 			_x(

--- a/connectors/class-connector-blogs.php
+++ b/connectors/class-connector-blogs.php
@@ -24,7 +24,7 @@ class Connector_Blogs extends Connector {
 	 * @var array
 	 */
 	public $actions = array(
-		'wpmu_new_blog',
+		'wp_insert_site',
 		'wpmu_activate_blog',
 		'wpmu_new_user',
 		'add_user_to_blog',
@@ -129,13 +129,11 @@ class Connector_Blogs extends Connector {
 	/**
 	 * Blog created
 	 *
-	 * @action wpmu_new_blog
+	 * @action wp_insert_site
 	 *
-	 * @param int $blog_id  Blog ID.
+	 * @param WP_Site $blog  New site.
 	 */
-	public function callback_wpmu_new_blog( $blog_id ) {
-		$blog = get_blog_details( $blog_id );
-
+	public function callback_wp_insert_site( $blog ) {
 		$this->log(
 			/* translators: %s: site name (e.g. "FooBar Blog") */
 			_x(
@@ -146,7 +144,7 @@ class Connector_Blogs extends Connector {
 			array(
 				'site_name' => $blog->blogname,
 			),
-			$blog_id,
+			$blog->blog_id,
 			sanitize_key( $blog->blogname ),
 			'created'
 		);
@@ -161,7 +159,7 @@ class Connector_Blogs extends Connector {
 	 * @param int $user_id  User ID.
 	 */
 	public function callback_wpmu_activate_blog( $blog_id, $user_id ) {
-		$blog = get_blog_details( $blog_id );
+		$blog = get_site( $blog_id );
 
 		$this->log(
 			/* translators: %s: site name (e.g. "FooBar Blog") */
@@ -190,7 +188,7 @@ class Connector_Blogs extends Connector {
 	 * @param int    $blog_id  Blog ID.
 	 */
 	public function callback_add_user_to_blog( $user_id, $role, $blog_id ) {
-		$blog = get_blog_details( $blog_id );
+		$blog = get_site( $blog_id );
 		$user = get_user_by( 'id', $user_id );
 
 		if ( ! is_a( $user, 'WP_User' ) ) {
@@ -224,7 +222,7 @@ class Connector_Blogs extends Connector {
 	 * @param int $blog_id  Blog ID.
 	 */
 	public function callback_remove_user_from_blog( $user_id, $blog_id ) {
-		$blog = get_blog_details( $blog_id );
+		$blog = get_site( $blog_id );
 		$user = get_user_by( 'id', $user_id );
 
 		if ( ! is_a( $user, 'WP_User' ) ) {
@@ -345,7 +343,7 @@ class Connector_Blogs extends Connector {
 	 * @param string $value    Status flag.
 	 */
 	public function callback_update_blog_public( $blog_id, $value ) {
-		if ( $value ) {
+		if ( absint( $value ) ) {
 			$status = esc_html__( 'marked as public', 'stream' );
 		} else {
 			$status = esc_html__( 'marked as private', 'stream' );
@@ -364,7 +362,7 @@ class Connector_Blogs extends Connector {
 	 * @param string $action   Action.
 	 */
 	public function callback_update_blog_status( $blog_id, $status, $action ) {
-		$blog = get_blog_details( $blog_id );
+		$blog = get_site( $blog_id );
 
 		$this->log(
 			/* translators: %1$s: a site name, %2$s: a blog status (e.g. "FooBar Blog", "archived") */

--- a/connectors/class-connector-blogs.php
+++ b/connectors/class-connector-blogs.php
@@ -148,6 +148,8 @@ class Connector_Blogs extends Connector {
 			),
 			array(
 				'site_name' => ! empty( $blogname ) ? $blogname : 'Site %d',
+				'siteurl'   => $new_site->siteurl,
+				'id'        => $new_site->blog_id,
 			),
 			$blog_id,
 			sanitize_key( $blogname ),
@@ -172,6 +174,8 @@ class Connector_Blogs extends Connector {
 			),
 			array(
 				'site_name' => $old_site->blogname,
+				'siteurl'   => $old_site->siteurl,
+				'id'        => $old_site->blog_id,
 			),
 			$old_site->blog_id,
 			sanitize_key( $old_site->blogname ),
@@ -199,6 +203,8 @@ class Connector_Blogs extends Connector {
 			),
 			array(
 				'site_name' => $blog->blogname,
+				'siteurl'   => $blog->siteurl,
+				'id'        => $blog->blog_id,
 			),
 			$blog_id,
 			sanitize_key( $blog->blogname ),
@@ -234,6 +240,8 @@ class Connector_Blogs extends Connector {
 			array(
 				'user_name' => $user->display_name,
 				'site_name' => $blog->blogname,
+				'siteurl'   => $blog->siteurl,
+				'id'        => $blog->blog_id,
 				'role_name' => $role,
 			),
 			$blog_id,
@@ -268,6 +276,8 @@ class Connector_Blogs extends Connector {
 			array(
 				'user_name' => $user->display_name,
 				'site_name' => $blog->blogname,
+				'siteurl'   => $blog->siteurl,
+				'id'        => $blog->blog_id,
 			),
 			$blog_id,
 			sanitize_key( $blog->blogname ),
@@ -401,6 +411,8 @@ class Connector_Blogs extends Connector {
 			),
 			array(
 				'site_name' => $blog->blogname,
+				'siteurl'   => $blog->siteurl,
+				'id'        => $blog->blog_id,
 				'status'    => $status,
 			),
 			$blog_id,

--- a/tests/tests/connectors/test-class-connector-blogs.php
+++ b/tests/tests/connectors/test-class-connector-blogs.php
@@ -146,7 +146,7 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 				$this->equalTo( $blog_id ),
 				$this->equalTo( 'testsite' ),
 				$this->equalTo( 'created' ),
-				1,
+				1
 			);
 
 		// Activate blog to trigger callback.
@@ -419,7 +419,7 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 					$this->equalTo( $blog_id ),
 					$this->equalTo( 'testsite' ),
 					$this->equalTo( 'updated' )
-				),
+				)
 			);
 
 		// Update blog status blog to trigger callback.

--- a/tests/tests/connectors/test-class-connector-blogs.php
+++ b/tests/tests/connectors/test-class-connector-blogs.php
@@ -80,7 +80,16 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 						'stream'
 					)
 				),
-				$this->equalTo( array( 'site_name' => 'testsite' ) ),
+				$this->callback(
+					function( $meta ) {
+						$expected_meta = array(
+							'site_name' => 'testsite',
+							'siteurl'   => '//testsite',
+						);
+
+						return $expected_meta === array_intersect_key( $expected_meta, $meta );
+					}
+				),
 				$this->greaterThan( 0 ),
 				$this->equalTo( 'testsite' ),
 				$this->equalTo( 'created' )
@@ -113,7 +122,13 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 						'stream'
 					)
 				),
-				$this->equalTo( array( 'site_name' => 'testsite' ) ),
+				$this->equalTo(
+					array(
+						'site_name' => 'testsite',
+						'siteurl'   => '//testsite',
+						'id'        => $blog_id,
+					)
+				),
 				$this->greaterThan( 0 ),
 				$this->equalTo( 'testsite' ),
 				$this->equalTo( 'deleted' )
@@ -142,7 +157,13 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 						'stream'
 					)
 				),
-				$this->equalTo( array( 'site_name' => 'testsite' ) ),
+				$this->equalTo(
+					array(
+						'site_name' => 'testsite',
+						'siteurl'   => '//testsite',
+						'id'        => $blog_id,
+					)
+				),
 				$this->equalTo( $blog_id ),
 				$this->equalTo( 'testsite' ),
 				$this->equalTo( 'created' ),
@@ -176,6 +197,8 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 					array(
 						'user_name' => 'testuser',
 						'site_name' => 'testsite',
+						'siteurl'   => '//testsite',
+						'id'        => $blog_id,
 						'role_name' => 'subscriber',
 					)
 				),
@@ -212,6 +235,8 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 					array(
 						'user_name' => 'testuser',
 						'site_name' => 'testsite',
+						'siteurl'   => '//testsite',
+						'id'        => $blog_id,
 					)
 				),
 				$this->equalTo( $blog_id ),
@@ -251,6 +276,8 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 					$this->equalTo(
 						array(
 							'site_name' => 'testsite',
+							'siteurl'   => '//testsite',
+							'id'        => $blog_id,
 							'status'    => esc_html__( 'marked as spam', 'stream' ),
 						)
 					),
@@ -269,6 +296,8 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 					$this->equalTo(
 						array(
 							'site_name' => 'testsite',
+							'siteurl'   => '//testsite',
+							'id'        => $blog_id,
 							'status'    => esc_html__( 'marked as not spam', 'stream' ),
 						)
 					),
@@ -287,6 +316,8 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 					$this->equalTo(
 						array(
 							'site_name' => 'testsite',
+							'siteurl'   => '//testsite',
+							'id'        => $blog_id,
 							'status'    => esc_html__( 'marked as mature', 'stream' ),
 						)
 					),
@@ -305,6 +336,8 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 					$this->equalTo(
 						array(
 							'site_name' => 'testsite',
+							'siteurl'   => '//testsite',
+							'id'        => $blog_id,
 							'status'    => esc_html__( 'marked as not mature', 'stream' ),
 						)
 					),
@@ -323,6 +356,8 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 					$this->equalTo(
 						array(
 							'site_name' => 'testsite',
+							'siteurl'   => '//testsite',
+							'id'        => $blog_id,
 							'status'    => esc_html__( 'archived', 'stream' ),
 						)
 					),
@@ -341,6 +376,8 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 					$this->equalTo(
 						array(
 							'site_name' => 'testsite',
+							'siteurl'   => '//testsite',
+							'id'        => $blog_id,
 							'status'    => esc_html__( 'restored from archive', 'stream' ),
 						)
 					),
@@ -359,6 +396,8 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 					$this->equalTo(
 						array(
 							'site_name' => 'testsite',
+							'siteurl'   => '//testsite',
+							'id'        => $blog_id,
 							'status'    => esc_html__( 'trashed', 'stream' ),
 						)
 					),
@@ -377,6 +416,8 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 					$this->equalTo(
 						array(
 							'site_name' => 'testsite',
+							'siteurl'   => '//testsite',
+							'id'        => $blog_id,
 							'status'    => esc_html__( 'restored', 'stream' ),
 						)
 					),
@@ -395,6 +436,8 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 					$this->equalTo(
 						array(
 							'site_name' => 'testsite',
+							'siteurl'   => '//testsite',
+							'id'        => $blog_id,
 							'status'    => esc_html__( 'marked as public', 'stream' ),
 						)
 					),
@@ -413,6 +456,8 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 					$this->equalTo(
 						array(
 							'site_name' => 'testsite',
+							'siteurl'   => '//testsite',
+							'id'        => $blog_id,
 							'status'    => esc_html__( 'marked as private', 'stream' ),
 						)
 					),

--- a/tests/tests/connectors/test-class-connector-blogs.php
+++ b/tests/tests/connectors/test-class-connector-blogs.php
@@ -64,11 +64,7 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 		$this->assertArrayHasKey( 'blog-' . $id, $labels );
 	}
 
-<<<<<<< HEAD
-	public function test_callback_wp_insert_site() {
-=======
 	public function test_callback_wp_initialize_site() {
->>>>>>> "wp_delete_site" callback added.
 		// Expected log calls.
 		$this->mock->expects( $this->once() )
 			->method( 'log' )


### PR DESCRIPTION
Works towards #1093 .
Fixes #1175 
Fixes #1187  

# Summary checklist
- [x] `wpmu_new_blog` callback replaced with `wp_initialize_site` callback due to the deprecation of the `wpmu_new_blog` hook.
- [x] `wp_initialize_site` callback tested and passing.
- [x] `wp_delete_site` callback implemented, testing and passing.
- [x] `wpmu_activate_blog` callback tested and passing.
- [x] `add_user_to_blog` callback tested and passing.
- [x] `remove_user_from_blog` callback tested and passing.
- [x] `update_blog status` function and all connected hooks tested and passing.

@dero @kasparsd I updated the Blog connector log meta with more info. It know include the the blog `name`, `url`, and `id`.