### PR TITLE
Remove references to deprecated filter.

### DIFF
--- a/classes/class-filter-input.php
+++ b/classes/class-filter-input.php
@@ -33,7 +33,6 @@ class Filter_Input {
 		FILTER_SANITIZE_NUMBER_FLOAT  => 'floatval',
 		FILTER_SANITIZE_NUMBER_INT    => 'intval',
 		FILTER_SANITIZE_SPECIAL_CHARS => 'htmlspecialchars',
-		FILTER_SANITIZE_STRING        => 'sanitize_text_field',
 		FILTER_SANITIZE_URL           => 'esc_url_raw',
 		// Other.
 		FILTER_UNSAFE_RAW             => null,

--- a/classes/class-live-update.php
+++ b/classes/class-live-update.php
@@ -56,9 +56,9 @@ class Live_Update {
 		check_ajax_referer( $this->user_meta_key . '_nonce', 'nonce' );
 
 		$input = array(
-			'checked'   => FILTER_SANITIZE_STRING,
-			'user'      => FILTER_SANITIZE_STRING,
-			'heartbeat' => FILTER_SANITIZE_STRING,
+			'checked'   => FILTER_SANITIZE_SPECIAL_CHARS,
+			'user'      => FILTER_SANITIZE_SPECIAL_CHARS,
+			'heartbeat' => FILTER_SANITIZE_SPECIAL_CHARS,
 		);
 
 		$input = filter_input_array( INPUT_POST, $input );


### PR DESCRIPTION
Fixes #1343 .

Describe your approach and how it fixes the issue.

# Checklist

- [X] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [X] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Change: Remove deprecated filter constant.


## Release Checklist

- [X] This pull request is to the `master` branch.
- [X] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).


Change `[ ]` to `[x]` to mark the items as done.
