### PR TITLE
Mercator deprecated actions patched in Blogs connector test

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,6 +6,9 @@
       "type": "php",
       "request": "launch",
       "port": 9000,
+      "ignore": [
+        "vendor/"
+      ],
       "pathMappings": {
         "/var/www/html/wp-content/plugins/stream-src": "${workspaceRoot}",
         "/var/www/html/wp-content/plugins/stream": "${workspaceRoot}/build",

--- a/connectors/class-connector-blogs.php
+++ b/connectors/class-connector-blogs.php
@@ -160,7 +160,7 @@ class Connector_Blogs extends Connector {
 	/**
 	 * A site has been deleted from the database.
 	 *
-	 * @action wp_deleted_site
+	 * @action wp_delete_site
 	 *
 	 * @param WP_Site $old_site  Deleted site object.
 	 */

--- a/tests/tests/connectors/test-class-connector-blogs.php
+++ b/tests/tests/connectors/test-class-connector-blogs.php
@@ -131,7 +131,11 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 			);
 
 		// Delete blog to trigger callback.
-		\wp_delete_site( $blog_id );
+		// Fix Mercator actions.
+		remove_all_actions( 'delete_blog' );
+		add_action( 'wp_delete_blog', '\Mercator\clear_mappings_on_delete' );
+
+		wpmu_delete_blog( $blog_id, true );
 		$wpdb->suppress_errors( $suppress );
 
 		// Check callback test action.


### PR DESCRIPTION
Minor deprecation patch for fixing CI. See error [here](https://travis-ci.com/github/xwp/stream/jobs/469007210#L776). The cause is this line in Mercator [here](https://github.com/humanmade/Mercator/blob/master/mercator.php#L92)


