### PR TITLE
Include the blog ID context in the context dropdown.

### DIFF
--- a/ui/js/exclude.js
+++ b/ui/js/exclude.js
@@ -354,7 +354,7 @@ jQuery(
 					function() {
 						var parts = $( this ).val().split( '-' );
 						$( this ).siblings( '.connector' ).val( parts[0] );
-						$( this ).siblings( '.context' ).val( parts[1] );
+						$( this ).siblings( '.context' ).val( parts.slice(1).join('-') );
 						$( this ).removeAttr( 'name' );
 					}
 				);


### PR DESCRIPTION
On the network admin exclude screen, the blogs column will fail to save with the correct blog context, saving `blogs` rather than `blogs-123`.

The value can be `blog-blogs-123` on the Network exclude screen, this ensures that the value used is `blogs-123` rather than `blogs`.

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [ ] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: Describe a bug fix included in this release.
- New: Describe a new feature in this release.


## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).


Change `[ ]` to `[x]` to mark the items as done.
