### PR TITLE
Remove redundant textdomain loading

### DIFF
--- a/stream.php
+++ b/stream.php
@@ -32,7 +32,6 @@
  */
 
 if ( ! version_compare( PHP_VERSION, '5.3', '>=' ) ) {
-	load_plugin_textdomain( 'stream', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
 	add_action( 'shutdown', 'wp_stream_fail_php_version' );
 } else {
 	require __DIR__ . '/classes/class-plugin.php';

--- a/stream.php
+++ b/stream.php
@@ -31,7 +31,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-if ( ! version_compare( PHP_VERSION, '5.3', '>=' ) ) {
+if ( version_compare( PHP_VERSION, '5.3', '<' ) ) {
 	add_action( 'shutdown', 'wp_stream_fail_php_version' );
 } else {
 	require __DIR__ . '/classes/class-plugin.php';


### PR DESCRIPTION
`wp_stream_fail_php_version` does it itself.

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [ ] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.
