### PR TITLE
Fixup fc606db

### DIFF
--- a/classes/class-db-driver-wpdb.php
+++ b/classes/class-db-driver-wpdb.php
@@ -81,9 +81,7 @@ class DB_Driver_WPDB implements DB_Driver {
 		// Insert record meta.
 		foreach ( (array) $meta as $key => $vals ) {
 			foreach ( (array) $vals as $val ) {
-				if ( is_scalar( $val ) && '' !== $val ) {
-					$this->insert_meta( $record_id, $key, $val );
-				}
+				$this->insert_meta( $record_id, $key, $val );
 			}
 		}
 

--- a/classes/class-log.php
+++ b/classes/class-log.php
@@ -110,12 +110,10 @@ class Log {
 		}
 
 		// Prevent any meta with null values from being logged.
-		$stream_meta = array_filter(
-			$args,
-			function ( $var ) {
-				return ! is_null( $var );
-			}
-		);
+		//
+		// @see https://www.php.net/manual/en/function.array-filter.php#111091
+		$stream_meta = array_filter( $args, 'strlen' );
+		$user_meta = array_filter( $user_meta, 'strlen' );
 
 		// Add user meta to Stream meta.
 		$stream_meta['user_meta'] = $user_meta;


### PR DESCRIPTION
This reverts commit fc606dbd175b1ce533ea88198f8bf91a78fb1439.

We found a more correct location to improve a previously existing sanity check.

Fixes #1080, but better. Sorry @kasparsd :smile:

You were right, there was a connection between #1038 and #1080 all along. I now traced down how all meta is added to a record, and found we're already trying to prevent empty values. Unfortunately

* existing `$stream_meta is_null()` check along is weak
* `$user_meta` being a nested array, its actual contents isn't checked at all

`strlen` trick seems to be a solid one, considering hundreds of upvotes on PHP docs. I always disliked having to do a separate empty string check for `is_scalar()` result.

Now that previous version is in, this PR doesn't have urgency for its own release.