### PR TITLE
Get comment author from the comment user_id field

### DIFF
--- a/connectors/class-connector-comments.php
+++ b/connectors/class-connector-comments.php
@@ -194,8 +194,8 @@ class Connector_Comments extends Connector {
 			$user_name = isset( $user->display_name ) ? $user->display_name : $comment->comment_author;
 		}
 
-		if ( $req_user_login ) {
-			$user      = wp_get_current_user();
+		if ( $req_user_login && isset( $comment->user_id ) ) {
+			$user      = get_user_by( 'id', $comment->user_id );
 			$user_id   = $user->ID;
 			$user_name = $user->display_name;
 		}


### PR DESCRIPTION
Updates the get_comment_author function to retrieve the comment author ID from the "user_id" field of the comment rather than assuming the current user is the author of the comment.

Fixes #1428.

Describe your approach and how it fixes the issue.

# Checklist

- [x] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: Updates the get_comment_author function to show the comment author rather than the current user.

## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).


Change `[ ]` to `[x]` to mark the items as done.
