### PR TITLE
Prevent sprintf errors by escaping % in post_title

### DIFF
--- a/connectors/class-connector-wordpress-seo.php
+++ b/connectors/class-connector-wordpress-seo.php
@@ -419,9 +419,9 @@ class Connector_WordPress_SEO extends Connector {
 			sprintf(
 				/* translators: %1$s: a meta field title, %2$s: a post title, %3$s: a post type (e.g. "Description", "Hello World", "Post") */
 				__( 'Updated "%1$s" of "%2$s" %3$s', 'stream' ),
-				$field['title'],
+				str_replace( '%', '%%', $field['title'] ),
 				str_replace( '%', '%%', $post->post_title ),
-				$post_type_label
+				str_replace( '%', '%%', $post_type_label )
 			),
 			array(
 				'meta_key'   => $meta_key,

--- a/connectors/class-connector-wordpress-seo.php
+++ b/connectors/class-connector-wordpress-seo.php
@@ -420,7 +420,7 @@ class Connector_WordPress_SEO extends Connector {
 				/* translators: %1$s: a meta field title, %2$s: a post title, %3$s: a post type (e.g. "Description", "Hello World", "Post") */
 				__( 'Updated "%1$s" of "%2$s" %3$s', 'stream' ),
 				$field['title'],
-				$post->post_title,
+				str_replace( '%', '%%', $post->post_title ),
 				$post_type_label
 			),
 			array(


### PR DESCRIPTION
Fixes #1443.

Straightforward escaping of `%` in `$post->post_title` with `%%` prevents the error.

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: Describe a bug fix included in this release.


## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).


Change `[ ]` to `[x]` to mark the items as done.
