### PR TITLE
Update audit log message for comments transitioning status

### DIFF
--- a/connectors/class-connector-comments.php
+++ b/connectors/class-connector-comments.php
@@ -591,7 +591,7 @@ class Connector_Comments extends Connector {
 		$comment_type = get_comment_type( $comment->comment_ID );
 
 		$this->log(
-			/* translators: %1$s: a comment author, %2$s: a post title, %3$s: a comment type */
+			/* translators: %1$s: comment author, %2$s: comment status, %3$s: comment type, %4$s: old comment status, %5$s: post title */
 			_x(
 				'%1$s\'s %3$s on "%5$s" %2$s',
 				'Comment status transition. 1: Comment author, 2: New status, 3: Comment type, 4. Old status, 5. Post title',

--- a/connectors/class-connector-comments.php
+++ b/connectors/class-connector-comments.php
@@ -593,8 +593,8 @@ class Connector_Comments extends Connector {
 		$this->log(
 			/* translators: %1$s: a comment author, %2$s: a post title, %3$s: a comment type */
 			_x(
-				'%1$s\'s %3$s %2$s',
-				'Comment status transition. 1: Comment author, 2: Post title, 3: Comment type',
+				'%1$s\'s %3$s on "%5$s" %2$s',
+				'Comment status transition. 1: Comment author, 2: New status, 3: Comment type, 4. Old status, 5. Post title',
 				'stream'
 			),
 			compact( 'user_name', 'new_status', 'comment_type', 'old_status', 'post_title', 'post_id', 'user_id' ),


### PR DESCRIPTION
This adds the post title to the audit log text for comments that are transitioning status, to be consistent with the other messages in the comments connector.

Describe your approach and how it fixes the issue.

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: Makes the log messages for comments transitioning status (approved, unapproved, marked as spam, deleted, etc.) consistent with the other messages generated by the Comments Connector by including the post title in the message.


## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).


Change `[ ]` to `[x]` to mark the items as done.
