### PR TITLE
some connector test cleaned up.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -287,6 +287,14 @@
         "globals": "^12.0.0",
         "prettier": "npm:wp-prettier@2.0.5",
         "requireindex": "^1.2.0"
+      },
+      "dependencies": {
+        "prettier": {
+          "version": "npm:wp-prettier@2.0.5",
+          "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5.tgz",
+          "integrity": "sha512-5GCgdeevIXwR3cW4Qj5XWC5MO1iSCz8+IPn0mMw6awAt/PBiey8yyO7MhePRsaMqghJAhg6Q3QLYWSnUHWkG6A==",
+          "dev": true
+        }
       }
     },
     "@wordpress/prettier-config": {
@@ -3512,12 +3520,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true
-    },
-    "prettier": {
-      "version": "npm:wp-prettier@2.0.5",
-      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5.tgz",
-      "integrity": "sha512-5GCgdeevIXwR3cW4Qj5XWC5MO1iSCz8+IPn0mMw6awAt/PBiey8yyO7MhePRsaMqghJAhg6Q3QLYWSnUHWkG6A==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/tests/tests/connectors/test-class-connector-acf.php
+++ b/tests/tests/connectors/test-class-connector-acf.php
@@ -149,7 +149,7 @@ class Test_WP_Stream_Connector_ACF extends WP_StreamTestCase {
 		$this->update_acf_field();
 
 		// Check callback test action.
-		$this->assertGreaterThan( 0, did_action( 'wp_stream_test_callback_save_post' ) );
+		$this->assertGreaterThan( 0, did_action( $this->action_prefix . 'callback_save_post' ) );
 
 		// 'acf/update_field_group' is called at the end of "acf_update_field()".
 		$this->assertSame( 1, did_action( 'acf/update_field_group' ) );
@@ -185,7 +185,7 @@ class Test_WP_Stream_Connector_ACF extends WP_StreamTestCase {
 		$this->update_acf_field_group( $field_group );
 
 		// Check callback test action.
-		$this->assertGreaterThan( 0, did_action( 'wp_stream_test_callback_post_updated' ) );
+		$this->assertGreaterThan( 0, did_action( $this->action_prefix . 'callback_post_updated' ) );
 
 		// 'acf/update_field_group' is called at the end of "acf_update_field()".
 		$this->assertSame( 2, did_action( 'acf/update_field_group' ) );
@@ -289,7 +289,7 @@ class Test_WP_Stream_Connector_ACF extends WP_StreamTestCase {
 		update_field( 'test_field', 'Yes sir!', "user_{$user_id}" );
 
 		// Check callback test actions.
-		$this->assertGreaterThan( 0, did_action( 'wp_stream_test_callback_added_post_meta' ) );
-		$this->assertGreaterThan( 0, did_action( 'wp_stream_test_callback_updated_post_meta' ) );
+		$this->assertGreaterThan( 0, did_action( $this->action_prefix . 'callback_added_post_meta' ) );
+		$this->assertGreaterThan( 0, did_action( $this->action_prefix . 'callback_updated_post_meta' ) );
 	}
 }

--- a/tests/tests/connectors/test-class-connector-edd.php
+++ b/tests/tests/connectors/test-class-connector-edd.php
@@ -12,7 +12,13 @@ class Test_WP_Stream_Connector_EDD extends WP_StreamTestCase {
 	 * Runs before all tests
 	 */
 	public static function wpSetUpBeforeClass() {
+		global $wpdb;
+
+		$suppress = $wpdb->suppress_errors();
+
 		edd_install();
+
+		$wpdb->suppress_errors( $suppress );
 	}
 
 	/**
@@ -28,7 +34,7 @@ class Test_WP_Stream_Connector_EDD extends WP_StreamTestCase {
 
 		// Make partial of Connector_EDD class, with mocked "log" function.
 		$this->mock = $this->getMockBuilder( Connector_EDD::class )
-			->setMethods( [ 'log' ] )
+			->setMethods( array( 'log' ) )
 			->getMock();
 
 		$this->mock->register();
@@ -117,7 +123,7 @@ class Test_WP_Stream_Connector_EDD extends WP_StreamTestCase {
 		$this->mock->expects( $this->exactly( 3 ) )
 			->method( 'log' )
 			->withConsecutive(
-				[
+				array(
 					$this->equalTo( __( '"%s" setting updated', 'stream' ) ),
 					$this->equalTo(
 						array(
@@ -131,8 +137,8 @@ class Test_WP_Stream_Connector_EDD extends WP_StreamTestCase {
 					$this->equalTo( null ),
 					$this->equalTo( 'settings' ),
 					$this->equalTo( 'updated' )
-				],
-				[
+				),
+				array(
 					$this->equalTo( __( '"%s" setting updated', 'stream' ) ),
 					$this->equalTo(
 						array(
@@ -146,8 +152,8 @@ class Test_WP_Stream_Connector_EDD extends WP_StreamTestCase {
 					$this->equalTo( null ),
 					$this->equalTo( 'settings' ),
 					$this->equalTo( 'updated' )
-				],
-				[
+				),
+				array(
 					$this->equalTo( __( '"%s" setting updated', 'stream' ) ),
 					$this->equalTo(
 						array(
@@ -161,7 +167,7 @@ class Test_WP_Stream_Connector_EDD extends WP_StreamTestCase {
 					$this->equalTo( null ),
 					$this->equalTo( 'settings' ),
 					$this->equalTo( 'updated' )
-				]
+				)
 			);
 
 		// Update option to trigger callback.
@@ -170,8 +176,8 @@ class Test_WP_Stream_Connector_EDD extends WP_StreamTestCase {
 		edd_update_option( 'thousands_separator' );
 
 		// Check callback test action.
-		$this->assertGreaterThan( 0, did_action( 'wp_stream_test_callback_add_option' ) );
-		$this->assertGreaterThan( 0, did_action( 'wp_stream_test_callback_update_option' ) );
+		$this->assertGreaterThan( 0, did_action( $this->action_prefix . 'callback_add_option' ) );
+		$this->assertGreaterThan( 0, did_action( $this->action_prefix . 'callback_update_option' ) );
 	}
 
 	public function test_log_override() {
@@ -214,10 +220,10 @@ class Test_WP_Stream_Connector_EDD extends WP_StreamTestCase {
 					)
 				),
 				$this->equalTo(
-					[
+					array(
 						'post_id' => $post_id,
 						'status'  => 'inactive',
-					]
+					)
 				),
 				$this->equalTo( $post_id ),
 				$this->equalTo( 'discounts' ),
@@ -228,7 +234,7 @@ class Test_WP_Stream_Connector_EDD extends WP_StreamTestCase {
 		$discount->update_status( 'inactive' );
 
 		// Check callback test action.
-		$this->assertGreaterThan( 0, did_action( 'wp_stream_test_callback_edd_pre_update_discount_status' ) );
+		$this->assertGreaterThan( 0, did_action( $this->action_prefix . 'callback_edd_pre_update_discount_status' ) );
 	}
 
 	public function test_settings_transport_callbacks() {
@@ -236,20 +242,20 @@ class Test_WP_Stream_Connector_EDD extends WP_StreamTestCase {
 		$this->mock->expects( $this->exactly( 2 ) )
 			->method( 'log' )
 			->withConsecutive(
-				[
+				array(
 					$this->equalTo( __( 'Imported Settings', 'stream' ) ),
 					$this->equalTo( array() ),
 					$this->equalTo( null ),
 					$this->equalTo( 'settings' ),
 					$this->equalTo( 'imported' ),
-				],
-				[
+				),
+				array(
 					$this->equalTo( __( 'Exported Settings', 'stream' ) ),
 					$this->equalTo( array() ),
 					$this->equalTo( null ),
 					$this->equalTo( 'settings' ),
 					$this->equalTo( 'exported' ),
-				]
+				)
 			);
 
 		// Manually trigger callbacks.
@@ -257,13 +263,13 @@ class Test_WP_Stream_Connector_EDD extends WP_StreamTestCase {
 		do_action( 'edd_export_settings' );
 
 		// Check callback test action.
-		$this->assertGreaterThan( 0, did_action( 'wp_stream_test_callback_edd_import_settings' ) );
-		$this->assertGreaterThan( 0, did_action( 'wp_stream_test_callback_edd_export_settings' ) );
+		$this->assertGreaterThan( 0, did_action( $this->action_prefix . 'callback_edd_import_settings' ) );
+		$this->assertGreaterThan( 0, did_action( $this->action_prefix . 'callback_edd_export_settings' ) );
 	}
 
 	public function test_meta() {
 		// Create and authenticate user.
-		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		\wp_set_current_user( $user_id );
 
 		// Expected log calls.
@@ -271,7 +277,7 @@ class Test_WP_Stream_Connector_EDD extends WP_StreamTestCase {
 			->method( 'log' )
 			->with(
 				$this->equalTo( __( 'User API Key created', 'stream' ) ),
-				$this->equalTo( [ 'meta_value' => 1 ] ),
+				$this->equalTo( array( 'meta_value' => 1 ) ),
 				$this->equalTo( $user_id ),
 				$this->equalTo( 'api_keys' ),
 				'created'
@@ -282,6 +288,6 @@ class Test_WP_Stream_Connector_EDD extends WP_StreamTestCase {
 		\edd_update_user_api_key( $user_id );
 
 		// Check callback test action.
-		$this->assertGreaterThan( 0, did_action( 'wp_stream_test_callback_add_user_meta' ) );
+		$this->assertGreaterThan( 0, did_action( $this->action_prefix . 'callback_add_user_meta' ) );
 	}
 }

--- a/tests/tests/connectors/test-class-connector-taxonomies.php
+++ b/tests/tests/connectors/test-class-connector-taxonomies.php
@@ -57,7 +57,7 @@ class Test_WP_Stream_Connector_Taxonomies extends WP_StreamTestCase {
 		wp_insert_term( 'test', 'category' );
 
 		// Check callback test action.
-		$this->assertGreaterThan( 0, did_action( 'wp_stream_test_callback_created_term' ) );
+		$this->assertGreaterThan( 0, did_action( $this->action_prefix . 'callback_created_term' ) );
 	}
 
 	public function test_callback_delete_term() {
@@ -93,7 +93,7 @@ class Test_WP_Stream_Connector_Taxonomies extends WP_StreamTestCase {
 		wp_delete_term( $term_data['term_id'], 'category' );
 
 		// Check callback test action.
-		$this->assertGreaterThan( 0, did_action( 'wp_stream_test_callback_delete_term' ) );
+		$this->assertGreaterThan( 0, did_action( $this->action_prefix . 'callback_delete_term' ) );
 	}
 
 	public function test_callback_edited_term() {
@@ -137,7 +137,7 @@ class Test_WP_Stream_Connector_Taxonomies extends WP_StreamTestCase {
 		);
 
 		// Check callback test action.
-		$this->assertGreaterThan( 0, did_action( 'wp_stream_test_callback_edit_term' ) );
-		$this->assertGreaterThan( 0, did_action( 'wp_stream_test_callback_edited_term' ) );
+		$this->assertGreaterThan( 0, did_action( $this->action_prefix . 'callback_edit_term' ) );
+		$this->assertGreaterThan( 0, did_action( $this->action_prefix . 'callback_edited_term' ) );
 	}
 }

--- a/tests/tests/connectors/test-class-connector-user-switching.php
+++ b/tests/tests/connectors/test-class-connector-user-switching.php
@@ -81,7 +81,7 @@ class Test_WP_Stream_Connector_User_Switching extends WP_StreamTestCase {
 		\switch_to_user( $user_id );
 
 		// Check callback test action.
-		$this->assertGreaterThan( 0, did_action( 'wp_stream_test_callback_switch_to_user' ) );
+		$this->assertGreaterThan( 0, did_action( $this->action_prefix . 'callback_switch_to_user' ) );
 	}
 
 	public function test_callback_switch_back_user() {
@@ -131,7 +131,7 @@ class Test_WP_Stream_Connector_User_Switching extends WP_StreamTestCase {
 		\switch_to_user( $old_user_id, false, false );
 
 		// Check callback test action.
-		$this->assertGreaterThan( 0, did_action( 'wp_stream_test_callback_switch_back_user' ) );
+		$this->assertGreaterThan( 0, did_action( $this->action_prefix . 'callback_switch_back_user' ) );
 	}
 
 	public function test_callback_switch_off_user() {
@@ -160,6 +160,6 @@ class Test_WP_Stream_Connector_User_Switching extends WP_StreamTestCase {
 		\switch_off_user();
 
 		// Check callback test action.
-		$this->assertGreaterThan( 0, did_action( 'wp_stream_test_callback_switch_off_user' ) );
+		$this->assertGreaterThan( 0, did_action( $this->action_prefix . 'callback_switch_off_user' ) );
 	}
 }


### PR DESCRIPTION
# Checklist
- Suppress the database error printed to the console when `edd_install()` called.
- Applies the `$this->action_prefix` to all test callback checks.
- All short version arrays `[]` refactor to long version `array()` for consistency