### PR TITLE
Posts Connector: Enable on the front end to ensure logging happens for REST API events

### DIFF
--- a/connectors/class-connector-posts.php
+++ b/connectors/class-connector-posts.php
@@ -29,13 +29,6 @@ class Connector_Posts extends Connector {
 	);
 
 	/**
-	 * Register connector in the WP Frontend
-	 *
-	 * @var bool
-	 */
-	public $register_frontend = false;
-
-	/**
 	 * Return translated connector label
 	 *
 	 * @return string Translated connector label


### PR DESCRIPTION
Post creation and updating that happens through the REST API is not considered to occur in the "admin" even if the request is made from the block editor. Therefore, these events aren't getting logged because the Posts connector is disabled for the frontend. I don't know what the rationale is for disabling it, but by _not_ doing that, post creation gets logged.

Fixes #1195 
Fixes #1250

# Checklist

- [ ] ~Project documentation has been updated to reflect the changes in this pull request, if applicable.~
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.

