### PR TITLE
Fix vscode launch.json and update Docker troubleshooting 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,9 +10,9 @@
         "vendor/"
       ],
       "pathMappings": {
-        "/var/www/html/wp-content/plugins/stream-src": "${workspaceRoot}",
-        "/var/www/html/wp-content/plugins/stream": "${workspaceRoot}/build",
-        "/var/www/html": "${workspaceRoot}/local/public"
+        "/var/www/html/wp-content/plugins/stream-src": "${workspaceFolder}",
+        "/var/www/html/wp-content/plugins/stream": "${workspaceFolder}/build",
+        "/var/www/html": "${workspaceFolder}/local/public"
       }
     }
   ]

--- a/contributing.md
+++ b/contributing.md
@@ -54,6 +54,9 @@ We use npm as the canonical task runner for the project. The following commands 
 - `npm run cli -- wp info` where `wp info` is the CLI command to run inside the WordPress container. For example, use `npm run cli -- ls -lah` to list all files in the root of the WordPress installation.
 - `npm run test` to run PHPunit tests inside the WordPress container.
 
+### Docker issues
+
+If you are having issues with incorrect versions of Xdebug or other Docker issues, first try rebuilding with no cache and up to date images using the command `docker compose build --no-cache --pull`. Then run `npm run start` as normal.
 
 ## Issues Tracker
 


### PR DESCRIPTION
This fixes the launch.json file for vscode. 

It also adds instructions on how to pull fresh images in case you have old ones sitting around causing issues, eg if the version of Xdebug is incorrect when starting.

This is a PR to the fix/dev-env branch.