### PR TITLE
Improve client IP resolution for Stream logs

### DIFF
--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -220,6 +220,12 @@ class Admin {
 		$this->network     = new Network( $this->plugin );
 		$this->live_update = new Live_Update( $this->plugin );
 		$this->export      = new Export( $this->plugin );
+
+		// Check if the host has configured the `REMOTE_ADDR` correctly.
+		$client_ip = $this->plugin->get_client_ip_address();
+		if ( empty( $client_ip ) ) {
+			$this->notice( esc_html__( 'Stream can\'t determine a reliable client IP address! Please update the hosting environment to set the REMOTE_ADDR in $_SERVER variable or use the `wp_stream_client_ip_address` filter to specify the verified client IP address!', 'stream' ) );
+		}
 	}
 
 	/**

--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -547,9 +547,10 @@ class Admin {
 			return true;
 		}
 
-		$screen = get_current_screen();
-		if ( Alerts::POST_TYPE === $screen->post_type ) {
-			return true;
+		if ( is_admin() && function_exists( 'get_current_screen' ) ) {
+			$screen = get_current_screen();
+
+			return ( Alerts::POST_TYPE === $screen->post_type );
 		}
 
 		return false;

--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -224,7 +224,7 @@ class Admin {
 		// Check if the host has configured the `REMOTE_ADDR` correctly.
 		$client_ip = $this->plugin->get_client_ip_address();
 		if ( ! empty( $client_ip ) && $this->is_stream_screen() ) {
-			$this->notice( __( 'Stream plugin can\'t determine a reliable client IP address! Please update the hosting environment to set the <code>$_SERVER[\'REMOTE_ADDR\']</code> variable or use the <code>wp_stream_client_ip_address</code> filter to specify the verified client IP address!', 'stream' ) );
+			$this->notice( __( 'Stream plugin can\'t determine a reliable client IP address! Please update the hosting environment to set the $_SERVER[\'REMOTE_ADDR\'] variable or use the wp_stream_client_ip_address filter to specify the verified client IP address!', 'stream' ) );
 		}
 	}
 

--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -223,7 +223,7 @@ class Admin {
 
 		// Check if the host has configured the `REMOTE_ADDR` correctly.
 		$client_ip = $this->plugin->get_client_ip_address();
-		if ( ! empty( $client_ip ) && $this->is_stream_screen() ) {
+		if ( empty( $client_ip ) && $this->is_stream_screen() ) {
 			$this->notice( __( 'Stream plugin can\'t determine a reliable client IP address! Please update the hosting environment to set the $_SERVER[\'REMOTE_ADDR\'] variable or use the wp_stream_client_ip_address filter to specify the verified client IP address!', 'stream' ) );
 		}
 	}

--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -223,8 +223,8 @@ class Admin {
 
 		// Check if the host has configured the `REMOTE_ADDR` correctly.
 		$client_ip = $this->plugin->get_client_ip_address();
-		if ( empty( $client_ip ) ) {
-			$this->notice( esc_html__( 'Stream can\'t determine a reliable client IP address! Please update the hosting environment to set the REMOTE_ADDR in $_SERVER variable or use the `wp_stream_client_ip_address` filter to specify the verified client IP address!', 'stream' ) );
+		if ( ! empty( $client_ip ) && $this->is_stream_screen() ) {
+			$this->notice( __( 'Stream plugin can\'t determine a reliable client IP address! Please update the hosting environment to set the <code>$_SERVER[\'REMOTE_ADDR\']</code> variable or use the <code>wp_stream_client_ip_address</code> filter to specify the verified client IP address!', 'stream' ) );
 		}
 	}
 

--- a/classes/class-log.php
+++ b/classes/class-log.php
@@ -75,11 +75,6 @@ class Log {
 
 		$ip_address = $this->plugin->get_client_ip_address();
 
-		// Fallback to unsafe IP extracted from the request HTTP headers.
-		if ( empty( $ip_address ) ) {
-			$ip_address = $this->plugin->get_unsafe_client_ip_address();
-		}
-
 		$user = new \WP_User( $user_id );
 
 		if ( $this->is_record_excluded( $connector, $context, $action, $user, $ip_address ) ) {

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -93,7 +93,7 @@ class Plugin {
 	/**
 	 * IP address for the current request to be associated with the log entry.
 	 *
-	 * @var null|false|string
+	 * @var null|false|string Valid IP address, null if not set, false if invalid.
 	 */
 	protected $client_ip_address;
 
@@ -329,7 +329,7 @@ class Plugin {
 	/**
 	 * Get the IP address for the current request.
 	 *
-	 * @return false|null|string
+	 * @return false|null|string Valid IP address, null if not set, false if invalid.
 	 */
 	public function get_client_ip_address() {
 		return apply_filters( 'wp_stream_client_ip_address', $this->client_ip_address );

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -342,7 +342,7 @@ class Plugin {
 	 *
 	 * @return string|null
 	 */
-	protected function get_unsafe_client_ip_address() {
+	public function get_unsafe_client_ip_address() {
 		// List of $_SERVER keys that could contain the client IP address.
 		$address_headers = array(
 			'HTTP_X_FORWARDED_FOR',

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -334,39 +334,4 @@ class Plugin {
 	public function get_client_ip_address() {
 		return apply_filters( 'wp_stream_client_ip_address', $this->client_ip_address );
 	}
-
-	/**
-	 * Get the client IP address from the HTTP request headers.
-	 *
-	 * There is no guarantee that this is the real IP address of the client.
-	 *
-	 * @return string|null
-	 */
-	public function get_unsafe_client_ip_address() {
-		// List of $_SERVER keys that could contain the client IP address.
-		$address_headers = array(
-			'HTTP_X_FORWARDED_FOR',
-			'HTTP_FORWARDED_FOR',
-		);
-
-		foreach ( $address_headers as $header ) {
-			if ( ! empty( $_SERVER[ $header ] ) ) {
-				$header_client_ip = $_SERVER[ $header ];
-
-				// Account for multiple IPs in case of multiple proxies.
-				if ( false !== strpos( $header_client_ip, ',' ) ) {
-					$header_client_ips = explode( ',', $header_client_ip );
-					$header_client_ip  = $header_client_ips[0];
-				}
-
-				$client_ip = wp_stream_filter_var( trim( $header_client_ip ), FILTER_VALIDATE_IP );
-
-				if ( ! empty( $client_ip ) ) {
-					return $client_ip;
-				}
-			}
-		}
-
-		return null;
-	}
 }

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -359,7 +359,7 @@ class Plugin {
 					$header_client_ip  = $header_client_ips[0];
 				}
 
-				$client_ip = filter_var( trim( $header_client_ip ), FILTER_VALIDATE_IP );
+				$client_ip = wp_stream_filter_var( trim( $header_client_ip ), FILTER_VALIDATE_IP );
 
 				if ( ! empty( $client_ip ) ) {
 					return $client_ip;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -16,7 +16,7 @@
  * @param int    $filter         The ID of the filter to apply.
  * @param mixed  $options        Associative array of options or bitwise disjunction of flags. If filter accepts options, flags can be provided in "flags" field of array.
  *
- * @return Value of the requested variable on success, FALSE if the filter fails, or NULL if the $variable_name is not set.
+ * @return mixed|false|null Value of the requested variable on success, FALSE if the filter fails, or NULL if the $variable_name is not set.
  */
 function wp_stream_filter_input( $type, $variable_name, $filter = null, $options = array() ) {
 	return call_user_func_array( array( '\WP_Stream\Filter_Input', 'super' ), func_get_args() );

--- a/readme.txt
+++ b/readme.txt
@@ -80,15 +80,19 @@ If `$_SERVER['REMOTE_ADDR']` is not configured, the plugin will attempt to extra
 Update your server configuration to set the `$_SERVER['REMOTE_ADDR']` variable to the verified client IP address or use the `wp_stream_client_ip_address` filter to do that:
 
 `add_filter(
-    'wp_stream_client_ip_address',
-    function( $client_ip ) {
-        // Trust the X-Forwarded-For header.
-        if ( ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
-            return $_SERVER['HTTP_X_FORWARDED_FOR'];
-        }
+	'wp_stream_client_ip_address',
+	function( $client_ip ) {
+		// Trust the first IP in the X-Forwarded-For header.
+		if ( ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+			$forwarded_ips = explode( ',' $_SERVER['HTTP_X_FORWARDED_FOR'] );
 
-        return $client_ip;
-    }
+			if ( filter_var( $forwarded_ips[0], FILTER_VALIDATE_IP ) ) {
+				return $forwarded_ips[0];
+			}
+		}
+
+		return $client_ip;
+	}
 );`
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -75,7 +75,19 @@ The plugin expects the `$_SERVER['REMOTE_ADDR']` variable to contain the verifie
 
 If `$_SERVER['REMOTE_ADDR']` is not configured, the plugin will attempt to extract the client IP from `$_SERVER['HTTP_X_FORWARDED_FOR']` and `$_SERVER['HTTP_FORWARDED_FOR']` *which are considered unsafe as they can contain arbitraty user input passed with the HTTP request*. This fallback behaviour will be disabled by default in the future versions of this plugin!
 
-Update your server configuration to set the `$_SERVER['REMOTE_ADDR']` variable to the verified client IP address or use the `wp_stream_client_ip_address` filter to do that.
+Update your server configuration to set the `$_SERVER['REMOTE_ADDR']` variable to the verified client IP address or use the `wp_stream_client_ip_address` filter to do that:
+
+`add_filter(
+    'wp_stream_client_ip_address',
+    function( $client_ip ) {
+        // Trust the X-Forwarded-For header.
+        if ( ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+            return $_SERVER['HTTP_X_FORWARDED_FOR'];
+        }
+
+        return $client_ip;
+    }
+);`
 
 
 ## Known Issues

--- a/readme.txt
+++ b/readme.txt
@@ -72,12 +72,7 @@ Most of the plugin configuration is available under the "Stream" → "Settings" 
 
 ### Request IP Address
 
-The plugin expects the `$_SERVER['REMOTE_ADDR']` variable to contain the verified IP address of the current request. On hosting environments with PHP processing behind reverse proxies or CDNs the actual client IP is passed to PHP through request HTTP headers such as `X-Forwarded-For` and `True-Client-IP` which can't be trusted without an additional layer of validation.
-
-If `$_SERVER['REMOTE_ADDR']` is not configured, the plugin will attempt to extract the client IP from `$_SERVER['HTTP_X_FORWARDED_FOR']` or `$_SERVER['HTTP_FORWARDED_FOR']` *which are considered unsafe as they can contain arbitrary user input passed with the HTTP request*. This fallback behaviour will be disabled by default in future versions of this plugin!
-
-
-Update your server configuration to set the `$_SERVER['REMOTE_ADDR']` variable to the verified client IP address or use the `wp_stream_client_ip_address` filter to do that:
+The plugin expects the `$_SERVER['REMOTE_ADDR']` variable to contain the verified IP address of the current request. On hosting environments with PHP processing behind reverse proxies or CDNs the actual client IP is passed to PHP through request HTTP headers such as `X-Forwarded-For` and `True-Client-IP` which can't be trusted without an additional layer of validation. Update your server configuration to set the `$_SERVER['REMOTE_ADDR']` variable to the verified client IP address or use the `wp_stream_client_ip_address` filter to do that:
 
 `add_filter(
 	'wp_stream_client_ip_address',

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,10 @@ Track changes to posts when using the block editor.
 
 == Changelog ==
 
+= NEXT =
+
+- Breaking: Use only `$_SERVER['REMOTE_ADDR']` as the reliable client IP address for event logs. This might cause incorrectly reported event log IP addresses on environments where PHP is behind a proxy server or CDN. Use the `wp_stream_client_ip_address` filter to set the correct client IP address (see `readme.txt` for instructions) or configure the hosting environment to report the correct IP address in `$_SERVER['REMOTE_ADDR']`.
+
 = 3.10.0 - October 9, 2023 =
 
 - Fix: Improve PHP 8.1 compatibility by updating `filter_*()` calls referencing `FILTER_SANITIZE_STRING` (issue [#1422](https://github.com/xwp/stream/pull/1422)).

--- a/readme.txt
+++ b/readme.txt
@@ -65,19 +65,22 @@ With Stream’s powerful logging, you’ll have the valuable information you nee
  * WP-CLI command for querying records
 
 
-## Configuration
+== Configuration ==
 
 Most of the plugin configuration is available under the "Stream" → "Settings" page in the WordPress dashboard.
 
 
-### Request IP Address
+= Request IP Address =
 
-The plugin expects the `$_SERVER['REMOTE_ADDR']` variable to contain the verified IP address of the current request. On hosting environments with PHP processing behind reverse proxies or CDNs the actual client IP is passed to PHP through request HTTP headers such as `X-Forwarded-For` and `True-Client-IP` which can't be trusted without an additional layer of validation. Update your server configuration to set the `$_SERVER['REMOTE_ADDR']` variable to the verified client IP address or use the `wp_stream_client_ip_address` filter to do that:
+The plugin expects the `$_SERVER['REMOTE_ADDR']` variable to contain the verified IP address of the current request. On hosting environments with PHP processing behind reverse proxies or CDNs the actual client IP is passed to PHP through request HTTP headers such as `X-Forwarded-For` and `True-Client-IP` which can't be trusted without an additional layer of validation. Update your server configuration to set the `$_SERVER['REMOTE_ADDR']` variable to the verified client IP address.
+
+As a workaround, you can use the `wp_stream_client_ip_address` filter to adapt the IP address:
 
 `add_filter(
 	'wp_stream_client_ip_address',
 	function( $client_ip ) {
 		// Trust the first IP in the X-Forwarded-For header.
+		// ⚠️ Note: This is inherently insecure and can easily be spoofed!
 		if ( ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
 			$forwarded_ips = explode( ',' $_SERVER['HTTP_X_FORWARDED_FOR'] );
 
@@ -90,13 +93,15 @@ The plugin expects the `$_SERVER['REMOTE_ADDR']` variable to contain the verifie
 	}
 );`
 
+⚠️ **WARNING:** The above is an insecure workaround that you should only use when you fully understand what this implies. Relying on any variable with the `HTTP_*` prefix is prone to spoofing and cannot be trusted!
 
-## Known Issues
+
+== Known Issues ==
 
  * We have temporarily disabled the data removal feature through plugin uninstallation, starting with version 3.9.3. We identified a few edge cases that did not behave as expected and we decided that a temporary removal is preferable at this time for such an impactful and irreversible operation. Our team is actively working on refining this feature to ensure it performs optimally and securely. We plan to reintroduce it in a future update with enhanced safeguards.
 
 
-## Contribute
+== Contribute ==
 
 There are several ways you can get involved to help make Stream better:
 

--- a/readme.txt
+++ b/readme.txt
@@ -67,7 +67,8 @@ With Stream’s powerful logging, you’ll have the valuable information you nee
 
 ## Configuration
 
-Most of the plugin configuration is available under the "Stream" → "Settings" in the WordPress dashboard.
+Most of the plugin configuration is available under the "Stream" → "Settings" page in the WordPress dashboard.
+
 
 ### Request IP Address
 

--- a/readme.txt
+++ b/readme.txt
@@ -74,7 +74,8 @@ Most of the plugin configuration is available under the "Stream" → "Settings" 
 
 The plugin expects the `$_SERVER['REMOTE_ADDR']` variable to contain the verified IP address of the current request. On hosting environments with PHP processing behind reverse proxies or CDNs the actual client IP is passed to PHP through request HTTP headers such as `X-Forwarded-For` and `True-Client-IP` which can't be trusted without an additional layer of validation.
 
-If `$_SERVER['REMOTE_ADDR']` is not configured, the plugin will attempt to extract the client IP from `$_SERVER['HTTP_X_FORWARDED_FOR']` and `$_SERVER['HTTP_FORWARDED_FOR']` *which are considered unsafe as they can contain arbitraty user input passed with the HTTP request*. This fallback behaviour will be disabled by default in the future versions of this plugin!
+If `$_SERVER['REMOTE_ADDR']` is not configured, the plugin will attempt to extract the client IP from `$_SERVER['HTTP_X_FORWARDED_FOR']` or `$_SERVER['HTTP_FORWARDED_FOR']` *which are considered unsafe as they can contain arbitrary user input passed with the HTTP request*. This fallback behaviour will be disabled by default in future versions of this plugin!
+
 
 Update your server configuration to set the `$_SERVER['REMOTE_ADDR']` variable to the verified client IP address or use the `wp_stream_client_ip_address` filter to do that:
 

--- a/readme.txt
+++ b/readme.txt
@@ -65,12 +65,25 @@ With Stream’s powerful logging, you’ll have the valuable information you nee
  * WP-CLI command for querying records
 
 
-= Known Issues
+## Configuration
+
+Most of the plugin configuration is available under the "Stream" → "Settings" in the WordPress dashboard.
+
+### Request IP Address
+
+The plugin expects the `$_SERVER['REMOTE_ADDR']` variable to contain the verified IP address of the current request. On hosting environments with PHP processing behind reverse proxies or CDNs the actual client IP is passed to PHP through request HTTP headers such as `X-Forwarded-For` and `True-Client-IP` which can't be trusted without an additional layer of validation.
+
+If `$_SERVER['REMOTE_ADDR']` is not configured, the plugin will attempt to extract the client IP from `$_SERVER['HTTP_X_FORWARDED_FOR']` and `$_SERVER['HTTP_FORWARDED_FOR']` *which are considered unsafe as they can contain arbitraty user input passed with the HTTP request*. This fallback behaviour will be disabled by default in the future versions of this plugin!
+
+Update your server configuration to set the `$_SERVER['REMOTE_ADDR']` variable to the verified client IP address or use the `wp_stream_client_ip_address` filter to do that.
+
+
+## Known Issues
 
  * We have temporarily disabled the data removal feature through plugin uninstallation, starting with version 3.9.3. We identified a few edge cases that did not behave as expected and we decided that a temporary removal is preferable at this time for such an impactful and irreversible operation. Our team is actively working on refining this feature to ensure it performs optimally and securely. We plan to reintroduce it in a future update with enhanced safeguards.
 
 
-= Contribute =
+## Contribute
 
 There are several ways you can get involved to help make Stream better:
 

--- a/tests/tests/test-class-plugin.php
+++ b/tests/tests/test-class-plugin.php
@@ -88,22 +88,4 @@ class Test_Plugin extends WP_StreamTestCase {
 	public function test_get_client_ip_address() {
 		$this->assertEquals( $_SERVER['REMOTE_ADDR'], $this->plugin->get_client_ip_address() );
 	}
-
-	public function test_get_unsafe_client_ip_address() {
-		$_SERVER['HTTP_X_FORWARDED_FOR'] = ' 123.123.123.123 , 321.123.123.123, 456.123.123.123 ';
-
-		$this->assertEquals(
-			'123.123.123.123',
-			$this->plugin->get_unsafe_client_ip_address(),
-			'Use the first IP from the list'
-		);
-
-		$_SERVER['HTTP_X_FORWARDED_FOR'] = '827.invalid-ip';
-
-		$this->assertEquals(
-			false,
-			$this->plugin->get_unsafe_client_ip_address(),
-			'Invalid IP format should fail the validation'
-		);
-	}
 }

--- a/tests/tests/test-class-plugin.php
+++ b/tests/tests/test-class-plugin.php
@@ -90,7 +90,7 @@ class Test_Plugin extends WP_StreamTestCase {
 	}
 
 	public function test_get_unsafe_client_ip_address() {
-		$_SERVER['HTTP_X_FORWARDED_FOR'] = '123.123.123.123,321.123.123.123';
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = ' 123.123.123.123 , 321.123.123.123, 456.123.123.123 ';
 
 		$this->assertEquals(
 			'123.123.123.123',

--- a/tests/tests/test-class-plugin.php
+++ b/tests/tests/test-class-plugin.php
@@ -84,4 +84,18 @@ class Test_Plugin extends WP_StreamTestCase {
 		$version = $this->plugin->get_version();
 		$this->assertNotEmpty( $version );
 	}
+
+	public function test_get_client_ip_address() {
+		$this->assertEquals( $_SERVER['REMOTE_ADDR'], $this->plugin->get_client_ip_address() );
+	}
+
+	public function test_get_unsafe_client_ip_address() {
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '123.123.123.123,321.123.123.123';
+
+		$this->assertEquals(
+			'123.123.123.123',
+			$this->plugin->get_unsafe_client_ip_address(),
+			'Use the first IP from the list'
+		);
+	}
 }

--- a/tests/tests/test-class-plugin.php
+++ b/tests/tests/test-class-plugin.php
@@ -97,5 +97,13 @@ class Test_Plugin extends WP_StreamTestCase {
 			$this->plugin->get_unsafe_client_ip_address(),
 			'Use the first IP from the list'
 		);
+
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '827.invalid-ip';
+
+		$this->assertEquals(
+			false,
+			$this->plugin->get_unsafe_client_ip_address(),
+			'Invalid IP format should fail the validation'
+		);
 	}
 }


### PR DESCRIPTION
Fixes #1456.

- Rely on `$_SERVER['REMOTE_ADDR']` as the canonical source for the request origin IP.
- Show a notice in admin if `$_SERVER['REMOTE_ADDR']` is not specified.
- ~Fallback to `$_SERVER['HTTP_X_FORWARDED_FOR']` only if `$_SERVER['REMOTE_ADDR']` not present.~

# Checklist

- [x] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [x] I have added phpunit tests.


## Release Changelog

- Fix: Prefer `$_SERVER['REMOTE_ADDR']` for the source of user IP and fallback to `$_SERVER['HTTP_X_FORWARDED_FOR']` only in case `REMOTE_ADDR` is not available. Introduce a `wp_stream_client_ip_address` filter to adjust the trusted client IP.
