### PR TITLE
Fix missing alert highlight color in list table

### DIFF
--- a/alerts/class-alert-type-highlight.php
+++ b/alerts/class-alert-type-highlight.php
@@ -217,8 +217,10 @@ class Alert_Type_Highlight extends Alert_Type {
 	 * @return array New list of classes.
 	 */
 	public function post_class( $classes, $record ) {
-		if ( ! empty( $record->meta['wp_stream_alerts_triggered']['highlight']['highlight_color'] ) ) {
-			$color = $record->meta['wp_stream_alerts_triggered']['highlight']['highlight_color'];
+		$record           = new Record( $record );
+		$alerts_triggered = $record->get_meta( Alerts::ALERTS_TRIGGERED_META_KEY, true );
+		if ( ! empty( $alerts_triggered[ $this->slug ]['highlight_color'] ) ) {
+			$color = $alerts_triggered[ $this->slug ]['highlight_color'];
 		}
 
 		if ( empty( $color ) || ! is_string( $color ) ) {


### PR DESCRIPTION
Fixes #1245.

`$record` is a plain PHP object which has no `meta` property. This PR converts it to a proper `Record` as done in `Alert_Type_Highlight::action_link_remove_highlight()`.


# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix missing alert highlight colors in list table