### PR TITLE
Refactored array_filter() to explicitly check !is_null() AND strlen() in class-log.php

### DIFF
--- a/classes/class-log.php
+++ b/classes/class-log.php
@@ -194,8 +194,8 @@ class Log {
 				'role'       => ( ! empty( $exclude_rule['author_or_role'] ) && ! is_numeric( $exclude_rule['author_or_role'] ) ) ? $exclude_rule['author_or_role'] : null,
 			);
 
-			$exclude_rules = array_filter($exclude, function ($val) {
-				return !is_null($val) && strlen($val);
+			$exclude_rules = array_filter( $exclude, function ( $val ) {
+				return !is_null( $val ) && strlen( $val );
 			});
 
 			if ( $this->record_matches_rules( $record, $exclude_rules ) ) {

--- a/classes/class-log.php
+++ b/classes/class-log.php
@@ -194,7 +194,9 @@ class Log {
 				'role'       => ( ! empty( $exclude_rule['author_or_role'] ) && ! is_numeric( $exclude_rule['author_or_role'] ) ) ? $exclude_rule['author_or_role'] : null,
 			);
 
-			$exclude_rules = array_filter( $exclude, 'strlen' );
+			$exclude_rules = array_filter($exclude, function ($val) {
+				return !is_null($val) && strlen($val);
+			});
 
 			if ( $this->record_matches_rules( $record, $exclude_rules ) ) {
 				$exclude_record = true;


### PR DESCRIPTION
… because passing 'strlen' as a callable caused warnings on null values.

Fixes  #1349.

The previously-merged commits did not, in fact, fix this issue. Null values were being passed through array_filter() with 'strlen' as the callable, but `strlen()` no longer accepts null values. Should be fixed now, with an explicit null check added.

OLD:
```
$exclude_rules = array_filter($exclude, 'strlen' );
```

NEW:
```
$exclude_rules = array_filter( $exclude, function ( $val ) {
	return !is_null( $val ) && strlen( $val );
});
```

# Checklist

- [n/a] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [X] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: Describe a bug fix included in this release.
- New: Describe a new feature in this release.


## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).


Change `[ ]` to `[x]` to mark the items as done.
