### PR TITLE
Remove get_user_attribute

### DIFF
--- a/alerts/class-alert-type-menu-alert.php
+++ b/alerts/class-alert-type-menu-alert.php
@@ -141,8 +141,6 @@ class Alert_Type_Menu_Alert extends Alert_Type {
 	/**
 	 * Get a list of all current alert messages for current user.
 	 *
-	 * @todo update this for VIP. (get_user_meta)
-	 *
 	 * @return array List of alert messages
 	 */
 	public function get_messages() {

--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -1100,10 +1100,6 @@ class Admin {
 	 * @return int|bool
 	 */
 	public function update_user_meta( $user_id, $meta_key, $meta_value, $prev_value = '' ) {
-		if ( wp_stream_is_vip() && function_exists( 'update_user_attribute' ) ) {
-			return update_user_attribute( $user_id, $meta_key, $meta_value );
-		}
-
 		return update_user_meta( $user_id, $meta_key, $meta_value, $prev_value );
 	}
 
@@ -1117,10 +1113,6 @@ class Admin {
 	 * @return bool
 	 */
 	public function delete_user_meta( $user_id, $meta_key, $meta_value = '' ) {
-		if ( wp_stream_is_vip() && function_exists( 'delete_user_attribute' ) ) {
-			return delete_user_attribute( $user_id, $meta_key, $meta_value );
-		}
-
 		return delete_user_meta( $user_id, $meta_key, $meta_value );
 	}
 }

--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -1086,10 +1086,6 @@ class Admin {
 	 * @return mixed
 	 */
 	public function get_user_meta( $user_id, $meta_key, $single = true ) {
-		if ( wp_stream_is_vip() && function_exists( 'get_user_attribute' ) ) {
-			return get_user_attribute( $user_id, $meta_key );
-		}
-
 		return get_user_meta( $user_id, $meta_key, $single );
 	}
 

--- a/classes/class-list-table.php
+++ b/classes/class-list-table.php
@@ -156,7 +156,7 @@ class List_Table extends \WP_List_Table {
 		// If user meta is not found; add the default hidden column 'id'.
 		if ( ! $hidden ) {
 			$hidden = array( 'id' );
-			$this->plugin->admin->update_user_meta( $user->ID, 'manage' . $this->screen->id . 'columnshidden', $hidden );
+			update_user_meta( $user->ID, 'manage' . $this->screen->id . 'columnshidden', $hidden );
 		}
 
 		return $hidden;
@@ -1133,13 +1133,13 @@ class List_Table extends \WP_List_Table {
 		unset( $args );
 
 		$user_id   = get_current_user_id();
-		$option    = get_user_meta( $user_id, $this->plugin->admin->live_update->user_meta_key, true );
+		$option    = $this->plugin->admin->get_user_meta( $user_id, $this->plugin->admin->live_update->user_meta_key, true );
 		$heartbeat = wp_script_is( 'heartbeat', 'done' ) ? 'true' : 'false';
 
 		if ( 'on' === $option && 'false' === $heartbeat ) {
 			$option = 'off';
 
-			$this->plugin->admin->update_user_meta( $user_id, $this->plugin->admin->live_update->user_meta_key, 'off' );
+			update_user_meta( $user_id, $this->plugin->admin->live_update->user_meta_key, 'off' );
 		}
 
 		$nonce = wp_create_nonce( $this->plugin->admin->live_update->user_meta_key . '_nonce' );

--- a/classes/class-list-table.php
+++ b/classes/class-list-table.php
@@ -151,7 +151,7 @@ class List_Table extends \WP_List_Table {
 		}
 
 		// Directly checking the user meta; to check whether user has changed screen option or not.
-		$hidden = $this->plugin->admin->get_user_meta( $user->ID, 'manage' . $this->screen->id . 'columnshidden', true );
+		$hidden = get_user_meta( $user->ID, 'manage' . $this->screen->id . 'columnshidden', true );
 
 		// If user meta is not found; add the default hidden column 'id'.
 		if ( ! $hidden ) {
@@ -1133,7 +1133,7 @@ class List_Table extends \WP_List_Table {
 		unset( $args );
 
 		$user_id   = get_current_user_id();
-		$option    = $this->plugin->admin->get_user_meta( $user_id, $this->plugin->admin->live_update->user_meta_key, true );
+		$option    = get_user_meta( $user_id, $this->plugin->admin->live_update->user_meta_key, true );
 		$heartbeat = wp_script_is( 'heartbeat', 'done' ) ? 'true' : 'false';
 
 		if ( 'on' === $option && 'false' === $heartbeat ) {

--- a/classes/class-live-update.php
+++ b/classes/class-live-update.php
@@ -72,14 +72,14 @@ class Live_Update {
 		$user = (int) $input['user'];
 
 		if ( 'false' === $input['heartbeat'] ) {
-			$this->plugin->admin->update_user_meta( $user, $this->user_meta_key, 'off' );
+			update_user_meta( $user, $this->user_meta_key, 'off' );
 
 			wp_send_json_error( esc_html__( "Live updates could not be enabled because Heartbeat is not loaded.\n\nYour hosting provider or another plugin may have disabled it for performance reasons.", 'stream' ) );
 
 			return;
 		}
 
-		$success = $this->plugin->admin->update_user_meta( $user, $this->user_meta_key, $checked );
+		$success = update_user_meta( $user, $this->user_meta_key, $checked );
 
 		if ( $success ) {
 			wp_send_json_success( ( 'on' === $checked ) ? 'Live Updates enabled' : 'Live Updates disabled' );

--- a/classes/class-live-update.php
+++ b/classes/class-live-update.php
@@ -183,7 +183,7 @@ class Live_Update {
 			return $response;
 		}
 
-		$enable_stream_update = ( 'off' !== $this->plugin->admin->get_user_meta( get_current_user_id(), $this->user_meta_key ) );
+		$enable_stream_update = ( 'off' !== get_user_meta( get_current_user_id(), $this->user_meta_key ) );
 
 		// Register list table.
 		$this->list_table = new List_Table(


### PR DESCRIPTION
Fixes [#1410](https://github.com/xwp/stream/issues/1410).

- removes references to `get_user_attributes`, replaces calls to this plugin's own `get_user_meta` method with WP core's `get_user_meta` function
- removes references to `delete_user_attributes`, replaces calls to this plugin's own `delete_user_meta` method with WP core's `delete_user_meta` function
- removes references to `update_user_attributes`, replaces calls to this plugin's own `update_user_meta` method with WP core's `update_user_meta` function

# Checklist

- [ ] ~Project documentation has been updated to reflect the changes in this pull request, if applicable.~ not really applicable ❓ 
- [ ] I have tested the changes in the local development environment (see `contributing.md`).
    - I used this code while developing a custom connector, and did not observe any errors, but my connector didn't directly interface with user meta functions
- [ ] I have added phpunit tests.
    - ❓ I debated removing this function's `get_user_meta`, `delete_user_meta`, and `update_user_meta` methods, but decided to leave them in in case third-party code uses these functions. For that reason, I left these tests in places. Does that make sense?

## Release Changelog

- Fix: Removes `*_user_attributes` function calls, in response to WP VIP deprecating those functions. This plugin's `*_user_meta` functions are still available for third-party plugins to call.

## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).