### PR TITLE
Check if entry/lead ID is empty in "gform_post_note_added" action

### DIFF
--- a/connectors/class-connector-gravityforms.php
+++ b/connectors/class-connector-gravityforms.php
@@ -672,6 +672,11 @@ class Connector_GravityForms extends Connector {
 		unset( $note );
 		unset( $note_type );
 
+		// Skip if no entry/lead id (e.g. Save and Continue notifications)
+		if( empty( $lead_id ) ) {
+			return;
+		}
+
 		$lead = \GFFormsModel::get_lead( $lead_id );
 		$form = $this->get_form( $lead['form_id'] );
 

--- a/connectors/class-connector-gravityforms.php
+++ b/connectors/class-connector-gravityforms.php
@@ -673,7 +673,7 @@ class Connector_GravityForms extends Connector {
 		unset( $note_type );
 
 		// Skip if no entry/lead id (e.g. Save and Continue notifications)
-		if( empty( $lead_id ) ) {
+		if ( empty( $lead_id ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #1446.

Adds a simple "empty" check on the incoming $lead_id to prevent warnings/notices when "null" is passed under certain circumstances (detailed in issue).

**Note:** After reviewing the rest of the class I think there's a lot of safety/sanity checks & general updates that could/should be made to this Gravity Forms connector class and there's a lack of PHPUnit tests for this connector as well. Since this PR is relatively simple & straightforward I think it's fine to merge for the time being to fix the immediate notices/warnings problem, and I can submit a more detailed improvement issue/PR in the near future to cover a more proper general refactoring. Let me know if that sounds alright or if you'd prefer to wait on this issue/update until that more proper refactoring is ready

# Checklist

- [x] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.
