### PR TITLE
Record list table "No items" message updated

### DIFF
--- a/classes/class-list-table.php
+++ b/classes/class-list-table.php
@@ -99,7 +99,7 @@ class List_Table extends \WP_List_Table {
 	public function no_items() {
 		?>
 		<div class="stream-list-table-no-items">
-			<p><?php esc_html_e( 'Sorry, no activity records were found.', 'stream' ); ?></p>
+			<p><?php esc_html_e( 'No activity records were found.', 'stream' ); ?></p>
 		</div>
 		<?php
 	}

--- a/languages/stream-en_US.po
+++ b/languages/stream-en_US.po
@@ -222,7 +222,7 @@ msgid "Records per page"
 msgstr ""
 
 #: classes/class-list-table.php:64
-msgid "Sorry, no activity records were found."
+msgid "No activity records were found."
 msgstr ""
 
 #: classes/class-list-table.php:78


### PR DESCRIPTION
Fixes #1178.

Changes "no_items" message for the Records list table to the message in the capture below.

![image](https://user-images.githubusercontent.com/13604318/94585779-78a95500-024e-11eb-84e0-65b1edf8b4d0.png)
