### PR TITLE
Fixing required/optional parameters

### DIFF
--- a/alerts/class-alert-trigger-action.php
+++ b/alerts/class-alert-trigger-action.php
@@ -164,12 +164,12 @@ class Alert_Trigger_Action extends Alert_Trigger {
 	 *
 	 * @see Alert_Trigger::get_display_value().
 	 *
-	 * @param string $context The location this data will be displayed in.
-	 * @param Alert  $alert Alert being processed.
+	 * @param string     $context The location this data will be displayed in.
+	 * @param Alert|null $alert Alert being processed.
 	 *
 	 * @return string
 	 */
-	public function get_display_value( $context = 'normal', $alert ) {
+	public function get_display_value( $context = 'normal', $alert = null ) {
 		$action = ( ! empty( $alert->alert_meta['trigger_action'] ) ) ? $alert->alert_meta['trigger_action'] : null;
 
 		if ( 'post_title' === $context ) {

--- a/alerts/class-alert-trigger-author.php
+++ b/alerts/class-alert-trigger-author.php
@@ -153,12 +153,12 @@ class Alert_Trigger_Author extends Alert_Trigger {
 	 *
 	 * @see Alert_Trigger::get_display_value().
 	 *
-	 * @param string $context The location this data will be displayed in.
-	 * @param Alert  $alert Alert being processed.
+	 * @param string      $context The location this data will be displayed in.
+	 * @param Alert|null  $alert Alert being processed.
 	 *
 	 * @return string
 	 */
-	public function get_display_value( $context = 'normal', $alert ) {
+	public function get_display_value( $context = 'normal', $alert = null ) {
 		$author = ( ! empty( $alert->alert_meta['trigger_author'] ) ) ? $alert->alert_meta['trigger_author'] : null;
 		if ( empty( $author ) ) {
 			$author = __( 'Any User', 'stream' );

--- a/alerts/class-alert-trigger-context.php
+++ b/alerts/class-alert-trigger-context.php
@@ -202,12 +202,12 @@ class Alert_Trigger_Context extends Alert_Trigger {
 	 *
 	 * @see Alert_Trigger::get_display_value().
 	 *
-	 * @param string $context The location this data will be displayed in.
-	 * @param Alert  $alert Alert being processed.
+	 * @param string     $context The location this data will be displayed in.
+	 * @param Alert|null $alert Alert being processed.
 	 *
 	 * @return string
 	 */
-	public function get_display_value( $context = 'normal', $alert ) {
+	public function get_display_value( $context = 'normal', $alert = null ) {
 		$context   = ( ! empty( $alert->alert_meta['trigger_context'] ) ) ? $alert->alert_meta['trigger_context'] : null;
 		$connector = ( ! empty( $alert->alert_meta['trigger_connector'] ) ) ? $alert->alert_meta['trigger_connector'] : null;
 		if ( empty( $context ) && empty( $connector ) ) {

--- a/classes/class-alert-trigger.php
+++ b/classes/class-alert-trigger.php
@@ -78,11 +78,11 @@ abstract class Alert_Trigger {
 	/**
 	 * Returns the trigger's value for the given alert.
 	 *
-	 * @param string $context The location this data will be displayed in.
-	 * @param Alert  $alert Alert being processed.
+	 * @param string     $context The location this data will be displayed in.
+	 * @param Alert|null $alert Alert being processed.
 	 * @return string
 	 */
-	abstract public function get_display_value( $context = 'normal', $alert );
+	abstract public function get_display_value( $context = 'normal', $alert = null );
 
 	/**
 	 * Allow connectors to determine if their dependencies is satisfied or not


### PR DESCRIPTION
Fixes #1272 .

This could be fixed in one of two ways, either just update the second parameter to have `null` as the default value, or to update all logic to flop the two parameters.

This PR does the former since it shouldn't have any BC issues. All uses of `$alert` inside of the methods appear to be used to bring out additional meta data, and the existing code uses an `empty()` check which is [safe with `null` parameters](https://3v4l.org/YZoX3)

It is possible that anyone else that has custom code with additional alerts, however, might run into signature issues depending on their PHP versions.

# Checklist

- [ ] ~Project documentation has been updated to reflect the changes in this pull request, if applicable.~
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] ~I have added phpunit tests.~

## Release Changelog

- Fix: Fixes PHP 8 deprecation warning

## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).