### PR TITLE
Connectors: Check the request type and unregister connectors that don't support it

### DIFF
--- a/classes/class-connector.php
+++ b/classes/class-connector.php
@@ -55,6 +55,13 @@ abstract class Connector {
 	public $register_frontend = true;
 
 	/**
+	 * Register connector for API requests
+	 *
+	 * @var bool
+	 */
+	public $register_api = true;
+
+	/**
 	 * Holds connector registration status flag.
 	 *
 	 * @var bool

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -148,3 +148,14 @@ function wp_stream_min_suffix() {
 
 	return $min;
 }
+
+/**
+ * Check if the current request is being processed by the REST API or XMLRPC.
+ *
+ * Can only be called after priority 10 of the `parse_request` action.
+ *
+ * @return bool
+ */
+function wp_stream_is_api_request() {
+	return ( ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) );
+}


### PR DESCRIPTION
This is an alternative approach to #1264. Since requests to WP APIs are not considered to be `is_admin`, connectors that are disabled for the "frontend" are also disabled for API requests, which is not always (or maybe ever) intended. In this PR we allow all connectors to be registered, regardless of `is_admin`, and then take the following steps when the `parse_request` action is fired (this is when the REST API is initialized):

1. Check to see what kind of request we have, differentiating between admin, frontend, and api requests.
2. Cycle through all the connectors and for each, check if it supports that type of request (via the `register_admin`, `register_frontend`, and the new `register_api` class properties)
3. If a connector does not support the current request type, unregister it.

This addresses the issue of the Posts connector not logging post changes that happen via the REST API, without changing its behavior for actual frontend requests.

Fixes #1195
Fixes #1250

# Checklist

- [x] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.
