### PR TITLE
Check for caps before loading alert settings

### DIFF
--- a/classes/class-alerts-list.php
+++ b/classes/class-alerts-list.php
@@ -112,7 +112,7 @@ class Alerts_List {
 	public function column_data( $column_name, $post_id ) {
 
 		$alert = $this->plugin->alerts->get_alert( $post_id );
-		if ( ! $alert ) {
+		if ( false === $alert ) {
 			return;
 		}
 


### PR DESCRIPTION
This PR includes the following changes:

* adds tests to trigger and assert the vulnerability described in [CVE-2022-43450](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-43450), props [@Lucisu](https://github.com/Lucisu) via [Patchstack](https://patchstack.com/)
* fixes [CVE-2022-43450](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-43450) by adding a capability check to the 'wp_ajax_load_alerts_settings ' AJAX action.

# Checklist

- [x] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [x] I have added phpunit tests.