### PR TITLE
CLI: Fix PHP Type error

### DIFF
--- a/classes/class-cli.php
+++ b/classes/class-cli.php
@@ -134,7 +134,7 @@ class CLI extends \WP_CLI_Command {
 
 			// Catch any fields missing in records.
 			foreach ( $fields as $field ) {
-				if ( ! array_key_exists( $field, $record ) ) {
+				if ( ! property_exists( $record, $field ) ) {
 					$record->$field = null;
 				}
 			}


### PR DESCRIPTION
A record is an Object, not an Array, so we should use `property_exists()` instead `array_key_exists`.

Fixes #1474.

## Release Changelog

- Fix: PHP Uncaught TypeError in CLI command #1474



