### PR TITLE
Check authorization on 'save_new_alert' AJAX action

### DIFF
--- a/classes/class-alerts.php
+++ b/classes/class-alerts.php
@@ -509,6 +509,7 @@ class Alerts {
 	 * @return void
 	 */
 	public function display_notification_box( $post = array() ) {
+		$alert      = null;
 		$alert_type = 'none';
 		if ( is_object( $post ) ) {
 			$alert      = $this->get_alert( $post->ID );
@@ -732,6 +733,13 @@ class Alerts {
 	 */
 	public function save_new_alert() {
 		check_ajax_referer( 'save_alert', 'wp_stream_alerts_nonce' );
+
+		if ( ! current_user_can( $this->plugin->admin->settings_cap ) ) {
+			wp_die(
+				esc_html__( "You don't have sufficient privileges to do this action.", 'stream' )
+			);
+		}
+
 		$trigger_author                = wp_stream_filter_input( INPUT_POST, 'wp_stream_trigger_author' );
 		$trigger_connector_and_context = wp_stream_filter_input( INPUT_POST, 'wp_stream_trigger_context' );
 		if ( false !== strpos( $trigger_connector_and_context, '-' ) ) {
@@ -799,6 +807,12 @@ class Alerts {
 	 * Return HTML string of the Alert page controls.
 	 */
 	public function get_new_alert_triggers_notifications() {
+		if ( ! current_user_can( $this->plugin->admin->settings_cap ) ) {
+			wp_die(
+				esc_html__( "You don't have sufficient privileges to do this action.", 'stream' )
+			);
+		}
+
 		ob_start();
 		?>
 		<fieldset class="inline-edit-col inline-edit-wp_stream_alerts inline-edit-add-new-triggers">


### PR DESCRIPTION
The logic in `save_new_alert` AJAX action does only check for a valid nonce, but not for authorization. This makes it possible to reuse a valid nonce and trigger the `save_new_alert` with an unauthorized or unauthenticated user.

This PR adds an authorization check to `save_new_alert` (as well as to `get_new_alert_triggers_notifications`, which could be used to retrieve a nonce as an authenticated but unauthorized user), and adds corresponding tests to ensure both wanted and unwanted requests behave as expected with regards to alert creation.

# Checklist

- [x] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [x] I have added phpunit tests.