### PR TITLE
Optionsfix

### DIFF
--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -143,9 +143,7 @@ class Admin {
 		add_filter( 'role_has_cap', array( $this, 'filter_role_caps' ), 10, 3 );
 
 		if ( is_multisite() && $plugin->is_network_activated() && ! is_network_admin() ) {
-			$options = (array) get_site_option( 'wp_stream_network', array() );
-			$option  = isset( $options['general_site_access'] ) ? absint( $options['general_site_access'] ) : 1;
-
+			$option  = isset( $this->plugin->settings->options['general_site_access'] ) ? absint( $this->plugin->settings->options['general_site_access'] ) : 1;
 			$this->disable_access = ( $option ) ? false : true;
 		}
 
@@ -746,18 +744,12 @@ class Admin {
 			return;
 		}
 
-		$defaults = $this->plugin->settings->get_defaults();
-		if ( is_multisite() && $this->plugin->is_network_activated() ) {
-			$options = (array) get_site_option( 'wp_stream_network', $defaults );
-		} else {
-			$options = (array) get_option( 'wp_stream', $defaults );
-		}
 
-		if ( ! empty( $options['general_keep_records_indefinitely'] ) || ! isset( $options['general_records_ttl'] ) ) {
+		if ( ! empty( $this->plugin->settings->options['general_keep_records_indefinitely'] ) || ! isset( $this->plugin->settings->options['general_records_ttl'] ) ) {
 			return;
 		}
 
-		$days     = $options['general_records_ttl'];
+		$days     = $this->plugin->settings->options['general_records_ttl'];
 		$timezone = new DateTimeZone( 'UTC' );
 		$date     = new DateTime( 'now', $timezone );
 

--- a/tests/tests/test-class-admin.php
+++ b/tests/tests/test-class-admin.php
@@ -269,13 +269,10 @@ class Test_Admin extends WP_StreamTestCase {
 
 	public function test_purge_scheduled_action() {
 		// Set the TTL to one day
+		$this->plugin->settings->options['general_records_ttl'] = '1';
 		if ( is_multisite() && is_plugin_active_for_network( $this->plugin->locations['plugin'] ) ) {
-			$options = (array) get_site_option( 'wp_stream_network', array() );
-			$options['general_records_ttl'] = '1';
 			update_site_option( 'wp_stream_network', $options );
 		} else {
-			$options = (array) get_option( 'wp_stream', array() );
-			$options['general_records_ttl'] = '1';
 			update_option( 'wp_stream', $options );
 		}
 


### PR DESCRIPTION
Potentially fixes #1056.

We discovered an issue where some defaults were saved to the database but not the complete set of fields. This meant that unless fields such as `general_records_ttl` were set, it wouldn't load the defaults and therefore never purge the records. The issue has the same description as #1056 but unsure of the exact cause from the bug reporter.

When reviewing the code, I could see that the Settings class already had the correct syntax for merging defaults so it was easiest to therefore adjust the Admin class to simply use this (instead of duplicating). By ensuring the full defaults are loaded (if not set in the database), this also ensures any new options added won't be dropped in the future. 

This may also resolve #1236.