### PR TITLE
CI locked to composer version 1 until support for composer 2 added.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,8 @@ before_install:
   - docker-compose pull wordpress
   - nvm install
   - nvm use
+  # Lock to Composer version 1 for now.
+  - composer self-update --1
 
 install:
   - npm install


### PR DESCRIPTION
Locks Travis-CI to composer version 1

