### PR TITLE
Update wp_stream_get_sites() to work consistently with the `limit`/`number` argument

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -95,7 +95,14 @@ function wp_stream_json_encode( $data, $options = 0, $depth = 512 ) {
  * @return array
  */
 function wp_stream_get_sites( $args = array() ) {
+	if ( empty( $args['limit'] ) ) {
+		$args['limit'] = 0;
+	}
+
 	if ( function_exists( 'get_sites' ) ) {
+		// get_sites() uses 'number', wp_get_sites() uses 'limit'.
+		$args['number'] = $args['limit'];
+		
 		$sites = get_sites( $args );
 	} else {
 		$sites = array();


### PR DESCRIPTION
Update wp_stream_get_sites() to work consistently with the `limit`/`number` argument

This also changes it so that by default, list every site rather than the first 100 encountered on networks.

This also changes it to listing all sites by default, rather than only the first 100.

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [ ] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: Describe a bug fix included in this release.
- New: Describe a new feature in this release.


## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).


Change `[ ]` to `[x]` to mark the items as done.
