### PR TITLE
Check for caps before loading alert settings

### DIFF
--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -18,7 +18,7 @@ class Plugin {
 	 *
 	 * @const string
 	 */
-	const VERSION = '3.9.2';
+	const VERSION = '3.9.3';
 
 	/**
 	 * WP-CLI command

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: xwp
 Tags: wp stream, stream, activity, logs, track
 Requires at least: 4.5
-Tested up to: 6.1
-Stable tag: 3.9.2
+Tested up to: 6.2
+Stable tag: 3.9.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -84,7 +84,7 @@ There are several ways you can get involved to help make Stream better:
 
 Thank you for wanting to make Stream better for everyone!
 
-Past Contributors: fjarrett, shadyvb, chacha, westonruter, johnregan3, jacobschweitzer, lukecarbis, kasparsd, bordoni, dero, faishal, rob, desaiuditd, DavidCramer, renovate-bot, marcin-lawrowski, JeffMatson, Powdered-Toast-Man, johnolek, johnbillion, greguly, pascal-klaeres, szepeviktor, rheinardkorf, frozzare, khromov, dkotter, bhubbard, stipsan, stephenharris, omniwired, kopepasah, joehoyle, eugenekireev, barryceelen, valendesigns, tlovett1, tareiking, stayallive, sayedtaqui, robbiet480, oscarssanchez, kidunot89, johnwatkins0, javorszky, jamesgol, desrosj, davelozier, davefx, cfoellmann, JustinSainton, JJJ, postphotos
+Past Contributors: fjarrett, shadyvb, chacha, westonruter, johnregan3, jacobschweitzer, lukecarbis, kasparsd, bordoni, dero, faishal, rob, desaiuditd, DavidCramer, renovate-bot, marcin-lawrowski, JeffMatson, Powdered-Toast-Man, johnolek, johnbillion, greguly, pascal-klaeres, szepeviktor, rheinardkorf, frozzare, khromov, dkotter, bhubbard, stipsan, stephenharris, omniwired, kopepasah, joehoyle, eugenekireev, barryceelen, valendesigns, tlovett1, tareiking, stayallive, sayedtaqui, robbiet480, oscarssanchez, kidunot89, johnwatkins0, javorszky, jamesgol, desrosj, davelozier, davefx, cfoellmann, JustinSainton, JJJ, postphotos, schlessera
 
 
 == Screenshots ==
@@ -102,6 +102,12 @@ Track changes to posts when using the block editor.
 
 
 == Changelog ==
+
+= 3.9.3 - April 25, 2023 =
+
+- Fix: [Security] CVE-2022-43490: Temporarily remove uninstall flow to avoid inadvertent uninstallation of the plugin, props [@Lucisu](https://github.com/Lucisu) via [Patchstack](https://patchstack.com/).
+- Fix: [Security] CVE-2022-43450: Check for capabilities in 'wp_ajax_load_alerts_settings' AJAX action before loading alert settings, props [@Lucisu](https://github.com/Lucisu) via [Patchstack](https://patchstack.com/).
+- Development: Mark as tested with the latest version 6.2 of WordPress.
 
 = 3.9.2 - January 10, 2023 =
 

--- a/stream.php
+++ b/stream.php
@@ -3,7 +3,7 @@
  * Plugin Name: Stream
  * Plugin URI: https://xwp.co/work/stream/
  * Description: Stream tracks logged-in user activity so you can monitor every change made on your WordPress site in beautifully organized detail. All activity is organized by context, action and IP address for easy filtering. Developers can extend Stream with custom connectors to log any kind of action.
- * Version: 3.9.2
+ * Version: 3.9.3
  * Author: XWP
  * Author URI: https://xwp.co
  * License: GPLv2+


### PR DESCRIPTION
## Release Changelog

- Fix: [Security] CVE-2022-43490: Temporarily remove uninstall flow to avoid inadvertent uninstallation of the plugin, props [@Lucisu](https://github.com/Lucisu) via [Patchstack](https://patchstack.com/).
- Fix: [Security] CVE-2022-43450: Check for capabilities in 'wp_ajax_load_alerts_settings' AJAX action before loading alert settings, props [@Lucisu](https://github.com/Lucisu) via [Patchstack](https://patchstack.com/).
- Development: Mark as tested with the latest version 6.2 of WordPress.


## Release Checklist

- [x] This pull request is to the `master` branch.
- [x] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [x] Update changelog in `readme.txt`.
- [x] Bump version in `stream.php`.
- [x] Bump `Stable tag` in `readme.txt`.
- [x] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).


Change `[ ]` to `[x]` to mark the items as done.
