### PR TITLE
Prevent Woocommerce context to be autoselected after filtering

### DIFF
--- a/connectors/class-connector-woocommerce.php
+++ b/connectors/class-connector-woocommerce.php
@@ -778,6 +778,10 @@ class Connector_Woocommerce extends Connector {
 				if ( empty( $sections ) ) {
 					$sections[''] = $page_label;
 				}
+				
+				if( empty( $page_id ) ) {
+				 	continue;
+				}
 
 				$settings_pages[ $page_id ] = $page_label;
 


### PR DESCRIPTION
Check if $page_id has a proper value, before adding it to the list. Because adding an empty key to this array results in "Woocommerce" always being selected after a filter action.

<img width="471" alt="Screenshot 2022-04-06 at 12 37 29" src="https://user-images.githubusercontent.com/145887/161959610-c24b1f5b-5fbb-415b-bdb6-b034de8a2946.png">

This happend when a third party plugin added a Woocommerce Settingpage without properly setting the `page_id`. Woocommerce doesn't give you a error when doing this. But this does result in a empty `key` in the `$context_labels` https://github.com/xwp/stream/blob/develop/connectors/class-connector-woocommerce.php#L177 here.

The settingspage with the empty `page_id` is retreived from `\WC_Admin_Settings::get_settings_pages()` on https://github.com/xwp/stream/blob/develop/connectors/class-connector-woocommerce.php#L768. So it's a WC thing, but regresses into Stream.

I found the solution by reading this issue #1051

Before diving into PHPUnit etc (not fluently with them) I wanted to know if this would be a PR that would get accepted.

Kind regards,

Jaime

# Checklist

- [x] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.

## Release Changelog

- Fix: Woocommerce context dropdown filter being selected by default after a "filter action"
- New: Woocommerce filter doesn't get selected by default anymore.


## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).

