### PR TITLE
Prevent sprintf errors by escaping % in form title

### DIFF
--- a/connectors/class-connector-gravityforms.php
+++ b/connectors/class-connector-gravityforms.php
@@ -258,7 +258,7 @@ class Connector_GravityForms extends Connector {
 			sprintf(
 				/* translators: %1$s: a confirmation name, %2$s: a status, %3$s: a form title (e.g. "Email", "created", "Contact Form") */
 				__( '"%1$s" confirmation %2$s for "%3$s"', 'stream' ),
-				$confirmation['name'],
+				str_replace( '%', '%%', $confirmation['name'] ),
 				$is_new ? esc_html__( 'created', 'stream' ) : esc_html__( 'updated', 'stream' ),
 				str_replace( '%', '%%', $form['title'] )
 			),
@@ -291,7 +291,7 @@ class Connector_GravityForms extends Connector {
 			sprintf(
 				/* translators: %1$s: a notification name, %2$s: a status, %3$s: a form title (e.g. "Email", "created", "Contact Form") */
 				__( '"%1$s" notification %2$s for "%3$s"', 'stream' ),
-				$notification['name'],
+				str_replace( '%', '%%', $notification['name'] ),
 				$is_new ? esc_html__( 'created', 'stream' ) : esc_html__( 'updated', 'stream' ),
 				str_replace( '%', '%%', $form['title'] )
 			),
@@ -318,7 +318,7 @@ class Connector_GravityForms extends Connector {
 			sprintf(
 				/* translators: %1$s: a notification name, %2$s: a form title (e.g. "Email", "Contact Form") */
 				__( '"%1$s" notification deleted from "%2$s"', 'stream' ),
-				$notification['name'],
+				str_replace( '%', '%%', $notification['name'] ),
 				str_replace( '%', '%%', $form['title'] )
 			),
 			array(
@@ -342,7 +342,7 @@ class Connector_GravityForms extends Connector {
 			sprintf(
 				/* translators: %1$s: a confirmation name, %2$s: a form title (e.g. "Email", "Contact Form") */
 				__( '"%1$s" confirmation deleted from "%2$s"', 'stream' ),
-				$confirmation['name'],
+				str_replace( '%', '%%', $confirmation['name'] ),
 				str_replace( '%', '%%', $form['title'] )
 			),
 			array(
@@ -367,7 +367,7 @@ class Connector_GravityForms extends Connector {
 			sprintf(
 				/* translators: %1$s: a confirmation name, %2$s: a status, %3$s: a form title (e.g. "Email", "activated", "Contact Form") */
 				__( '"%1$s" confirmation %2$s from "%3$s"', 'stream' ),
-				$confirmation['name'],
+				str_replace( '%', '%%', $confirmation['name'] ),
 				$is_active ? esc_html__( 'activated', 'stream' ) : esc_html__( 'deactivated', 'stream' ),
 				str_replace( '%', '%%', $form['title'] )
 			),
@@ -394,7 +394,7 @@ class Connector_GravityForms extends Connector {
 			sprintf(
 				/* translators: %1$s: a notification name, %2$s: a status, %3$s: a form title (e.g. "Email", "activated", "Contact Form") */
 				__( '"%1$s" notification %2$s from "%3$s"', 'stream' ),
-				$notification['name'],
+				str_replace( '%', '%%', $notification['name'] ),
 				$is_active ? esc_html__( 'activated', 'stream' ) : esc_html__( 'deactivated', 'stream' ),
 				str_replace( '%', '%%', $form['title'] )
 			),

--- a/connectors/class-connector-gravityforms.php
+++ b/connectors/class-connector-gravityforms.php
@@ -221,7 +221,7 @@ class Connector_GravityForms extends Connector {
 	 * @param bool  $is_new  Is this a new form?.
 	 */
 	public function callback_gform_after_save_form( $form, $is_new ) {
-		$title = $form['title'];
+		$title = str_replace( '%', '%%', $form['title'] );
 		$id    = $form['id'];
 
 		$this->log(
@@ -260,7 +260,7 @@ class Connector_GravityForms extends Connector {
 				__( '"%1$s" confirmation %2$s for "%3$s"', 'stream' ),
 				$confirmation['name'],
 				$is_new ? esc_html__( 'created', 'stream' ) : esc_html__( 'updated', 'stream' ),
-				$form['title']
+				str_replace( '%', '%%', $form['title'] )
 			),
 			array(
 				'is_new'  => $is_new,
@@ -293,7 +293,7 @@ class Connector_GravityForms extends Connector {
 				__( '"%1$s" notification %2$s for "%3$s"', 'stream' ),
 				$notification['name'],
 				$is_new ? esc_html__( 'created', 'stream' ) : esc_html__( 'updated', 'stream' ),
-				$form['title']
+				str_replace( '%', '%%', $form['title'] )
 			),
 			array(
 				'is_update' => $is_new,
@@ -319,7 +319,7 @@ class Connector_GravityForms extends Connector {
 				/* translators: %1$s: a notification name, %2$s: a form title (e.g. "Email", "Contact Form") */
 				__( '"%1$s" notification deleted from "%2$s"', 'stream' ),
 				$notification['name'],
-				$form['title']
+				str_replace( '%', '%%', $form['title'] )
 			),
 			array(
 				'form_id'      => $form['id'],
@@ -343,7 +343,7 @@ class Connector_GravityForms extends Connector {
 				/* translators: %1$s: a confirmation name, %2$s: a form title (e.g. "Email", "Contact Form") */
 				__( '"%1$s" confirmation deleted from "%2$s"', 'stream' ),
 				$confirmation['name'],
-				$form['title']
+				str_replace( '%', '%%', $form['title'] )
 			),
 			array(
 				'form_id'      => $form['id'],
@@ -369,7 +369,7 @@ class Connector_GravityForms extends Connector {
 				__( '"%1$s" confirmation %2$s from "%3$s"', 'stream' ),
 				$confirmation['name'],
 				$is_active ? esc_html__( 'activated', 'stream' ) : esc_html__( 'deactivated', 'stream' ),
-				$form['title']
+				str_replace( '%', '%%', $form['title'] )
 			),
 			array(
 				'form_id'      => $form['id'],
@@ -396,7 +396,7 @@ class Connector_GravityForms extends Connector {
 				__( '"%1$s" notification %2$s from "%3$s"', 'stream' ),
 				$notification['name'],
 				$is_active ? esc_html__( 'activated', 'stream' ) : esc_html__( 'deactivated', 'stream' ),
-				$form['title']
+				str_replace( '%', '%%', $form['title'] )
 			),
 			array(
 				'form_id'      => $form['id'],
@@ -756,7 +756,7 @@ class Connector_GravityForms extends Connector {
 				__( 'Lead #%1$d %2$s on "%3$s" form', 'stream' ),
 				$lead_id,
 				$actions[ $status ],
-				$form['title']
+				str_replace( '%', '%%', $form['title'] )
 			),
 			array(
 				'lead_id'    => $lead_id,
@@ -791,7 +791,7 @@ class Connector_GravityForms extends Connector {
 				$lead_id,
 				$status,
 				$form['id'],
-				$form['title']
+				str_replace( '%', '%%', $form['title'] )
 			),
 			array(
 				'lead_id'     => $lead_id,
@@ -826,7 +826,7 @@ class Connector_GravityForms extends Connector {
 				$lead_id,
 				$status,
 				$form['id'],
-				$form['title']
+				str_replace( '%', '%%', $form['title'] )
 			),
 			array(
 				'lead_id'     => $lead_id,
@@ -945,7 +945,7 @@ class Connector_GravityForms extends Connector {
 				/* translators: %1$d: an ID, %2$s: a form title, %3$s: a status (e.g. "42", "Contact Form", "Activated") */
 				__( 'Form #%1$d ("%2$s") %3$s', 'stream' ),
 				$form_id,
-				$form['title'],
+				str_replace( '%', '%%', $form['title'] ),
 				strtolower( $actions[ $action ] )
 			),
 			array(


### PR DESCRIPTION
Fixes #1445.

Straightforward escaping of `%` in `$post->post_title` with `%%` prevents the error.

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: Describe a bug fix included in this release.
- New: Describe a new feature in this release.


## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).


Change `[ ]` to `[x]` to mark the items as done.
