### PR TITLE
Add missing nonce check to uninstall action

### DIFF
--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -820,8 +820,8 @@ class Admin {
 		if ( ! defined( 'DISALLOW_FILE_MODS' ) || false === DISALLOW_FILE_MODS ) {
 			$url = add_query_arg(
 				array(
-					'action'          => 'wp_stream_uninstall',
-					'wp_stream_nonce' => wp_create_nonce( 'stream_nonce' ),
+					'action' => 'wp_stream_uninstall',
+					'nonce'  => wp_create_nonce( 'stream_uninstall_nonce' ),
 				),
 				admin_url( 'admin-ajax.php' )
 			);

--- a/classes/class-db-driver-wpdb.php
+++ b/classes/class-db-driver-wpdb.php
@@ -173,6 +173,20 @@ class DB_Driver_WPDB implements DB_Driver {
 	 * @return \WP_Stream\Uninstall
 	 */
 	public function purge_storage( $plugin ) {
+		// Avoid duplicate uninstall action.
+		// TODO: This is nasty code right now due to the fact the object instance is only known to the action.
+		// The architecture around how the uninstall action is registered should be rethought.
+		if ( has_action( 'wp_ajax_wp_stream_uninstall' ) ) {
+			// Get a list of all callbacks registered to the default priority 10 for the uninstall action.
+			$callbacks = array_values( $GLOBALS['wp_filter']['wp_ajax_wp_stream_uninstall']->callbacks[10] );
+			// From that list, retrieve function of the first (and only) callback.
+			$callback_function = $callbacks[0]['function'];
+			// The callback's first element should be the object instance of the Uninstall class.
+			$uninstall = $callback_function[0];
+
+			return $uninstall;
+		}
+
 		$uninstall = new Uninstall( $plugin );
 		add_action( 'wp_ajax_wp_stream_uninstall', array( $uninstall, 'uninstall' ) );
 

--- a/classes/class-uninstall.php
+++ b/classes/class-uninstall.php
@@ -52,6 +52,8 @@ class Uninstall {
 	 * Uninstall Stream by deleting its data
 	 */
 	public function uninstall() {
+		check_ajax_referer( 'stream_uninstall_nonce', 'nonce' );
+
 		$this->options = array(
 			$this->plugin->install->option_key,
 			$this->plugin->settings->option_key,
@@ -235,6 +237,10 @@ class Uninstall {
 	 */
 	private function deactivate() {
 		deactivate_plugins( $this->plugin->locations['plugin'] );
+
+		if ( defined( 'WP_STREAM_TESTS' ) && WP_STREAM_TESTS ) {
+			return true;
+		}
 
 		wp_safe_redirect(
 			add_query_arg(

--- a/classes/class-uninstall.php
+++ b/classes/class-uninstall.php
@@ -220,7 +220,7 @@ class Uninstall {
 		// Specific user meta.
 		foreach ( $this->user_meta as $meta_key ) {
 			$wpdb->query(
-				$wpdb->prepare( "DELETE FROM {$wpdb->usermeta} WHERE meta_key = {$wpdb->prefix}%s;", $meta_key )
+				$wpdb->prepare( "DELETE FROM {$wpdb->usermeta} WHERE meta_key = %s;", $wpdb->prefix . $meta_key )
 			);
 		}
 	}

--- a/tests/tests/test-class-admin.php
+++ b/tests/tests/test-class-admin.php
@@ -392,7 +392,7 @@ class Test_Admin extends WP_StreamTestCase {
 
 		try {
 			$this->_handleAjax( 'wp_stream_filters' );
-		} catch ( WPAjaxDieStopException $e ) {}
+		} catch ( \WPAjaxDieStopException $e ) {}
 
 		// Check that the exception was thrown.
 		$this->assertTrue( isset( $e ) );

--- a/tests/tests/test-class-alerts.php
+++ b/tests/tests/test-class-alerts.php
@@ -382,22 +382,15 @@ class Test_Alerts extends WP_StreamTestCase {
 		wp_set_current_user( $user_id );
 
 		$alerts = new Alerts( $this->plugin );
-		try {
-			$_POST['wp_stream_trigger_author'] = 'me';
-			$_POST['wp_stream_trigger_context'] = 'posts-post';
-			$_POST['wp_stream_trigger_action'] = 'edit';
-			$_POST['wp_stream_alert_type'] = 'highlight';
 
-			$this->expectException( 'WPAjaxDieStopException' );
-			$this->_handleAjax( 'save_new_alert' );
-		} catch ( \WPAjaxDieContinueException $e ) {
-			$exception = $e;
-			// Check that the exception was thrown.
-			$this->assertTrue( isset( $exception ) );
+		$_POST['wp_stream_trigger_author'] = 'me';
+		$_POST['wp_stream_trigger_context'] = 'posts-post';
+		$_POST['wp_stream_trigger_action'] = 'edit';
+		$_POST['wp_stream_alert_type'] = 'highlight';
 
-			// The output should be a -1 for failure.
-			$this->assertEquals( '-1', $exception->getMessage() );
-		}
+		$this->expectException( 'WPAjaxDieStopException' );
+		$this->expectExceptionMessage( '-1' );
+		$this->_handleAjax( 'save_new_alert' );
 	}
 
 	/**
@@ -409,23 +402,16 @@ class Test_Alerts extends WP_StreamTestCase {
 		wp_set_current_user( $user_id );
 
 		$alerts = new Alerts( $this->plugin );
-		try {
-			$_POST['wp_stream_trigger_author'] = 'me';
-			$_POST['wp_stream_trigger_context'] = 'posts-post';
-			$_POST['wp_stream_trigger_action'] = 'edit';
-			$_POST['wp_stream_alert_type'] = 'highlight';
-			$_POST['wp_stream_alerts_nonce'] = 'invalid';
 
-			$this->expectException( 'WPAjaxDieStopException' );
-			$this->_handleAjax( 'save_new_alert' );
-		} catch ( \WPAjaxDieContinueException $e ) {
-			$exception = $e;
-			// Check that the exception was thrown.
-			$this->assertTrue( isset( $exception ) );
+		$_POST['wp_stream_trigger_author'] = 'me';
+		$_POST['wp_stream_trigger_context'] = 'posts-post';
+		$_POST['wp_stream_trigger_action'] = 'edit';
+		$_POST['wp_stream_alert_type'] = 'highlight';
+		$_POST['wp_stream_alerts_nonce'] = 'invalid';
 
-			// The output should be a -1 for failure.
-			$this->assertEquals( '-1', $exception->getMessage() );
-		}
+		$this->expectException( 'WPAjaxDieStopException' );
+		$this->expectExceptionMessage( '-1' );
+		$this->_handleAjax( 'save_new_alert' );
 	}
 
 	/**
@@ -437,23 +423,16 @@ class Test_Alerts extends WP_StreamTestCase {
 		wp_set_current_user( $user_id );
 
 		$alerts = new Alerts( $this->plugin );
-		try {
-			$_POST['wp_stream_trigger_author'] = 'me';
-			$_POST['wp_stream_trigger_context'] = 'posts-post';
-			$_POST['wp_stream_trigger_action'] = 'edit';
-			$_POST['wp_stream_alert_type'] = 'highlight';
-			$_POST['wp_stream_alerts_nonce'] = wp_create_nonce( 'some_nonce' );
 
-			$this->expectException( 'WPAjaxDieStopException' );
-			$this->_handleAjax( 'save_new_alert' );
-		} catch ( \WPAjaxDieContinueException $e ) {
-			$exception = $e;
-			// Check that the exception was thrown.
-			$this->assertTrue( isset( $exception ) );
+		$_POST['wp_stream_trigger_author'] = 'me';
+		$_POST['wp_stream_trigger_context'] = 'posts-post';
+		$_POST['wp_stream_trigger_action'] = 'edit';
+		$_POST['wp_stream_alert_type'] = 'highlight';
+		$_POST['wp_stream_alerts_nonce'] = wp_create_nonce( 'some_nonce' );
 
-			// The output should be a -1 for failure.
-			$this->assertEquals( '-1', $exception->getMessage() );
-		}
+		$this->expectException( 'WPAjaxDieStopException' );
+		$this->expectExceptionMessage( '-1' );
+		$this->_handleAjax( 'save_new_alert' );
 	}
 
 	/**
@@ -465,23 +444,16 @@ class Test_Alerts extends WP_StreamTestCase {
 		wp_set_current_user( $user_id );
 
 		$alerts = new Alerts( $this->plugin );
-		try {
-			$_POST['wp_stream_trigger_author'] = 'me';
-			$_POST['wp_stream_trigger_context'] = 'posts-post';
-			$_POST['wp_stream_trigger_action'] = 'edit';
-			$_POST['wp_stream_alert_type'] = 'highlight';
-			$_POST['wp_stream_alerts_nonce'] = wp_create_nonce( 'save_alert' );
 
-			$this->expectException( 'WPAjaxDieStopException' );
-			$this->_handleAjax( 'save_new_alert' );
-		} catch ( \WPAjaxDieContinueException $e ) {
-			$exception = $e;
-			// Check that the exception was thrown.
-			$this->assertTrue( isset( $exception ) );
+		$_POST['wp_stream_trigger_author'] = 'me';
+		$_POST['wp_stream_trigger_context'] = 'posts-post';
+		$_POST['wp_stream_trigger_action'] = 'edit';
+		$_POST['wp_stream_alert_type'] = 'highlight';
+		$_POST['wp_stream_alerts_nonce'] = wp_create_nonce( 'save_alert' );
 
-			// The output should be a -1 for failure.
-			$this->assertEquals( '-1', $exception->getMessage() );
-		}
+		$this->expectException( 'WPAjaxDieStopException' );
+		$this->expectExceptionMessage( 'You don&#039;t have sufficient privileges to do this action.' );
+		$this->_handleAjax( 'save_new_alert' );
 	}
 
 	function test_get_new_alert_triggers_notifications() {
@@ -513,23 +485,16 @@ class Test_Alerts extends WP_StreamTestCase {
 		wp_set_current_user( $user_id );
 
 		$alerts = new Alerts( $this->plugin );
-		try {
-			$_POST['wp_stream_trigger_author'] = 'me';
-			$_POST['wp_stream_trigger_context'] = 'posts-post';
-			$_POST['wp_stream_trigger_action'] = 'edit';
-			$_POST['wp_stream_alert_type'] = 'highlight';
-			$_POST['wp_stream_alerts_nonce'] = wp_create_nonce( 'save_alert' );
 
-			$this->expectException( 'WPAjaxDieStopException' );
-			$this->_handleAjax( 'get_new_alert_triggers_notifications' );
-		} catch ( \WPAjaxDieContinueException $e ) {
-			$exception = $e;
-			// Check that the exception was thrown.
-			$this->assertTrue( isset( $exception ) );
+		$_POST['wp_stream_trigger_author'] = 'me';
+		$_POST['wp_stream_trigger_context'] = 'posts-post';
+		$_POST['wp_stream_trigger_action'] = 'edit';
+		$_POST['wp_stream_alert_type'] = 'highlight';
+		$_POST['wp_stream_alerts_nonce'] = wp_create_nonce( 'save_alert' );
 
-			// The output should be a -1 for failure.
-			$this->assertEquals( '-1', $exception->getMessage() );
-		}
+		$this->expectException( 'WPAjaxDieStopException' );
+		$this->expectExceptionMessage( 'You don&#039;t have sufficient privileges to do this action.' );
+		$this->_handleAjax( 'get_new_alert_triggers_notifications' );
 	}
 
 	private function dummy_alert_data() {

--- a/tests/tests/test-class-db.php
+++ b/tests/tests/test-class-db.php
@@ -104,6 +104,11 @@ class Test_DB extends WP_StreamTestCase {
 	}
 
 	public function test_existing_records() {
+		$dummy_data         = $this->dummy_stream_data();
+		$dummy_data['meta'] = $this->dummy_meta_data();
+
+		$stream_id = $this->db->insert( $dummy_data );
+
 		$summaries = $this->db->existing_records( 'summary' );
 		$this->assertNotEmpty( $summaries );
 


### PR DESCRIPTION
Fixes #1426.

This PR includes the following changes:

* adds tests to trigger and assert the vulnerability described in [CVE-2022-43490](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-43490), props [@Lucisu](https://github.com/Lucisu) via [Patchstack](https://patchstack.com/)
* fixes [CVE-2022-43490](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-43490) by adding a nonce check to the `'wp_ajax_wp_stream_uninstall'` AJAX action.
* fixes a broken SQL query that failed to delete user meta records on multisite installations.

# Checklist

- [x] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [x] I have added phpunit tests.