### PR TITLE
Split issue and PR templates into separate files

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/1-FEATURE_REQUEST.md
@@ -1,0 +1,12 @@
+---
+name: "\U0001F195 Feature Request"
+about: "I have a suggestion for missing functionality or improvements"
+title: ''
+labels: 'i: enhancement'
+assignees: ''
+
+---
+
+# Feature Request
+
+Describe the suggested feature and how it's beneficial to Stream users.

--- a/.github/ISSUE_TEMPLATE/2-BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/2-BUG_REPORT.md
@@ -1,9 +1,11 @@
-Delete the section that is not applicable:
+---
+name: "\U0001F41B Bug Report"
+about: "Something isn't working as expected"
+title: ''
+labels: 'i: bug'
+assignees: ''
 
-# Feature Request
-
-Describe the suggested feature and how it's beneficial to Stream users.
-
+---
 
 # Bug Report
 
@@ -18,9 +20,7 @@ Describe what actually happens.
 ## Steps to Reproduce the Problem
 
 1.
-
 2.
-
 3.
 
 ## Screenshots

--- a/.github/PULL_REQUEST_TEMPLATE/1-REGULAR_PULL_REQUEST.md
+++ b/.github/PULL_REQUEST_TEMPLATE/1-REGULAR_PULL_REQUEST.md
@@ -1,0 +1,20 @@
+---
+name: "\U0001F527 Patch Release Checklist"
+about: "Merge a fix or a new feature into the development version"
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Fixes #000.
+
+Describe your approach and how it fixes the issue.
+
+# Checklist
+
+- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
+- [ ] I have tested the changes in the local development environment (see `contributing.md`).
+- [ ] I have added phpunit tests.
+
+Change `[ ]` to `[x]` to mark the items as done.

--- a/.github/PULL_REQUEST_TEMPLATE/1-REGULAR_PULL_REQUEST.md
+++ b/.github/PULL_REQUEST_TEMPLATE/1-REGULAR_PULL_REQUEST.md
@@ -1,5 +1,5 @@
 ---
-name: "\U0001F527 Patch Release Checklist"
+name: "\U0001F527 Regular pull request"
 about: "Merge a fix or a new feature into the development version"
 title: ''
 labels: ''

--- a/.github/PULL_REQUEST_TEMPLATE/2-RELEASE_PULL_REQUEST.md
+++ b/.github/PULL_REQUEST_TEMPLATE/2-RELEASE_PULL_REQUEST.md
@@ -1,5 +1,5 @@
 ---
-name: "\U0001F680 Release Pull Request"
+name: "\U0001F680 Release pull request"
 about: "\U0001F512 Maintainers only: fixes/features in development get released"
 title: 'Release x.x.x'
 labels: ''

--- a/.github/PULL_REQUEST_TEMPLATE/2-RELEASE_PULL_REQUEST.md
+++ b/.github/PULL_REQUEST_TEMPLATE/2-RELEASE_PULL_REQUEST.md
@@ -1,21 +1,18 @@
-Fixes #000.
+---
+name: "\U0001F680 Release Pull Request"
+about: "\U0001F512 Maintainers only: fixes/features in development get released"
+title: 'Release x.x.x'
+labels: ''
+assignees: ''
 
-Describe your approach and how it fixes the issue.
+---
 
-# Checklist
-
-- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
-- [ ] I have tested the changes in the local development environment (see `contributing.md`).
-- [ ] I have added phpunit tests.
-
-
-## Release Changelog
+# Release Changelog
 
 - Fix: Describe a bug fix included in this release.
 - New: Describe a new feature in this release.
 
-
-## Release Checklist
+# Release Checklist
 
 - [ ] This pull request is to the `master` branch.
 - [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
@@ -24,6 +21,5 @@ Describe your approach and how it fixes the issue.
 - [ ] Bump `Stable tag` in `readme.txt`.
 - [ ] Bump version in `classes/class-plugin.php`.
 - [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).
-
 
 Change `[ ]` to `[x]` to mark the items as done.


### PR DESCRIPTION
The issue and PR templates are single files that contain multiple workflows, and the user needs to delete the workflows that are not applicable.

This PR splits these templates into separate files, which enables a GitHub template chooser that lets user pick the right one from the start. This avoids a lot of confusion and makes sure users only deal with the template parts that are relevant to them.

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [ ] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.
