### PR TITLE
publish docker image on master only again

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -36,5 +36,5 @@ jobs:
         run: docker compose --file docker-compose.build.yml build
 
       - name: Publish images
-        #if: contains( github.ref_name, 'master' )
+        if: contains( github.ref_name, 'master' )
         run: docker buildx bake --file docker-compose.build.yml --push --set '*.platform=linux/amd64,linux/arm64'


### PR DESCRIPTION
I think we should be more selective about when to publish a new Docker image; it feels to me that any changes should go through a round of code review before being published? 

It might be that it should be published on `develop` instead which allows us to update the local environment without a release but after going through the code review and testing process.

That having been said, pushing this branch, `fix/publish-on-master`, [also published the Docker image](https://github.com/xwp/stream/actions/runs/9962566359) so it might need something a bit different.