### PR TITLE
Adjust exclude rules filtering to avoid passing null to strlen() to fix PHP 8 deprecation notice

### DIFF
--- a/classes/class-log.php
+++ b/classes/class-log.php
@@ -194,7 +194,12 @@ class Log {
 				'role'       => ( ! empty( $exclude_rule['author_or_role'] ) && ! is_numeric( $exclude_rule['author_or_role'] ) ) ? $exclude_rule['author_or_role'] : null,
 			);
 
-			$exclude_rules = array_filter( $exclude, 'strlen' );
+			$exclude_rules = array_filter(
+				$exclude,
+				static function ( $value ) {
+					return null === $value || strlen( (string) $value ) > 0;
+				}
+			);
 
 			if ( $this->record_matches_rules( $record, $exclude_rules ) ) {
 				$exclude_record = true;


### PR DESCRIPTION
Fixes #1349.

This fixes a deprecation notice in PHP 8:

>  PHP Deprecated:  strlen(): Passing null to parameter #1 ($string) of type string is deprecated in classes/class-log.php on line 217

The value of my exclude rule was:

```
Array
(
    [connector] =>
    [context] =>
    [action] =>
    [ip_address] => 127.0.0.1
    [author] =>
    [role] =>
)
```

The fix is to check for null first.

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [ ] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: Avoid deprecation notices in PHP 8.


## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).


Change `[ ]` to `[x]` to mark the items as done.
