### PR TITLE
Install Composer v2 on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,8 +74,6 @@ before_install:
   - docker-compose pull
   - nvm install
   - nvm use
-  # Lock to Composer version 1 for now.
-  - composer self-update --1
 
 install:
   - npm install


### PR DESCRIPTION
As Composer v2 was used to update the lock file
https://github.com/xwp/stream/blob/3273731a0182353ee78cec3a0f9f77956407a932/composer.lock#L7445
