### PR TITLE
Fixes #1294 widget connector php 8 incompatibility

### DIFF
--- a/connectors/class-connector-widgets.php
+++ b/connectors/class-connector-widgets.php
@@ -297,8 +297,8 @@ class Connector_Widgets extends Connector {
 	 * @return void
 	 */
 	protected function handle_widget_removal( $old, $new ) {
-		$all_old_widget_ids = array_unique( call_user_func_array( 'array_merge', $old ) );
-		$all_new_widget_ids = array_unique( call_user_func_array( 'array_merge', $new ) );
+		$all_old_widget_ids = array_unique( call_user_func_array( 'array_merge', array_values( $old ) ) );
+		$all_new_widget_ids = array_unique( call_user_func_array( 'array_merge', array_values( $new ) ) );
 		// @todo In the customizer, moving widgets to other sidebars is problematic because each sidebar is registered as a separate setting; so we need to make sure that all $_POST['customized'] are applied?
 		// @todo The widget option is getting updated before the sidebars_widgets are updated, so we need to hook into the option update to try to cache any deletions for future lookup
 
@@ -357,8 +357,8 @@ class Connector_Widgets extends Connector {
 	 * @return void
 	 */
 	protected function handle_widget_addition( $old, $new ) {
-		$all_old_widget_ids = array_unique( call_user_func_array( 'array_merge', $old ) );
-		$all_new_widget_ids = array_unique( call_user_func_array( 'array_merge', $new ) );
+		$all_old_widget_ids = array_unique( call_user_func_array( 'array_merge', array_values( $old ) ) );
+		$all_new_widget_ids = array_unique( call_user_func_array( 'array_merge', array_values( $new ) ) );
 		$added_widget_ids   = array_diff( $all_new_widget_ids, $all_old_widget_ids );
 
 		foreach ( $added_widget_ids as $widget_id ) {


### PR DESCRIPTION
Fixes #1294

The widget connector throws PHP fatal errors on widget add/remove on PHP 8.x:
`PHP Fatal error:  Uncaught ArgumentCountError: array_merge() does not accept unknown named parameters in /wp-content/plugins/stream/connectors/class-connector-widgets.php:300`

This update fixes the issue by applying `array_values()` on the arguments before passing them to `array_merge()/call_user_func_array()`.

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [X] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.