### PR TITLE
Enable `phpcs` sniffs for PHPUnit test files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,8 +66,12 @@
       "@composer validate",
       "@lint-php"
     ],
+    "lint-tests": [
+      "phpcs ./tests --standard=./tests/phpcs.xml.dist"
+    ],
     "format": [
-      "phpcbf ."
+      "phpcbf .",
+      "phpcbf ./tests --standard=./tests/phpcs.xml.dist"
     ],
     "test": [
       "phpunit --coverage-text",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "lint": "npm-run-all lint:*",
     "lint:js": "eslint .",
     "lint:php": "composer lint",
+    "lint:php-tests": "composer lint-tests",
     "format": "composer format",
     "test": "npm-run-all test:*",
     "test:php": "npm run cli -- composer test --working-dir=wp-content/plugins/stream-src",

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * PHPUnit bootstrap file
+ *
+ * @package WP_Stream
+ */
 
 // Defined in docker-compose.yml for the container running the tests.
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
@@ -41,7 +46,7 @@ tests_add_filter( 'option_active_plugins', 'xwp_filter_active_plugins_for_phpuni
 
 tests_add_filter(
 	'muplugins_loaded',
-	function() {
+	function () {
 		// Manually load the plugin.
 		require dirname( __DIR__ ) . '/stream.php';
 
@@ -71,14 +76,20 @@ function xwp_install_edd() {
 
 	$edd_options = get_option( 'edd_settings' );
 
-	$current_user = new WP_User(1);
-	$current_user->set_role('administrator');
-	wp_update_user( array( 'ID' => 1, 'first_name' => 'Admin', 'last_name' => 'User' ) );
+	$current_user = new WP_User( 1 );
+	$current_user->set_role( 'administrator' );
+	wp_update_user(
+		array(
+			'ID'         => 1,
+			'first_name' => 'Admin',
+			'last_name'  => 'User',
+		)
+	);
 	add_filter( 'edd_log_email_errors', '__return_false' );
 
 	add_filter(
 		'pre_http_request',
-		function( $status = false, $args = array(), $url = '') {
+		function ( $status = false, $args = array(), $url = '' ) {
 			return new WP_Error( 'no_reqs_in_unit_tests', __( 'HTTP Requests disabled for unit tests', 'easy-digital-downloads' ) );
 		}
 	);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,7 +9,7 @@
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 
 if ( empty( $_tests_dir ) || ! file_exists( $_tests_dir . '/includes' ) ) {
-	trigger_error( 'Unable to locate WP_TESTS_DIR', E_USER_ERROR );
+	trigger_error( 'Unable to locate WP_TESTS_DIR', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 }
 
 // Use in code to trigger custom actions.
@@ -28,7 +28,7 @@ require_once $_tests_dir . '/includes/functions.php';
  * @param array $active_plugins
  * @return array
  */
-function xwp_filter_active_plugins_for_phpunit( $active_plugins ) {
+function wp_stream_filter_active_plugins_for_phpunit( $active_plugins ) {
 	$forced_active_plugins = array();
 	if ( defined( 'WP_TEST_ACTIVATED_PLUGINS' ) ) {
 		$forced_active_plugins = preg_split( '/\s*,\s*/', WP_TEST_ACTIVATED_PLUGINS );
@@ -41,8 +41,8 @@ function xwp_filter_active_plugins_for_phpunit( $active_plugins ) {
 	}
 	return $active_plugins;
 }
-tests_add_filter( 'site_option_active_sitewide_plugins', 'xwp_filter_active_plugins_for_phpunit' );
-tests_add_filter( 'option_active_plugins', 'xwp_filter_active_plugins_for_phpunit' );
+tests_add_filter( 'site_option_active_sitewide_plugins', 'wp_stream_filter_active_plugins_for_phpunit' );
+tests_add_filter( 'option_active_plugins', 'wp_stream_filter_active_plugins_for_phpunit' );
 
 tests_add_filter(
 	'muplugins_loaded',
@@ -59,16 +59,16 @@ tests_add_filter(
 /**
  * Manually loads Mercator for testing.
  */
-function xwp_manually_load_mercator() {
+function wp_stream_manually_load_mercator() {
 	define( 'MERCATOR_SKIP_CHECKS', true );
 	require WPMU_PLUGIN_DIR . '/mercator/mercator.php';
 }
-tests_add_filter( 'muplugins_loaded', 'xwp_manually_load_mercator' );
+tests_add_filter( 'muplugins_loaded', 'wp_stream_manually_load_mercator' );
 
 /**
  * Manually creates EDD's database tables, users, and settings for testing.
  */
-function xwp_install_edd() {
+function wp_stream_install_edd() {
 
 	edd_install();
 
@@ -76,7 +76,7 @@ function xwp_install_edd() {
 
 	$edd_options = get_option( 'edd_settings' );
 
-	$current_user = new WP_User( 1 );
+	$current_user = new WP_User( 1 ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 	$current_user->set_role( 'administrator' );
 	wp_update_user(
 		array(
@@ -89,8 +89,8 @@ function xwp_install_edd() {
 
 	add_filter(
 		'pre_http_request',
-		function ( $status = false, $args = array(), $url = '' ) {
-			return new WP_Error( 'no_reqs_in_unit_tests', __( 'HTTP Requests disabled for unit tests', 'easy-digital-downloads' ) );
+		function () {
+			return new WP_Error( 'no_reqs_in_unit_tests', __( 'HTTP Requests disabled for unit tests', 'stream' ) );
 		}
 	);
 }
@@ -104,7 +104,7 @@ require $_tests_dir . '/includes/bootstrap.php';
 define( 'EDD_USE_PHP_SESSIONS', false );
 define( 'WP_USE_THEMES', false );
 activate_plugin( 'easy-digital-downloads/easy-digital-downloads.php' );
-xwp_install_edd();
+wp_stream_install_edd();
 
 require __DIR__ . '/testcase.php';
 

--- a/tests/phpcs.xml.dist
+++ b/tests/phpcs.xml.dist
@@ -28,4 +28,8 @@
 		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
 		<exclude name="Squiz.Commenting.VariableComment.Missing" />
 	</rule>
+
+	<rule ref="Generic.CodeAnalysis">
+		<exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedCatch" />
+	</rule>
 </ruleset>

--- a/tests/phpcs.xml.dist
+++ b/tests/phpcs.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Coding Standards for WP Stream Tests">
+	<config name="ignore_warnings_on_exit" value="1" /><!-- FIXME -->
+
+	<arg name="extensions" value="php" />
+	<arg name="colors" />
+	<arg value="sp" /><!-- Show sniff codes in all reports and progress. -->
+
+	<rule ref="PHPCompatibilityWP" />
+	<config name="testVersion" value="8.1-" />
+
+	<rule ref="WordPress-Docs">
+		<type>warning</type><!-- FIXME Report but ignore for now. -->
+	</rule>
+
+	<rule ref="WordPress-Extra" />
+
+	<rule ref="WordPress-Core">
+		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
+		<exclude name="WordPress.WP.I18n.MissingTranslatorsComment" />
+	</rule>
+
+	<rule ref="Squiz.Commenting">
+		<exclude name="Squiz.Commenting.FileComment.Missing" />
+		<exclude name="Squiz.Commenting.ClassComment.Missing" />
+		<exclude name="Squiz.Commenting.FunctionComment.Missing" />
+		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment" />
+		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
+		<exclude name="Squiz.Commenting.VariableComment.Missing" />
+	</rule>
+</ruleset>

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -21,7 +21,7 @@ class WP_StreamTestCase extends \WP_Ajax_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	function setUp(): void {
+	public function setUp(): void {
 		parent::setUp();
 		$this->plugin = $GLOBALS['wp_stream'];
 		$this->assertNotEmpty( $this->plugin );

--- a/tests/testcase.php
+++ b/tests/testcase.php
@@ -11,6 +11,7 @@ class WP_StreamTestCase extends \WP_Ajax_UnitTestCase {
 
 	/**
 	 * Custom action prefix for test custom triggered actions
+	 *
 	 * @var string
 	 */
 	protected $action_prefix = 'wp_stream_test_';
@@ -32,17 +33,17 @@ class WP_StreamTestCase extends \WP_Ajax_UnitTestCase {
 	 * @param array  $tests
 	 * @param string $function_call
 	 */
-	protected function do_action_validation( array $tests = array(), $function_call = 'has_action' ){
+	protected function do_action_validation( array $tests = array(), $function_call = 'has_action' ) {
 		foreach ( $tests as $test ) {
 			list( $action, $class, $function ) = $test;
 
-			//Default WP priority
+			// Default WP priority
 			$priority = isset( $test[3] ) ? $test[3] : 10;
 
-			//Default function call
+			// Default function call
 			$function_call = ( in_array( $function_call, array( 'has_action', 'has_filter' ), true ) ) ? $function_call : 'has_action';
 
-			//Run assertion here
+			// Run assertion here
 			$this->assertEquals(
 				$priority,
 				$function_call( $action, array( $class, $function ) ),
@@ -57,9 +58,10 @@ class WP_StreamTestCase extends \WP_Ajax_UnitTestCase {
 
 	/**
 	 * Helper function to check validity of filters
+	 *
 	 * @param array $tests
 	 */
-	protected function do_filter_validation( array $tests = array() ){
+	protected function do_filter_validation( array $tests = array() ) {
 		$this->do_action_validation( $tests, 'has_filter' );
 	}
 }

--- a/tests/tests/alerts/test-class-alert-trigger-action.php
+++ b/tests/tests/alerts/test-class-alert-trigger-action.php
@@ -17,7 +17,7 @@ class Test_Alert_Trigger_Action extends Test_Alert_Trigger {
 		$this->alert->alert_meta['trigger_action'] = 'activated';
 	}
 
-	function test_check_record_bad() {
+	public function test_check_record_bad() {
 		$data           = $this->dummy_stream_data();
 		$data['action'] = 'updated';
 
@@ -25,7 +25,7 @@ class Test_Alert_Trigger_Action extends Test_Alert_Trigger {
 		$this->assertFalse( $status );
 	}
 
-	function test_save_fields() {
+	public function test_save_fields() {
 		$_POST['wp_stream_trigger_action'] = 'updated';
 
 		$this->assertNotEquals( 'updated', $this->alert->alert_meta['trigger_action'] );

--- a/tests/tests/alerts/test-class-alert-trigger-action.php
+++ b/tests/tests/alerts/test-class-alert-trigger-action.php
@@ -1,7 +1,9 @@
 <?php
 namespace WP_Stream;
+
 /**
  * Class Test_Alert_Trigger_Action
+ *
  * @package WP_Stream
  * @group alerts
  */
@@ -11,12 +13,12 @@ class Test_Alert_Trigger_Action extends Test_Alert_Trigger {
 		parent::setUp();
 		$this->trigger = new Alert_Trigger_Action( $this->plugin );
 
-		$this->alert = $this->plugin->alerts->get_alert();
+		$this->alert                               = $this->plugin->alerts->get_alert();
 		$this->alert->alert_meta['trigger_action'] = 'activated';
 	}
 
 	function test_check_record_bad() {
-		$data = $this->dummy_stream_data();
+		$data           = $this->dummy_stream_data();
 		$data['action'] = 'updated';
 
 		$status = $this->trigger->check_record( true, null, $data, $this->alert );

--- a/tests/tests/alerts/test-class-alert-trigger-author.php
+++ b/tests/tests/alerts/test-class-alert-trigger-author.php
@@ -17,7 +17,7 @@ class Test_Alert_Trigger_Author extends Test_Alert_Trigger {
 		$this->alert->alert_meta['trigger_author'] = '1';
 	}
 
-	function test_check_record_bad() {
+	public function test_check_record_bad() {
 		$data            = $this->dummy_stream_data();
 		$data['user_id'] = '2';
 
@@ -25,7 +25,7 @@ class Test_Alert_Trigger_Author extends Test_Alert_Trigger {
 		$this->assertFalse( $status );
 	}
 
-	function test_save_fields() {
+	public function test_save_fields() {
 		$_POST['wp_stream_trigger_author'] = '0';
 
 		$this->assertNotEquals( '0', $this->alert->alert_meta['trigger_author'] );

--- a/tests/tests/alerts/test-class-alert-trigger-author.php
+++ b/tests/tests/alerts/test-class-alert-trigger-author.php
@@ -1,7 +1,9 @@
 <?php
 namespace WP_Stream;
+
 /**
  * Class Test_Alert_Trigger_Author
+ *
  * @package WP_Stream
  * @group alerts
  */
@@ -11,12 +13,12 @@ class Test_Alert_Trigger_Author extends Test_Alert_Trigger {
 		parent::setUp();
 		$this->trigger = new Alert_Trigger_Author( $this->plugin );
 
-		$this->alert = $this->plugin->alerts->get_alert();
+		$this->alert                               = $this->plugin->alerts->get_alert();
 		$this->alert->alert_meta['trigger_author'] = '1';
 	}
 
 	function test_check_record_bad() {
-		$data = $this->dummy_stream_data();
+		$data            = $this->dummy_stream_data();
 		$data['user_id'] = '2';
 
 		$status = $this->trigger->check_record( true, null, $data, $this->alert );

--- a/tests/tests/alerts/test-class-alert-trigger-context.php
+++ b/tests/tests/alerts/test-class-alert-trigger-context.php
@@ -18,7 +18,7 @@ class Test_Alert_Trigger_Context extends Test_Alert_Trigger {
 		$this->alert->alert_meta['trigger_context']   = 'plugins';
 	}
 
-	function test_check_record_bad() {
+	public function test_check_record_bad() {
 		$data              = $this->dummy_stream_data();
 		$data['connector'] = 'settings';
 		$data['context']   = 'general';
@@ -27,7 +27,7 @@ class Test_Alert_Trigger_Context extends Test_Alert_Trigger {
 		$this->assertFalse( $status );
 	}
 
-	function test_save_fields() {
+	public function test_save_fields() {
 		$_POST['wp_stream_trigger_connector'] = 'settings';
 		$_POST['wp_stream_trigger_context']   = 'general';
 

--- a/tests/tests/alerts/test-class-alert-trigger-context.php
+++ b/tests/tests/alerts/test-class-alert-trigger-context.php
@@ -1,7 +1,9 @@
 <?php
 namespace WP_Stream;
+
 /**
  * Class Test_Alert_Trigger_Context
+ *
  * @package WP_Stream
  * @group alerts
  */
@@ -11,15 +13,15 @@ class Test_Alert_Trigger_Context extends Test_Alert_Trigger {
 		parent::setUp();
 		$this->trigger = new Alert_Trigger_Context( $this->plugin );
 
-		$this->alert = $this->plugin->alerts->get_alert();
+		$this->alert                                  = $this->plugin->alerts->get_alert();
 		$this->alert->alert_meta['trigger_connector'] = 'installer';
-		$this->alert->alert_meta['trigger_context'] = 'plugins';
+		$this->alert->alert_meta['trigger_context']   = 'plugins';
 	}
 
 	function test_check_record_bad() {
-		$data = $this->dummy_stream_data();
+		$data              = $this->dummy_stream_data();
 		$data['connector'] = 'settings';
-		$data['context'] = 'general';
+		$data['context']   = 'general';
 
 		$status = $this->trigger->check_record( true, null, $data, $this->alert );
 		$this->assertFalse( $status );
@@ -27,7 +29,7 @@ class Test_Alert_Trigger_Context extends Test_Alert_Trigger {
 
 	function test_save_fields() {
 		$_POST['wp_stream_trigger_connector'] = 'settings';
-		$_POST['wp_stream_trigger_context'] = 'general';
+		$_POST['wp_stream_trigger_context']   = 'general';
 
 		$this->assertNotEquals( 'settings', $this->alert->alert_meta['trigger_connector'] );
 		$this->assertNotEquals( 'general', $this->alert->alert_meta['trigger_context'] );

--- a/tests/tests/connectors/test-class-connector-acf.php
+++ b/tests/tests/connectors/test-class-connector-acf.php
@@ -35,13 +35,6 @@ class Test_WP_Stream_Connector_ACF extends WP_StreamTestCase {
 	}
 
 	/**
-	 * Runs after each test
-	 */
-	public function tearDown(): void {
-		parent::tearDown();
-	}
-
-	/**
 	 * Create/Update ACF field group
 	 *
 	 * @param array $config  ACF field group configuration.

--- a/tests/tests/connectors/test-class-connector-acf.php
+++ b/tests/tests/connectors/test-class-connector-acf.php
@@ -6,6 +6,7 @@
  *
  * @package WP_Stream
  */
+
 namespace WP_Stream;
 
 class Test_WP_Stream_Connector_ACF extends WP_StreamTestCase {
@@ -78,7 +79,7 @@ class Test_WP_Stream_Connector_ACF extends WP_StreamTestCase {
 	 * @param array $config  ACF field configuration.
 	 */
 	private function update_acf_field( $config = array() ) {
-		$defaults = [
+		$defaults = array(
 			'parent'            => $this->group_key,
 			'key'               => uniqid(),
 			'label'             => 'Test Field',
@@ -97,7 +98,7 @@ class Test_WP_Stream_Connector_ACF extends WP_StreamTestCase {
 			'prepend'           => '',
 			'append'            => '',
 			'maxlength'         => '',
-		];
+		);
 
 		return \acf_update_field( array_merge( $defaults, $config ) );
 	}
@@ -200,7 +201,7 @@ class Test_WP_Stream_Connector_ACF extends WP_StreamTestCase {
 		// Register test ACF field group and field for later use.
 		$field_group = $this->update_acf_field_group(
 			array(
-				'location'              => array(
+				'location' => array(
 					array(
 						array(
 							'param'    => 'post_type',
@@ -247,7 +248,7 @@ class Test_WP_Stream_Connector_ACF extends WP_StreamTestCase {
 					),
 					$this->equalTo( $post_id ),
 					$this->equalTo( 'values' ),
-					$this->equalTo( 'updated' )
+					$this->equalTo( 'updated' ),
 				),
 				array(
 					$this->equalTo( esc_html_x( '"%1$s" of "%2$s" %3$s updated', 'acf', 'stream' ) ),
@@ -263,7 +264,7 @@ class Test_WP_Stream_Connector_ACF extends WP_StreamTestCase {
 					),
 					$this->equalTo( $post_id ),
 					$this->equalTo( 'values' ),
-					$this->equalTo( 'updated' )
+					$this->equalTo( 'updated' ),
 				),
 				array(
 					$this->equalTo( esc_html_x( '"%1$s" of "%2$s" %3$s updated', 'acf', 'stream' ) ),
@@ -279,7 +280,7 @@ class Test_WP_Stream_Connector_ACF extends WP_StreamTestCase {
 					),
 					$this->equalTo( $user_id ),
 					$this->equalTo( 'values' ),
-					$this->equalTo( 'updated' )
+					$this->equalTo( 'updated' ),
 				)
 			);
 

--- a/tests/tests/connectors/test-class-connector-blogs.php
+++ b/tests/tests/connectors/test-class-connector-blogs.php
@@ -4,6 +4,7 @@
  *
  * @package WP_Stream
  */
+
 namespace WP_Stream;
 
 class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
@@ -58,7 +59,7 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 	 */
 	public function test_get_context_labels() {
 		// Validate this works for foreign characters as well.
-		$id = self::factory()->blog->create( array( 'title'  => 'ובזכויותיהם' ) );
+		$id     = self::factory()->blog->create( array( 'title' => 'ובזכויותיהם' ) );
 		$labels = $this->mock->get_context_labels();
 		$this->assertArrayHasKey( 'blog-1', $labels );
 		$this->assertArrayHasKey( 'blog-' . $id, $labels );
@@ -77,7 +78,7 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 					)
 				),
 				$this->callback(
-					function( $meta ) {
+					function ( $meta ) {
 						$expected_meta = array(
 							'site_name' => 'testsite',
 							'siteurl'   => '//testsite',
@@ -92,7 +93,7 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 			);
 
 		// Create new blog to trigger callback.
-		self::factory()->blog->create( array( 'title'  => 'testsite' ) );
+		self::factory()->blog->create( array( 'title' => 'testsite' ) );
 
 		// Check callback test action.
 		$this->assertGreaterThan( 0, did_action( $this->action_prefix . 'callback_wp_initialize_site' ) );
@@ -102,7 +103,7 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 		global $wpdb;
 
 		// Create site for later use.
-		$blog_id = self::factory()->blog->create( array( 'title'  => 'testsite' ) );
+		$blog_id = self::factory()->blog->create( array( 'title' => 'testsite' ) );
 
 		// Temporary tables will trigger DB errors when we attempt to reference them as new temporary tables.
 		$suppress = $wpdb->suppress_errors();
@@ -144,7 +145,7 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 
 	public function test_callback_wpmu_activate_blog() {
 		// Create site for later use.
-		$blog_id = self::factory()->blog->create( array( 'title'  => 'testsite' ) );
+		$blog_id = self::factory()->blog->create( array( 'title' => 'testsite' ) );
 
 		// Expected log calls.
 		$this->mock->expects( $this->once() )
@@ -283,7 +284,7 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 					),
 					$this->equalTo( $blog_id ),
 					$this->equalTo( 'testsite' ),
-					$this->equalTo( 'updated' )
+					$this->equalTo( 'updated' ),
 				),
 				array(
 					$this->equalTo(
@@ -303,7 +304,7 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 					),
 					$this->equalTo( $blog_id ),
 					$this->equalTo( 'testsite' ),
-					$this->equalTo( 'updated' )
+					$this->equalTo( 'updated' ),
 				),
 				array(
 					$this->equalTo(
@@ -323,7 +324,7 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 					),
 					$this->equalTo( $blog_id ),
 					$this->equalTo( 'testsite' ),
-					$this->equalTo( 'updated' )
+					$this->equalTo( 'updated' ),
 				),
 				array(
 					$this->equalTo(
@@ -343,7 +344,7 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 					),
 					$this->equalTo( $blog_id ),
 					$this->equalTo( 'testsite' ),
-					$this->equalTo( 'updated' )
+					$this->equalTo( 'updated' ),
 				),
 				array(
 					$this->equalTo(
@@ -363,7 +364,7 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 					),
 					$this->equalTo( $blog_id ),
 					$this->equalTo( 'testsite' ),
-					$this->equalTo( 'archive_blog' )
+					$this->equalTo( 'archive_blog' ),
 				),
 				array(
 					$this->equalTo(
@@ -383,7 +384,7 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 					),
 					$this->equalTo( $blog_id ),
 					$this->equalTo( 'testsite' ),
-					$this->equalTo( 'updated' )
+					$this->equalTo( 'updated' ),
 				),
 				array(
 					$this->equalTo(
@@ -403,7 +404,7 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 					),
 					$this->equalTo( $blog_id ),
 					$this->equalTo( 'testsite' ),
-					$this->equalTo( 'trashed' )
+					$this->equalTo( 'trashed' ),
 				),
 				array(
 					$this->equalTo(
@@ -423,7 +424,7 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 					),
 					$this->equalTo( $blog_id ),
 					$this->equalTo( 'testsite' ),
-					$this->equalTo( 'restored' )
+					$this->equalTo( 'restored' ),
 				),
 				array(
 					$this->equalTo(
@@ -443,7 +444,7 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 					),
 					$this->equalTo( $blog_id ),
 					$this->equalTo( 'testsite' ),
-					$this->equalTo( 'updated' )
+					$this->equalTo( 'updated' ),
 				),
 				array(
 					$this->equalTo(
@@ -463,7 +464,7 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 					),
 					$this->equalTo( $blog_id ),
 					$this->equalTo( 'testsite' ),
-					$this->equalTo( 'updated' )
+					$this->equalTo( 'updated' ),
 				)
 			);
 
@@ -475,7 +476,7 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 			'deleted'  => '1',
 			'public'   => '1',
 		);
-		foreach( $fields as $field => $value ) {
+		foreach ( $fields as $field => $value ) {
 			wp_update_site( $blog_id, array( $field => $value ) );
 			wp_update_site( $blog_id, array( $field => absint( $value ) ? '0' : '1' ) );
 		}

--- a/tests/tests/connectors/test-class-connector-blogs.php
+++ b/tests/tests/connectors/test-class-connector-blogs.php
@@ -84,7 +84,7 @@ class Test_WP_Stream_Connector_Blogs extends WP_StreamTestCase {
 							'siteurl'   => '//testsite',
 						);
 
-						return $expected_meta === array_intersect_key( $expected_meta, $meta );
+						return array_intersect_key( $expected_meta, $meta ) === $expected_meta;
 					}
 				),
 				$this->greaterThan( 0 ),

--- a/tests/tests/connectors/test-class-connector-comments.php
+++ b/tests/tests/connectors/test-class-connector-comments.php
@@ -8,7 +8,7 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 
 		// Make partial of Connector_ACF class, with mocked "log" function.
 		$this->mock = $this->getMockBuilder( Connector_Comments::class )
-			->setMethods( [ 'log' ] )
+			->setMethods( array( 'log' ) )
 			->getMock();
 
 		// Register connector.
@@ -17,17 +17,17 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 
 	public function test_callback_wp_insert_comment() {
 		$post_id = wp_insert_post(
-			[
-				'post_title'    => 'Test post',
-				'post_content'  => 'Lorem ipsum dolor...',
-				'post_status'   => 'publish',
-			]
+			array(
+				'post_title'   => 'Test post',
+				'post_content' => 'Lorem ipsum dolor...',
+				'post_status'  => 'publish',
+			)
 		);
 
 		$this->mock->expects( $this->atLeastOnce() )
 			->method( 'log' )
 			->withConsecutive(
-				[
+				array(
 					$this->equalTo(
 						_x(
 							'New %4$s by %1$s on %2$s %3$s',
@@ -36,21 +36,21 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 						)
 					),
 					$this->equalTo(
-						[
+						array(
 							'user_name'      => 'Jim Bean',
 							'post_title'     => '"Test post"',
 							'comment_status' => 'pending approval',
 							'comment_type'   => 'comment',
 							'post_id'        => $post_id,
 							'is_spam'        => false,
-						]
+						)
 					),
 					$this->greaterThan( 0 ),
 					$this->equalTo( 'post' ),
 					$this->equalTo( 'created' ),
-					$this->equalTo( 0 )
-				],
-				[
+					$this->equalTo( 0 ),
+				),
+				array(
 					$this->equalTo(
 						_x(
 							'Reply to %1$s\'s %5$s by %2$s on %3$s %4$s',
@@ -59,62 +59,62 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 						)
 					),
 					$this->equalTo(
-						[
+						array(
 							'parent_user_name' => 'Jim Bean',
 							'user_name'        => 'Jim Bean',
 							'post_title'       => '"Test post"',
 							'comment_status'   => 'pending approval',
 							'comment_type'     => 'comment',
 							'post_id'          => "$post_id",
-						]
+						)
 					),
 					$this->greaterThan( 0 ),
 					$this->equalTo( 'post' ),
 					$this->equalTo( 'replied' ),
-					$this->equalTo( 0 )
-				]
+					$this->equalTo( 0 ),
+				)
 			);
 
 		// Do stuff.
 		$comment_id = wp_insert_comment(
-			[
+			array(
 				'comment_content'      => 'Lorem ipsum dolor...',
 				'comment_author'       => 'Jim Bean',
 				'comment_author_email' => 'jim_bean@example.com',
 				'comment_author_IP'    => '::1',
 				'comment_post_ID'      => $post_id,
-			]
+			)
 		);
 		wp_insert_comment(
-			[
+			array(
 				'comment_content'      => 'Lorem ipsum dolor...',
 				'comment_author'       => 'Jim Bean',
 				'comment_author_email' => 'jim_bean@example.com',
 				'comment_author_IP'    => '::1',
 				'comment_post_ID'      => $post_id,
 				'comment_parent'       => $comment_id,
-			]
+			)
 		);
 
 		$this->assertFalse( 0 === did_action( $this->action_prefix . 'callback_wp_insert_comment' ) );
 	}
 
 	public function test_callback_edit_comment() {
-		$post_id = wp_insert_post(
-			[
-				'post_title'    => 'Test post',
-				'post_content'  => 'Lorem ipsum dolor...',
-				'post_status'   => 'publish',
-			]
+		$post_id    = wp_insert_post(
+			array(
+				'post_title'   => 'Test post',
+				'post_content' => 'Lorem ipsum dolor...',
+				'post_status'  => 'publish',
+			)
 		);
 		$comment_id = wp_insert_comment(
-			[
+			array(
 				'comment_content'      => 'Lorem ipsum dolor...',
 				'comment_author'       => 'Jim Bean',
 				'comment_author_email' => 'jim_bean@example.com',
 				'comment_author_IP'    => '::1',
 				'comment_post_ID'      => $post_id,
-			]
+			)
 		);
 
 		$this->mock->expects( $this->atLeastOnce() )
@@ -128,13 +128,13 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 					)
 				),
 				$this->equalTo(
-					[
+					array(
 						'user_name'    => 'Jim Bean',
 						'post_title'   => '"Test post"',
 						'comment_type' => 'comment',
 						'post_id'      => "$post_id",
 						'user_id'      => 0,
-					]
+					)
 				),
 				$this->equalTo( $comment_id ),
 				$this->equalTo( 'post' ),
@@ -143,31 +143,31 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 
 		// Do stuff.
 		wp_update_comment(
-			[
+			array(
 				'comment_ID'      => $comment_id,
 				'comment_content' => 'Lorem ipsum dolor... 2',
-			]
+			)
 		);
 
 		$this->assertFalse( 0 === did_action( $this->action_prefix . 'callback_edit_comment' ) );
 	}
 
 	public function test_callback_delete_comment() {
-		$post_id = wp_insert_post(
-			[
-				'post_title'    => 'Test post',
-				'post_content'  => 'Lorem ipsum dolor...',
-				'post_status'   => 'publish',
-			]
+		$post_id    = wp_insert_post(
+			array(
+				'post_title'   => 'Test post',
+				'post_content' => 'Lorem ipsum dolor...',
+				'post_status'  => 'publish',
+			)
 		);
 		$comment_id = wp_insert_comment(
-			[
+			array(
 				'comment_content'      => 'Lorem ipsum dolor...',
 				'comment_author'       => 'Jim Bean',
 				'comment_author_email' => 'jim_bean@example.com',
 				'comment_author_IP'    => '::1',
 				'comment_post_ID'      => $post_id,
-			]
+			)
 		);
 
 		$this->mock->expects( $this->atLeastOnce() )
@@ -181,13 +181,13 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 					)
 				),
 				$this->equalTo(
-					[
+					array(
 						'user_name'    => 'Jim Bean',
 						'post_title'   => '"Test post"',
 						'comment_type' => 'comment',
 						'post_id'      => "$post_id",
 						'user_id'      => 0,
-					]
+					)
 				),
 				$this->equalTo( $comment_id ),
 				$this->equalTo( 'post' ),
@@ -201,21 +201,21 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 	}
 
 	public function test_callback_trash_comment() {
-		$post_id = wp_insert_post(
-			[
-				'post_title'    => 'Test post',
-				'post_content'  => 'Lorem ipsum dolor...',
-				'post_status'   => 'publish',
-			]
+		$post_id    = wp_insert_post(
+			array(
+				'post_title'   => 'Test post',
+				'post_content' => 'Lorem ipsum dolor...',
+				'post_status'  => 'publish',
+			)
 		);
 		$comment_id = wp_insert_comment(
-			[
+			array(
 				'comment_content'      => 'Lorem ipsum dolor...',
 				'comment_author'       => 'Jim Bean',
 				'comment_author_email' => 'jim_bean@example.com',
 				'comment_author_IP'    => '::1',
 				'comment_post_ID'      => $post_id,
-			]
+			)
 		);
 
 		$this->mock->expects( $this->atLeastOnce() )
@@ -229,13 +229,13 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 					)
 				),
 				$this->equalTo(
-					[
+					array(
 						'user_name'    => 'Jim Bean',
 						'post_title'   => '"Test post"',
 						'comment_type' => 'comment',
 						'post_id'      => "$post_id",
 						'user_id'      => 0,
-					]
+					)
 				),
 				$this->equalTo( $comment_id ),
 				$this->equalTo( 'post' ),
@@ -249,21 +249,21 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 	}
 
 	public function test_callback_untrash_comment() {
-		$post_id = wp_insert_post(
-			[
-				'post_title'    => 'Test post',
-				'post_content'  => 'Lorem ipsum dolor...',
-				'post_status'   => 'publish',
-			]
+		$post_id    = wp_insert_post(
+			array(
+				'post_title'   => 'Test post',
+				'post_content' => 'Lorem ipsum dolor...',
+				'post_status'  => 'publish',
+			)
 		);
 		$comment_id = wp_insert_comment(
-			[
+			array(
 				'comment_content'      => 'Lorem ipsum dolor...',
 				'comment_author'       => 'Jim Bean',
 				'comment_author_email' => 'jim_bean@example.com',
 				'comment_author_IP'    => '::1',
 				'comment_post_ID'      => $post_id,
-			]
+			)
 		);
 		wp_trash_comment( $comment_id );
 
@@ -278,13 +278,13 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 					)
 				),
 				$this->equalTo(
-					[
+					array(
 						'user_name'    => 'Jim Bean',
 						'post_title'   => '"Test post"',
 						'comment_type' => 'comment',
 						'post_id'      => "$post_id",
 						'user_id'      => 0,
-					]
+					)
 				),
 				$this->equalTo( $comment_id ),
 				$this->equalTo( 'post' ),
@@ -298,21 +298,21 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 	}
 
 	public function test_callback_spam_comment() {
-		$post_id = wp_insert_post(
-			[
-				'post_title'    => 'Test post',
-				'post_content'  => 'Lorem ipsum dolor...',
-				'post_status'   => 'publish',
-			]
+		$post_id    = wp_insert_post(
+			array(
+				'post_title'   => 'Test post',
+				'post_content' => 'Lorem ipsum dolor...',
+				'post_status'  => 'publish',
+			)
 		);
 		$comment_id = wp_insert_comment(
-			[
+			array(
 				'comment_content'      => 'Lorem ipsum dolor...',
 				'comment_author'       => 'Jim Bean',
 				'comment_author_email' => 'jim_bean@example.com',
 				'comment_author_IP'    => '::1',
 				'comment_post_ID'      => $post_id,
-			]
+			)
 		);
 
 		$this->mock->expects( $this->atLeastOnce() )
@@ -326,13 +326,13 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 					)
 				),
 				$this->equalTo(
-					[
+					array(
 						'user_name'    => 'Jim Bean',
 						'post_title'   => '"Test post"',
 						'comment_type' => 'comment',
 						'post_id'      => "$post_id",
 						'user_id'      => 0,
-					]
+					)
 				),
 				$this->equalTo( $comment_id ),
 				$this->equalTo( 'post' ),
@@ -346,21 +346,21 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 	}
 
 	public function test_callback_unspam_comment() {
-		$post_id = wp_insert_post(
-			[
-				'post_title'    => 'Test post',
-				'post_content'  => 'Lorem ipsum dolor...',
-				'post_status'   => 'publish',
-			]
+		$post_id    = wp_insert_post(
+			array(
+				'post_title'   => 'Test post',
+				'post_content' => 'Lorem ipsum dolor...',
+				'post_status'  => 'publish',
+			)
 		);
 		$comment_id = wp_insert_comment(
-			[
+			array(
 				'comment_content'      => 'Lorem ipsum dolor...',
 				'comment_author'       => 'Jim Bean',
 				'comment_author_email' => 'jim_bean@example.com',
 				'comment_author_IP'    => '::1',
 				'comment_post_ID'      => $post_id,
-			]
+			)
 		);
 		wp_spam_comment( $comment_id );
 
@@ -375,13 +375,13 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 					)
 				),
 				$this->equalTo(
-					[
+					array(
 						'user_name'    => 'Jim Bean',
 						'post_title'   => '"Test post"',
 						'comment_type' => 'comment',
 						'post_id'      => "$post_id",
 						'user_id'      => 0,
-					]
+					)
 				),
 				$this->equalTo( $comment_id ),
 				$this->equalTo( 'post' ),
@@ -395,21 +395,21 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 	}
 
 	public function test_callback_transition_comment_status() {
-		$post_id = wp_insert_post(
-			[
-				'post_title'    => 'Test post',
-				'post_content'  => 'Lorem ipsum dolor...',
-				'post_status'   => 'publish',
-			]
+		$post_id    = wp_insert_post(
+			array(
+				'post_title'   => 'Test post',
+				'post_content' => 'Lorem ipsum dolor...',
+				'post_status'  => 'publish',
+			)
 		);
 		$comment_id = wp_insert_comment(
-			[
+			array(
 				'comment_content'      => 'Lorem ipsum dolor...',
 				'comment_author'       => 'Jim Bean',
 				'comment_author_email' => 'jim_bean@example.com',
 				'comment_author_IP'    => '::1',
 				'comment_post_ID'      => $post_id,
-			]
+			)
 		);
 
 		$this->mock->expects( $this->atLeastOnce() )
@@ -423,7 +423,7 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 					)
 				),
 				$this->equalTo(
-					[
+					array(
 						'user_name'    => 'Jim Bean',
 						'new_status'   => 'unapproved',
 						'comment_type' => 'comment',
@@ -431,7 +431,7 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 						'post_title'   => '"Test post"',
 						'post_id'      => "$post_id",
 						'user_id'      => 0,
-					]
+					)
 				),
 				$this->equalTo( $comment_id ),
 				$this->equalTo( 'post' ),
@@ -445,22 +445,22 @@ class Test_WP_Stream_Connector_Comments extends WP_StreamTestCase {
 	}
 
 	public function test_callback_comment_duplicate_trigger() {
-		$post_id = wp_insert_post(
-			[
-				'post_title'    => 'Test post',
-				'post_content'  => 'Lorem ipsum dolor...',
-				'post_status'   => 'publish',
-			]
+		$post_id    = wp_insert_post(
+			array(
+				'post_title'   => 'Test post',
+				'post_content' => 'Lorem ipsum dolor...',
+				'post_status'  => 'publish',
+			)
 		);
 		$comment_id = wp_insert_comment(
-			[
+			array(
 				'comment_content'      => 'Lorem ipsum dolor...',
 				'comment_author'       => 'Jim Bean',
 				'comment_author_email' => 'jim_bean@example.com',
 				'comment_author_url'   => '',
 				'comment_author_IP'    => '::1',
 				'comment_post_ID'      => $post_id,
-			]
+			)
 		);
 
 		// Create duplicate comment and trigger mock.

--- a/tests/tests/connectors/test-class-connector-edd.php
+++ b/tests/tests/connectors/test-class-connector-edd.php
@@ -39,37 +39,39 @@ class Test_WP_Stream_Connector_EDD extends WP_StreamTestCase {
 	 * @return int
 	 */
 	private function create_simple_download() {
-		$post_id = wp_insert_post( array(
-			'post_title'    => 'Test Download Product',
-			'post_name'     => 'test-download-product',
-			'post_type'     => 'download',
-			'post_status'   => 'publish'
-		) );
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Test Download Product',
+				'post_name'   => 'test-download-product',
+				'post_type'   => 'download',
+				'post_status' => 'publish',
+			)
+		);
 
 		$_download_files = array(
 			array(
 				'name'      => 'Simple File 1',
 				'file'      => 'http://localhost/simple-file1.jpg',
-				'condition' => 0
+				'condition' => 0,
 			),
 		);
 
 		$meta = array(
-			'edd_price'                         => '20.00',
-			'_variable_pricing'                 => 0,
-			'edd_variable_prices'               => false,
-			'edd_download_files'                => array_values( $_download_files ),
-			'_edd_download_limit'               => 20,
-			'_edd_hide_purchase_link'           => 1,
-			'edd_product_notes'                 => 'Purchase Notes',
-			'_edd_product_type'                 => 'default',
-			'_edd_download_earnings'            => 40,
-			'_edd_download_sales'               => 2,
-			'_edd_download_limit_override_1'    => 1,
-			'edd_sku'                           => 'sku_0012'
+			'edd_price'                      => '20.00',
+			'_variable_pricing'              => 0,
+			'edd_variable_prices'            => false,
+			'edd_download_files'             => array_values( $_download_files ),
+			'_edd_download_limit'            => 20,
+			'_edd_hide_purchase_link'        => 1,
+			'edd_product_notes'              => 'Purchase Notes',
+			'_edd_product_type'              => 'default',
+			'_edd_download_earnings'         => 40,
+			'_edd_download_sales'            => 2,
+			'_edd_download_limit_override_1' => 1,
+			'edd_sku'                        => 'sku_0012',
 		);
 
-		foreach( $meta as $key => $value ) {
+		foreach ( $meta as $key => $value ) {
 			update_post_meta( $post_id, $key, $value );
 		}
 
@@ -82,7 +84,7 @@ class Test_WP_Stream_Connector_EDD extends WP_StreamTestCase {
 	 * @return int
 	 */
 	private function create_simple_percent_discount() {
-		$post = array(
+		$post        = array(
 			'code'              => '20OFF',
 			'uses'              => 54,
 			'max'               => 10,
@@ -93,7 +95,7 @@ class Test_WP_Stream_Connector_EDD extends WP_StreamTestCase {
 			'expiration'        => '12/31/2050 23:59:59',
 			'min_price'         => 128,
 			'status'            => 'active',
-			'product_condition' => 'all'
+			'product_condition' => 'all',
 		);
 		$discount_id = edd_store_discount( $post );
 
@@ -122,7 +124,7 @@ class Test_WP_Stream_Connector_EDD extends WP_StreamTestCase {
 					),
 					$this->equalTo( null ),
 					$this->equalTo( 'settings' ),
-					$this->equalTo( 'updated' )
+					$this->equalTo( 'updated' ),
 				),
 				array(
 					$this->equalTo( __( '"%s" setting updated', 'stream' ) ),
@@ -137,7 +139,7 @@ class Test_WP_Stream_Connector_EDD extends WP_StreamTestCase {
 					),
 					$this->equalTo( null ),
 					$this->equalTo( 'settings' ),
-					$this->equalTo( 'updated' )
+					$this->equalTo( 'updated' ),
 				),
 				array(
 					$this->equalTo( __( '"%s" setting updated', 'stream' ) ),
@@ -152,7 +154,7 @@ class Test_WP_Stream_Connector_EDD extends WP_StreamTestCase {
 					),
 					$this->equalTo( null ),
 					$this->equalTo( 'settings' ),
-					$this->equalTo( 'updated' )
+					$this->equalTo( 'updated' ),
 				)
 			);
 
@@ -171,7 +173,7 @@ class Test_WP_Stream_Connector_EDD extends WP_StreamTestCase {
 		$asserted = 0;
 		add_action(
 			'wp_stream_log_data',
-			function( $data ) use( &$asserted ) {
+			function ( $data ) use ( &$asserted ) {
 				if ( 'edd' === $data['connector'] && in_array( $data['context'], array( 'downloads', 'discounts' ), true ) ) {
 					$asserted++;
 				}

--- a/tests/tests/connectors/test-class-connector-edd.php
+++ b/tests/tests/connectors/test-class-connector-edd.php
@@ -27,13 +27,6 @@ class Test_WP_Stream_Connector_EDD extends WP_StreamTestCase {
 	}
 
 	/**
-	 * Runs after each test
-	 */
-	public function tearDown(): void {
-		parent::tearDown();
-	}
-
-	/**
 	 * Create a download
 	 *
 	 * @return int

--- a/tests/tests/connectors/test-class-connector-editor.php
+++ b/tests/tests/connectors/test-class-connector-editor.php
@@ -14,10 +14,6 @@ class Test_WP_Stream_Connector_Editor extends WP_StreamTestCase {
 		$this->mock->register();
 	}
 
-	public function tearDown(): void {
-		parent::tearDown();
-	}
-
 	public function test_log_changes() {
 		$theme  = wp_get_theme( 'twentytwentythree' );
 		$plugin = get_plugins()['hello.php'];

--- a/tests/tests/connectors/test-class-connector-editor.php
+++ b/tests/tests/connectors/test-class-connector-editor.php
@@ -71,18 +71,18 @@ class Test_WP_Stream_Connector_Editor extends WP_StreamTestCase {
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$_POST['action']           = 'update';
 		$_POST['theme']            = 'twentytwentythree';
-		do_action( 'load-theme-editor.php' );
+		do_action( 'load-theme-editor.php' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 
-		\file_put_contents( $theme->get_files( 'css' )['style.css'], "\r\n", FILE_APPEND );
+		\file_put_contents( $theme->get_files( 'css' )['style.css'], "\r\n", FILE_APPEND ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 		apply_filters( 'wp_redirect', 'theme-editor.php' );
 
 		// Update plugin file
 		$_POST['plugin'] = 'hello.php';
 		$_POST['file']   = 'hello.php';
 		unset( $_POST['theme'] );
-		do_action( 'load-plugin-editor.php' );
+		do_action( 'load-plugin-editor.php' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 
-		\file_put_contents( WP_PLUGIN_DIR . '/hello.php', "\r\n", FILE_APPEND );
+		\file_put_contents( WP_PLUGIN_DIR . '/hello.php', "\r\n", FILE_APPEND ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 		apply_filters( 'wp_redirect', 'plugin-editor.php' );
 	}
 }

--- a/tests/tests/connectors/test-class-connector-installer.php
+++ b/tests/tests/connectors/test-class-connector-installer.php
@@ -1,7 +1,10 @@
 <?php
 /**
  * Tests for Installer Connector class callbacks.
+ *
+ * @package WP_Stream
  */
+
 namespace WP_Stream;
 
 class Test_WP_Stream_Connector_Installer extends WP_StreamTestCase {
@@ -46,7 +49,7 @@ class Test_WP_Stream_Connector_Installer extends WP_StreamTestCase {
 					),
 					null,
 					'plugins',
-					'installed'
+					'installed',
 				),
 				array(
 					_x(
@@ -65,7 +68,7 @@ class Test_WP_Stream_Connector_Installer extends WP_StreamTestCase {
 					),
 					null,
 					'themes',
-					'updated'
+					'updated',
 				)
 			);
 
@@ -90,7 +93,7 @@ class Test_WP_Stream_Connector_Installer extends WP_StreamTestCase {
 				$this->equalTo(
 					array(
 						'name'         => 'Hello Dolly',
-						'network_wide' => null
+						'network_wide' => null,
 					)
 				),
 				$this->equalTo( null ),
@@ -199,7 +202,6 @@ class Test_WP_Stream_Connector_Installer extends WP_StreamTestCase {
 
 		// Do stuff.
 
-
 		// Check callback test action.
 		$this->assertFalse( 0 === did_action( $this->action_prefix . 'callback_pre_set_site_transient_update_plugins' ) );
 	}
@@ -223,7 +225,7 @@ class Test_WP_Stream_Connector_Installer extends WP_StreamTestCase {
 					),
 					$this->equalTo( null ),
 					$this->equalTo( 'WordPress' ),
-					$this->equalTo( 'updated' )
+					$this->equalTo( 'updated' ),
 				),
 				array(
 					$this->equalTo( esc_html__( 'WordPress updated to %s', 'stream' ) ),
@@ -236,7 +238,7 @@ class Test_WP_Stream_Connector_Installer extends WP_StreamTestCase {
 					),
 					$this->equalTo( null ),
 					$this->equalTo( 'WordPress' ),
-					$this->equalTo( 'updated' )
+					$this->equalTo( 'updated' ),
 				)
 			);
 

--- a/tests/tests/connectors/test-class-connector-jetpack.php
+++ b/tests/tests/connectors/test-class-connector-jetpack.php
@@ -9,9 +9,7 @@ namespace WP_Stream;
 
 class Test_WP_Stream_Connector_Jetpack extends WP_StreamTestCase {
 
-	/**
-	 * @var WP_REST_Server $wp_rest_server
-	 */
+	/** @var WP_REST_Server $wp_rest_server Rest server instance. */
 	protected $server;
 
 	protected $namespaced_route = '/jetpack/v4';
@@ -218,7 +216,7 @@ class Test_WP_Stream_Connector_Jetpack extends WP_StreamTestCase {
 		$this->assertArrayHasKey( $this->namespaced_route, $routes );
 
 		// Execute REST requests and trigger callbacks.
-		$request = new \WP_Rest_Request( 'POST', "{$this->namespaced_route}/settings" );
+		$request = new \WP_REST_Request( 'POST', "{$this->namespaced_route}/settings" );
 		$request->set_body_params(
 			array(
 				'carousel'                  => true,

--- a/tests/tests/connectors/test-class-connector-jetpack.php
+++ b/tests/tests/connectors/test-class-connector-jetpack.php
@@ -9,7 +9,11 @@ namespace WP_Stream;
 
 class Test_WP_Stream_Connector_Jetpack extends WP_StreamTestCase {
 
-	/** @var WP_REST_Server $wp_rest_server Rest server instance. */
+	/**
+	 * Rest server instance.
+	 *
+	 * @var WP_REST_Server $wp_rest_server
+	 */
 	protected $server;
 
 	protected $namespaced_route = '/jetpack/v4';
@@ -21,7 +25,10 @@ class Test_WP_Stream_Connector_Jetpack extends WP_StreamTestCase {
 		parent::setUp();
 
 		global $wp_rest_server;
-		$this->server = $wp_rest_server = new \WP_REST_Server();
+
+		$wp_rest_server = new \WP_REST_Server(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		$this->server   = $wp_rest_server;
+
 		do_action( 'rest_api_init' );
 
 		// Make partial of Connector_Installer class, with mocked "log" function.

--- a/tests/tests/connectors/test-class-connector-jetpack.php
+++ b/tests/tests/connectors/test-class-connector-jetpack.php
@@ -1,6 +1,8 @@
 <?php
 /**
  * Tests for Jetpack Connector class callbacks.
+ *
+ * @package WP_Stream
  */
 
 namespace WP_Stream;
@@ -21,7 +23,7 @@ class Test_WP_Stream_Connector_Jetpack extends WP_StreamTestCase {
 		parent::setUp();
 
 		global $wp_rest_server;
-		$this->server = $wp_rest_server = new \WP_REST_Server;
+		$this->server = $wp_rest_server = new \WP_REST_Server();
 		do_action( 'rest_api_init' );
 
 		// Make partial of Connector_Installer class, with mocked "log" function.
@@ -39,8 +41,8 @@ class Test_WP_Stream_Connector_Jetpack extends WP_StreamTestCase {
 
 	public function test_callback_jetpack_log_entry() {
 		// Get blog details and create user for later use.
-		$user_id   = self::factory()->user->create( array( 'display_name' => 'testuser' ) );
-		$user      = new \WP_User( $user_id );
+		$user_id = self::factory()->user->create( array( 'display_name' => 'testuser' ) );
+		$user    = new \WP_User( $user_id );
 
 		// Expected log calls.
 		$this->mock->expects( $this->exactly( 3 ) )
@@ -48,7 +50,7 @@ class Test_WP_Stream_Connector_Jetpack extends WP_StreamTestCase {
 			->withConsecutive(
 				array(
 					'Comments module activated',
-					array( 'module_slug' => 'comments'),
+					array( 'module_slug' => 'comments' ),
 					null,
 					'modules',
 					'activated',
@@ -69,7 +71,7 @@ class Test_WP_Stream_Connector_Jetpack extends WP_StreamTestCase {
 					array(),
 					null,
 					'blogs',
-					'register'
+					'register',
 				)
 			);
 
@@ -84,8 +86,8 @@ class Test_WP_Stream_Connector_Jetpack extends WP_StreamTestCase {
 
 	public function test_callback_sharing_get_services_state() {
 		// Create sharing service instance and services object for later use.
-		require_once JETPACK__PLUGIN_DIR. 'modules/sharedaddy/sharing-service.php';
-		$sharer = new \Sharing_Service();
+		require_once JETPACK__PLUGIN_DIR . 'modules/sharedaddy/sharing-service.php';
+		$sharer   = new \Sharing_Service();
 		$services = $sharer->get_all_services();
 
 		// Expected log calls.
@@ -105,7 +107,7 @@ class Test_WP_Stream_Connector_Jetpack extends WP_StreamTestCase {
 					),
 					$this->equalTo( null ),
 					$this->equalTo( 'sharedaddy' ),
-					$this->equalTo( 'updated' )
+					$this->equalTo( 'updated' ),
 				)
 			);
 
@@ -166,11 +168,11 @@ class Test_WP_Stream_Connector_Jetpack extends WP_StreamTestCase {
 							'old_value'    => null,
 							'new_value'    => array(
 								'global' => array(
-									'button_style'              => 'icon-text',
-									'sharing_label'             => 'Share this:',
-									'open_links'                => 'same',
-									'show'                      => array( 'post', 'page' ),
-									'custom'                    => array(),
+									'button_style'  => 'icon-text',
+									'sharing_label' => 'Share this:',
+									'open_links'    => 'same',
+									'show'          => array( 'post', 'page' ),
+									'custom'        => array(),
 								),
 							),
 						)
@@ -187,20 +189,20 @@ class Test_WP_Stream_Connector_Jetpack extends WP_StreamTestCase {
 							'option'       => 'sharing-options',
 							'old_value'    => array(
 								'global' => array(
-									'button_style'              => 'icon-text',
-									'sharing_label'             => 'Share this:',
-									'open_links'                => 'same',
-									'show'                      => array( 'post', 'page' ),
-									'custom'                    => array(),
+									'button_style'  => 'icon-text',
+									'sharing_label' => 'Share this:',
+									'open_links'    => 'same',
+									'show'          => array( 'post', 'page' ),
+									'custom'        => array(),
 								),
 							),
 							'new_value'    => array(
 								'global' => array(
-									'button_style'              => 'icon-text',
-									'sharing_label'             => 'Share what',
-									'open_links'                => 'same',
-									'show'                      => array( 'post', 'page' ),
-									'custom'                    => array(),
+									'button_style'  => 'icon-text',
+									'sharing_label' => 'Share what',
+									'open_links'    => 'same',
+									'show'          => array( 'post', 'page' ),
+									'custom'        => array(),
 								),
 							),
 						)
@@ -216,13 +218,13 @@ class Test_WP_Stream_Connector_Jetpack extends WP_StreamTestCase {
 		$this->assertArrayHasKey( $this->namespaced_route, $routes );
 
 		// Execute REST requests and trigger callbacks.
-		$request  = new \WP_Rest_Request( 'POST', "{$this->namespaced_route}/settings" );
+		$request = new \WP_Rest_Request( 'POST', "{$this->namespaced_route}/settings" );
 		$request->set_body_params(
 			array(
 				'carousel'                  => true,
 				'carousel_background_color' => 'white',
 				'sharedaddy'                => true,
-				'sharing_label'             => 'Share what'
+				'sharing_label'             => 'Share what',
 			)
 		);
 		$response = $this->server->dispatch( $request );

--- a/tests/tests/connectors/test-class-connector-media.php
+++ b/tests/tests/connectors/test-class-connector-media.php
@@ -1,6 +1,8 @@
 <?php
 /**
  * Tests for Media Connector class callbacks.
+ *
+ * @package WP_Stream
  */
 
 namespace WP_Stream;
@@ -38,7 +40,7 @@ class Test_WP_Stream_Connector_Media extends WP_StreamTestCase {
 				array(
 					$this->equalTo( esc_html__( 'Added "%s" to Media library', 'stream' ) ),
 					$this->callback(
-						function( $subject ) {
+						function ( $subject ) {
 							$expected = array(
 								'name'         => 'Document one',
 								'parent_title' => null,
@@ -60,7 +62,7 @@ class Test_WP_Stream_Connector_Media extends WP_StreamTestCase {
 						)
 					),
 					$this->callback(
-						function( $subject ) use ( $post_id ) {
+						function ( $subject ) use ( $post_id ) {
 							$expected = array(
 								'name'         => 'Document one',
 								'parent_title' => 'Test post',
@@ -82,7 +84,7 @@ class Test_WP_Stream_Connector_Media extends WP_StreamTestCase {
 						)
 					),
 					$this->callback(
-						function( $subject ) {
+						function ( $subject ) {
 							$expected = array(
 								'name'         => 'Document one',
 								'parent_title' => 'Unidentifiable post',
@@ -110,7 +112,7 @@ class Test_WP_Stream_Connector_Media extends WP_StreamTestCase {
 				'post_title'   => 'Document one',
 				'post_type'    => 'attachment',
 				'post_content' => 'some description',
-				'post_parent'  => $post_id
+				'post_parent'  => $post_id,
 			)
 		);
 
@@ -120,7 +122,7 @@ class Test_WP_Stream_Connector_Media extends WP_StreamTestCase {
 				'post_title'   => 'Document one',
 				'post_type'    => 'attachment',
 				'post_content' => 'some description',
-				'post_parent'  => 42
+				'post_parent'  => 42,
 			)
 		);
 
@@ -154,7 +156,6 @@ class Test_WP_Stream_Connector_Media extends WP_StreamTestCase {
 			array( 'post_title' => 'Document one' )
 		);
 
-
 		// Check callback test action.
 		$this->assertFalse( 0 === did_action( $this->action_prefix . 'callback_edit_attachment' ) );
 	}
@@ -174,7 +175,7 @@ class Test_WP_Stream_Connector_Media extends WP_StreamTestCase {
 			->with(
 				$this->equalTo( esc_html__( 'Deleted "%s"', 'stream' ) ),
 				$this->callback(
-					function( $subject ) {
+					function ( $subject ) {
 						$expected = array(
 							'name'      => 'Attachment one',
 							'parent_id' => null,

--- a/tests/tests/connectors/test-class-connector-media.php
+++ b/tests/tests/connectors/test-class-connector-media.php
@@ -46,7 +46,7 @@ class Test_WP_Stream_Connector_Media extends WP_StreamTestCase {
 								'parent_title' => null,
 								'parent_id'    => 0,
 							);
-							return $expected === array_intersect_key( $expected, $subject );
+							return array_intersect_key( $expected, $subject ) === $expected;
 						}
 					),
 					$this->greaterThan( 0 ),
@@ -68,7 +68,7 @@ class Test_WP_Stream_Connector_Media extends WP_StreamTestCase {
 								'parent_title' => 'Test post',
 								'parent_id'    => $post_id,
 							);
-							return $expected === array_intersect_key( $expected, $subject );
+							return array_intersect_key( $expected, $subject ) === $expected;
 						}
 					),
 					$this->greaterThan( 0 ),
@@ -90,7 +90,7 @@ class Test_WP_Stream_Connector_Media extends WP_StreamTestCase {
 								'parent_title' => 'Unidentifiable post',
 								'parent_id'    => 42,
 							);
-							return $expected === array_intersect_key( $expected, $subject );
+							return array_intersect_key( $expected, $subject ) === $expected;
 						}
 					),
 					$this->greaterThan( 0 ),
@@ -180,7 +180,7 @@ class Test_WP_Stream_Connector_Media extends WP_StreamTestCase {
 							'name'      => 'Attachment one',
 							'parent_id' => null,
 						);
-						return $expected === array_intersect_key( $expected, $subject );
+						return array_intersect_key( $expected, $subject ) === $expected;
 					}
 				),
 				$this->equalTo( $attachment_id ),

--- a/tests/tests/connectors/test-class-connector-menus.php
+++ b/tests/tests/connectors/test-class-connector-menus.php
@@ -32,7 +32,7 @@ class Test_WP_Stream_Connector_Menus extends WP_StreamTestCase {
 				$this->callback(
 					function ( $subject ) {
 						$expected = array( 'name' => 'test-menu' );
-						return $expected === array_intersect_key( $expected, $subject );
+						return array_intersect_key( $expected, $subject ) === $expected;
 					}
 				),
 				$this->greaterThan( 0 ),

--- a/tests/tests/connectors/test-class-connector-menus.php
+++ b/tests/tests/connectors/test-class-connector-menus.php
@@ -4,6 +4,7 @@
  *
  * @package WP_Stream
  */
+
 namespace WP_Stream;
 
 class Test_WP_Stream_Connector_Menus extends WP_StreamTestCase {
@@ -29,7 +30,7 @@ class Test_WP_Stream_Connector_Menus extends WP_StreamTestCase {
 			->with(
 				$this->equalTo( __( 'Created new menu "%s"', 'stream' ) ),
 				$this->callback(
-					function( $subject ) {
+					function ( $subject ) {
 						$expected = array( 'name' => 'test-menu' );
 						return $expected === array_intersect_key( $expected, $subject );
 					}
@@ -97,8 +98,8 @@ class Test_WP_Stream_Connector_Menus extends WP_StreamTestCase {
 				$this->equalTo( _x( 'Deleted "%s"', 'Menu name', 'stream' ) ),
 				$this->equalTo(
 					array(
-						'name'      => 'test-menu',
-						'menu_id'   => $menu_id,
+						'name'    => 'test-menu',
+						'menu_id' => $menu_id,
 					)
 				),
 				$this->equalTo( $menu_id ),
@@ -119,7 +120,7 @@ class Test_WP_Stream_Connector_Menus extends WP_StreamTestCase {
 		register_nav_menu( 'main', 'Main Navigation' );
 
 		// Create theme mods options for later use.
-		$locations         = get_theme_mod('nav_menu_locations');
+		$locations         = get_theme_mod( 'nav_menu_locations' );
 		$locations['main'] = '';
 		set_theme_mod( 'nav_menu_locations', $locations );
 
@@ -137,15 +138,15 @@ class Test_WP_Stream_Connector_Menus extends WP_StreamTestCase {
 					),
 					$this->equalTo(
 						array(
-							'name'         => 'test-menu',
-							'location'     => 'Main Navigation',
-							'location_id'  => 'main',
-							'menu_id'      => $menu_id,
+							'name'        => 'test-menu',
+							'location'    => 'Main Navigation',
+							'location_id' => 'main',
+							'menu_id'     => $menu_id,
 						)
 					),
 					$this->equalTo( $menu_id ),
 					$this->equalTo( 'test-menu' ),
-					$this->equalTo( 'assigned' )
+					$this->equalTo( 'assigned' ),
 				),
 				array(
 					$this->equalTo(
@@ -157,15 +158,15 @@ class Test_WP_Stream_Connector_Menus extends WP_StreamTestCase {
 					),
 					$this->equalTo(
 						array(
-							'name'         => 'test-menu',
-							'location'     => 'Main Navigation',
-							'location_id'  => 'main',
-							'menu_id'      => $menu_id,
+							'name'        => 'test-menu',
+							'location'    => 'Main Navigation',
+							'location_id' => 'main',
+							'menu_id'     => $menu_id,
 						)
 					),
 					$this->equalTo( $menu_id ),
 					$this->equalTo( 'test-menu' ),
-					$this->equalTo( 'unassigned' )
+					$this->equalTo( 'unassigned' ),
 				)
 			);
 

--- a/tests/tests/connectors/test-class-connector-mercator.php
+++ b/tests/tests/connectors/test-class-connector-mercator.php
@@ -6,6 +6,7 @@
  *
  * @package WP_Stream
  */
+
 namespace WP_Stream;
 
 class Test_WP_Stream_Connector_Mercator extends WP_StreamTestCase {
@@ -55,10 +56,10 @@ class Test_WP_Stream_Connector_Mercator extends WP_StreamTestCase {
 	 */
 	public function test_get_context_labels() {
 		// Validate this works for foreign characters as well.
-		$id = $this->factory->blog->create( array( 'title' => 'ובזכויותיהם' ) );
+		$id     = $this->factory->blog->create( array( 'title' => 'ובזכויותיהם' ) );
 		$labels = $this->mock->get_context_labels();
 		$this->assertArrayHasKey( 'blog-1', $labels );
-		$this->assertArrayHasKey( 'blog-' . $id , $labels );
+		$this->assertArrayHasKey( 'blog-' . $id, $labels );
 	}
 
 	public function test_callback_mercator_mapping_made_primary() {

--- a/tests/tests/connectors/test-class-connector-mercator.php
+++ b/tests/tests/connectors/test-class-connector-mercator.php
@@ -197,9 +197,11 @@ class Test_WP_Stream_Connector_Mercator extends WP_StreamTestCase {
 				$this->equalTo( 'deleted' )
 			);
 
-		// Execute action to trigger callback because the tables need to
-		// run the "\Mercator\Mapping::delete() don't currently exist.
-		do_action( 'mercator.mapping.deleted', $mapping );
+		/*
+		 * Execute action to trigger callback because the tables need to
+		 * run the \Mercator\Mapping::delete() don't currently exist.
+		 */
+		do_action( 'mercator.mapping.deleted', $mapping ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 
 		// Check callback test action.
 		$this->assertGreaterThan( 0, did_action( $this->action_prefix . 'callback_mercator_mapping_deleted' ) );

--- a/tests/tests/connectors/test-class-connector-posts.php
+++ b/tests/tests/connectors/test-class-connector-posts.php
@@ -76,7 +76,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 								'new_status'    => 'draft',
 								'old_status'    => 'new',
 							);
-							return $expected === array_intersect_key( $expected, $subject );
+							return array_intersect_key( $expected, $subject ) === $expected;
 						}
 					),
 					$this->greaterThan( 0 ),
@@ -99,7 +99,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 								'new_status'    => 'publish',
 								'old_status'    => 'draft',
 							);
-							return $expected === array_intersect_key( $expected, $subject );
+							return array_intersect_key( $expected, $subject ) === $expected;
 						}
 					),
 					$this->greaterThan( 0 ),
@@ -122,7 +122,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 								'new_status'    => 'draft',
 								'old_status'    => 'publish',
 							);
-							return $expected === array_intersect_key( $expected, $subject );
+							return array_intersect_key( $expected, $subject ) === $expected;
 						}
 					),
 					$this->greaterThan( 0 ),
@@ -145,7 +145,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 								'new_status'    => 'draft',
 								'old_status'    => 'draft',
 							);
-							return $expected === array_intersect_key( $expected, $subject );
+							return array_intersect_key( $expected, $subject ) === $expected;
 						}
 					),
 					$this->greaterThan( 0 ),
@@ -168,7 +168,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 								'new_status'    => 'pending',
 								'old_status'    => 'draft',
 							);
-							return $expected === array_intersect_key( $expected, $subject );
+							return array_intersect_key( $expected, $subject ) === $expected;
 						}
 					),
 					$this->greaterThan( 0 ),
@@ -191,7 +191,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 								'new_status'    => 'future',
 								'old_status'    => 'pending',
 							);
-							return $expected === array_intersect_key( $expected, $subject );
+							return array_intersect_key( $expected, $subject ) === $expected;
 						}
 					),
 					$this->greaterThan( 0 ),
@@ -214,7 +214,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 								'new_status'    => 'publish',
 								'old_status'    => 'future',
 							);
-							return $expected === array_intersect_key( $expected, $subject );
+							return array_intersect_key( $expected, $subject ) === $expected;
 						}
 					),
 					$this->greaterThan( 0 ),
@@ -237,7 +237,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 								'new_status'    => 'private',
 								'old_status'    => 'publish',
 							);
-							return $expected === array_intersect_key( $expected, $subject );
+							return array_intersect_key( $expected, $subject ) === $expected;
 						}
 					),
 					$this->greaterThan( 0 ),
@@ -260,7 +260,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 								'new_status'    => 'trash',
 								'old_status'    => 'private',
 							);
-							return $expected === array_intersect_key( $expected, $subject );
+							return array_intersect_key( $expected, $subject ) === $expected;
 						}
 					),
 					$this->greaterThan( 0 ),
@@ -283,7 +283,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 								'new_status'    => 'publish',
 								'old_status'    => 'trash',
 							);
-							return $expected === array_intersect_key( $expected, $subject );
+							return array_intersect_key( $expected, $subject ) === $expected;
 						}
 					),
 					$this->greaterThan( 0 ),
@@ -306,7 +306,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 								'new_status'    => 'publish',
 								'old_status'    => 'publish',
 							);
-							return $expected === array_intersect_key( $expected, $subject );
+							return array_intersect_key( $expected, $subject ) === $expected;
 						}
 					),
 					$this->greaterThan( 0 ),
@@ -329,7 +329,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 								'new_status'    => 'publish',
 								'old_status'    => 'new',
 							);
-							return $expected === array_intersect_key( $expected, $subject );
+							return array_intersect_key( $expected, $subject ) === $expected;
 						}
 					),
 					$this->greaterThan( 0 ),

--- a/tests/tests/connectors/test-class-connector-posts.php
+++ b/tests/tests/connectors/test-class-connector-posts.php
@@ -369,7 +369,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 			array(
 				'ID'            => $post_id,
 				'post_status'   => 'future',
-				'post_date'     => date( 'Y-m-d H:i:s', $time ),
+				'post_date'     => date( 'Y-m-d H:i:s', $time ), // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 				'post_date_gmt' => gmdate( 'Y-m-d H:i:s', $time ),
 			)
 		);
@@ -378,7 +378,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 			array(
 				'ID'            => $post_id,
 				'post_status'   => 'publish',
-				'post_date'     => date( 'Y-m-d H:i:s', $time ),
+				'post_date'     => date( 'Y-m-d H:i:s', $time ), // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 				'post_date_gmt' => gmdate( 'Y-m-d H:i:s', $time ),
 			)
 		);

--- a/tests/tests/connectors/test-class-connector-posts.php
+++ b/tests/tests/connectors/test-class-connector-posts.php
@@ -4,6 +4,7 @@
  *
  * @package WP_Stream
  */
+
 namespace WP_Stream;
 
 class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
@@ -52,7 +53,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 			'post_content'  => 'Lorem ipsum dolor...',
 			'post_date'     => $this->date,
 			'post_date_gmt' => $this->date_gmt,
-			'post_status'   => 'draft'
+			'post_status'   => 'draft',
 		);
 
 		// Set expected calls for the Mock.
@@ -68,7 +69,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 						)
 					),
 					$this->callback(
-						function( $subject ) {
+						function ( $subject ) {
 							$expected = array(
 								'post_title'    => 'Test post',
 								'singular_name' => 'post',
@@ -91,7 +92,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 						)
 					),
 					$this->callback(
-						function( $subject ) {
+						function ( $subject ) {
 							$expected = array(
 								'post_title'    => 'Test post',
 								'singular_name' => 'post',
@@ -114,7 +115,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 						)
 					),
 					$this->callback(
-						function( $subject ) {
+						function ( $subject ) {
 							$expected = array(
 								'post_title'    => 'Test post',
 								'singular_name' => 'post',
@@ -137,7 +138,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 						)
 					),
 					$this->callback(
-						function( $subject ) {
+						function ( $subject ) {
 							$expected = array(
 								'post_title'    => 'Test post',
 								'singular_name' => 'post',
@@ -160,7 +161,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 						)
 					),
 					$this->callback(
-						function( $subject ) {
+						function ( $subject ) {
 							$expected = array(
 								'post_title'    => 'Test post',
 								'singular_name' => 'post',
@@ -183,7 +184,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 						)
 					),
 					$this->callback(
-						function( $subject ) {
+						function ( $subject ) {
 							$expected = array(
 								'post_title'    => 'Test post',
 								'singular_name' => 'post',
@@ -206,7 +207,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 						)
 					),
 					$this->callback(
-						function( $subject ) {
+						function ( $subject ) {
 							$expected = array(
 								'post_title'    => 'Test post',
 								'singular_name' => 'post',
@@ -229,7 +230,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 						)
 					),
 					$this->callback(
-						function( $subject ) {
+						function ( $subject ) {
 							$expected = array(
 								'post_title'    => 'Test post',
 								'singular_name' => 'post',
@@ -252,7 +253,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 						)
 					),
 					$this->callback(
-						function( $subject ) {
+						function ( $subject ) {
 							$expected = array(
 								'post_title'    => 'Test post',
 								'singular_name' => 'post',
@@ -275,7 +276,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 						)
 					),
 					$this->callback(
-						function( $subject ) {
+						function ( $subject ) {
 							$expected = array(
 								'post_title'    => 'Test post',
 								'singular_name' => 'post',
@@ -298,7 +299,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 						)
 					),
 					$this->callback(
-						function( $subject ) {
+						function ( $subject ) {
 							$expected = array(
 								'post_title'    => 'Test post',
 								'singular_name' => 'post',
@@ -321,7 +322,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 						)
 					),
 					$this->callback(
-						function( $subject ) {
+						function ( $subject ) {
 							$expected = array(
 								'post_title'    => 'Test post',
 								'singular_name' => 'post',
@@ -369,7 +370,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 				'ID'            => $post_id,
 				'post_status'   => 'future',
 				'post_date'     => date( 'Y-m-d H:i:s', $time ),
-    			'post_date_gmt' => gmdate( 'Y-m-d H:i:s', $time ),
+				'post_date_gmt' => gmdate( 'Y-m-d H:i:s', $time ),
 			)
 		);
 		$time = strtotime( 'now' );
@@ -378,7 +379,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 				'ID'            => $post_id,
 				'post_status'   => 'publish',
 				'post_date'     => date( 'Y-m-d H:i:s', $time ),
-    			'post_date_gmt' => gmdate( 'Y-m-d H:i:s', $time ),
+				'post_date_gmt' => gmdate( 'Y-m-d H:i:s', $time ),
 			)
 		);
 		wp_update_post(
@@ -409,9 +410,9 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 		// Expected log to be made with "created" action.
 		wp_insert_post(
 			array(
-				'post_title'    => 'Test post',
-				'post_content'  => 'Lorem ipsum dolor...',
-				'post_status'   => 'publish',
+				'post_title'   => 'Test post',
+				'post_content' => 'Lorem ipsum dolor...',
+				'post_status'  => 'publish',
 			)
 		);
 
@@ -421,13 +422,12 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 		 */
 		wp_insert_post(
 			array(
-				'post_title'    => 'Test attachment',
-				'post_content'  => 'Lorem ipsum dolor...',
-				'post_status'   => 'publish',
-				'post_type'     => 'attachment',
+				'post_title'   => 'Test attachment',
+				'post_content' => 'Lorem ipsum dolor...',
+				'post_status'  => 'publish',
+				'post_type'    => 'attachment',
 			)
 		);
-
 
 		// Confirm callback execution.
 		$this->assertGreaterThan( 0, did_action( $this->action_prefix . 'callback_transition_post_status' ) );
@@ -440,25 +440,25 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 		// Create post for later use.
 		$post_id = wp_insert_post(
 			array(
-				'post_title'    => 'Test post',
-				'post_content'  => 'Lorem ipsum dolor...',
-				'post_status'   => 'publish'
+				'post_title'   => 'Test post',
+				'post_content' => 'Lorem ipsum dolor...',
+				'post_status'  => 'publish',
 			)
 		);
 
 		$auto_draft_post_id = wp_insert_post(
 			array(
-				'post_title'    => 'Test post',
-				'post_content'  => 'Lorem ipsum dolor...',
-				'post_status'   => 'auto-draft'
+				'post_title'   => 'Test post',
+				'post_content' => 'Lorem ipsum dolor...',
+				'post_status'  => 'auto-draft',
 			)
 		);
 
 		$attachment_post_id = wp_insert_post(
 			array(
-				'post_title'    => 'Test post',
-				'post_content'  => 'Lorem ipsum dolor...',
-				'post_type'     => 'attachment'
+				'post_title'   => 'Test post',
+				'post_content' => 'Lorem ipsum dolor...',
+				'post_type'    => 'attachment',
 			)
 		);
 
@@ -491,9 +491,7 @@ class Test_WP_Stream_Connector_Posts extends WP_StreamTestCase {
 		wp_delete_post( $auto_draft_post_id, true );
 		wp_delete_post( $attachment_post_id, true );
 
-
 		// Confirm callback execution.
 		$this->assertGreaterThan( 0, did_action( $this->action_prefix . 'callback_deleted_post' ) );
 	}
-
 }

--- a/tests/tests/connectors/test-class-connector-settings.php
+++ b/tests/tests/connectors/test-class-connector-settings.php
@@ -1,5 +1,6 @@
 <?php
 namespace WP_Stream;
+
 /**
  * Tests for Settings connector class callbacks.
  *
@@ -39,9 +40,14 @@ class Test_Connector_Settings extends WP_StreamTestCase {
 		// Test custom ignores.
 		$this->assertFalse( $this->mock->is_option_ignored( 'ignore_me' ) );
 
-		add_filter( 'wp_stream_is_option_ignored', function( $is_ignored, $option_name, $default_ignored ) {
-			return in_array( $option_name, array_merge( [ 'ignore_me' ], $default_ignored ), true );
-		}, 10, 3 );
+		add_filter(
+			'wp_stream_is_option_ignored',
+			function ( $is_ignored, $option_name, $default_ignored ) {
+				return in_array( $option_name, array_merge( array( 'ignore_me' ), $default_ignored ), true );
+			},
+			10,
+			3
+		);
 
 		$this->assertTrue( $this->mock->is_option_ignored( 'ignore_me' ) );
 	}
@@ -74,7 +80,7 @@ class Test_Connector_Settings extends WP_StreamTestCase {
 					),
 					$this->equalTo( null ),
 					$this->equalTo( 'settings' ),
-					$this->equalTo( 'updated' )
+					$this->equalTo( 'updated' ),
 				),
 				array(
 					$this->equalTo( __( '"%s" setting was updated', 'stream' ) ),
@@ -89,7 +95,7 @@ class Test_Connector_Settings extends WP_StreamTestCase {
 					),
 					$this->equalTo( null ),
 					$this->equalTo( 'permalink' ),
-					$this->equalTo( 'updated' )
+					$this->equalTo( 'updated' ),
 				),
 				array(
 					$this->equalTo( __( '"%s" setting was updated', 'stream' ) ),
@@ -104,7 +110,7 @@ class Test_Connector_Settings extends WP_StreamTestCase {
 					),
 					$this->equalTo( null ),
 					$this->equalTo( 'permalink' ),
-					$this->equalTo( 'updated' )
+					$this->equalTo( 'updated' ),
 				),
 				array(
 					$this->equalTo( __( '"%s" setting was updated', 'stream' ) ),
@@ -119,7 +125,7 @@ class Test_Connector_Settings extends WP_StreamTestCase {
 					),
 					$this->equalTo( null ),
 					$this->equalTo( 'permalink' ),
-					$this->equalTo( 'updated' )
+					$this->equalTo( 'updated' ),
 				)
 			);
 

--- a/tests/tests/connectors/test-class-connector-taxonomies.php
+++ b/tests/tests/connectors/test-class-connector-taxonomies.php
@@ -46,7 +46,7 @@ class Test_WP_Stream_Connector_Taxonomies extends WP_StreamTestCase {
 							'taxonomy'       => 'category',
 							'term_parent'    => 0,
 						);
-						return $expected === array_intersect_key( $expected, $subject );
+						return array_intersect_key( $expected, $subject ) === $expected;
 					}
 				),
 				$this->greaterThan( 0 ),

--- a/tests/tests/connectors/test-class-connector-taxonomies.php
+++ b/tests/tests/connectors/test-class-connector-taxonomies.php
@@ -4,6 +4,7 @@
  *
  * @package WP_Stream
  */
+
 namespace WP_Stream;
 
 class Test_WP_Stream_Connector_Taxonomies extends WP_StreamTestCase {
@@ -38,12 +39,12 @@ class Test_WP_Stream_Connector_Taxonomies extends WP_StreamTestCase {
 					)
 				),
 				$this->callback(
-					function( $subject ) {
+					function ( $subject ) {
 						$expected = array(
 							'term_name'      => 'test',
 							'taxonomy_label' => 'Category',
 							'taxonomy'       => 'category',
-							'term_parent'    => 0
+							'term_parent'    => 0,
 						);
 						return $expected === array_intersect_key( $expected, $subject );
 					}
@@ -81,7 +82,7 @@ class Test_WP_Stream_Connector_Taxonomies extends WP_StreamTestCase {
 						'taxonomy_label' => 'category',
 						'term_id'        => $term_data['term_id'],
 						'taxonomy'       => 'category',
-						'term_parent'    => 0
+						'term_parent'    => 0,
 					)
 				),
 				$this->greaterThan( 0 ),
@@ -117,7 +118,7 @@ class Test_WP_Stream_Connector_Taxonomies extends WP_StreamTestCase {
 						'taxonomy_label' => 'category',
 						'term_id'        => $term_data['term_id'],
 						'taxonomy'       => 'category',
-						'term_parent'    => 0
+						'term_parent'    => 0,
 					)
 				),
 				$this->greaterThan( 0 ),

--- a/tests/tests/connectors/test-class-connector-user-switching.php
+++ b/tests/tests/connectors/test-class-connector-user-switching.php
@@ -6,6 +6,7 @@
  *
  * @package WP_Stream
  */
+
 namespace WP_Stream;
 
 class Test_WP_Stream_Connector_User_Switching extends WP_StreamTestCase {
@@ -35,7 +36,7 @@ class Test_WP_Stream_Connector_User_Switching extends WP_StreamTestCase {
 
 	public function test_callback_switch_to_user() {
 		// Create and authenticate user to be switched from.
-		$old_user_id    = self::factory()->user->create(
+		$old_user_id = self::factory()->user->create(
 			array(
 				'user_login'   => 'oldtestuser',
 				'user_role'    => 'administrator',
@@ -45,7 +46,7 @@ class Test_WP_Stream_Connector_User_Switching extends WP_StreamTestCase {
 		wp_set_current_user( $old_user_id );
 
 		// Create user ID for destination user.
-		$user_id        = self::factory()->user->create(
+		$user_id = self::factory()->user->create(
 			array(
 				'user_login'   => 'testuser',
 				'user_role'    => 'administrator',
@@ -85,14 +86,14 @@ class Test_WP_Stream_Connector_User_Switching extends WP_StreamTestCase {
 
 	public function test_callback_switch_back_user() {
 		// Create and authenticate users for later use.
-		$old_user_id    = self::factory()->user->create(
+		$old_user_id = self::factory()->user->create(
 			array(
 				'user_login'   => 'oldtestuser',
 				'user_role'    => 'administrator',
 				'display_name' => 'oldtestuserdisplay',
 			)
 		);
-		$user_id        = self::factory()->user->create(
+		$user_id     = self::factory()->user->create(
 			array(
 				'user_login'   => 'testuser',
 				'user_role'    => 'administrator',
@@ -135,7 +136,7 @@ class Test_WP_Stream_Connector_User_Switching extends WP_StreamTestCase {
 
 	public function test_callback_switch_off_user() {
 		// Create/authenticate user for later use.
-		$user_id        = self::factory()->user->create(
+		$user_id = self::factory()->user->create(
 			array(
 				'user_login'   => 'testuser',
 				'user_role'    => 'administrator',

--- a/tests/tests/connectors/test-class-connector-users.php
+++ b/tests/tests/connectors/test-class-connector-users.php
@@ -4,6 +4,7 @@
  *
  * @package WP_Stream
  */
+
 namespace WP_Stream;
 
 class Test_WP_Stream_Connector_Users extends WP_StreamTestCase {
@@ -38,7 +39,7 @@ class Test_WP_Stream_Connector_Users extends WP_StreamTestCase {
 					$this->greaterThan( 0 ),
 					$this->equalTo( 'users' ),
 					$this->equalTo( 'created' ),
-					$this->greaterThan( 0 )
+					$this->greaterThan( 0 ),
 				),
 				array(
 					$this->equalTo(
@@ -57,7 +58,7 @@ class Test_WP_Stream_Connector_Users extends WP_StreamTestCase {
 					$this->greaterThan( 0 ),
 					$this->equalTo( 'users' ),
 					$this->equalTo( 'created' ),
-					$this->greaterThan( 0 )
+					$this->greaterThan( 0 ),
 				)
 			);
 
@@ -86,7 +87,7 @@ class Test_WP_Stream_Connector_Users extends WP_StreamTestCase {
 					$this->equalTo( $user_id ),
 					$this->equalTo( 'profiles' ),
 					$this->equalTo( 'password-reset' ),
-					$this->equalTo( $user_id )
+					$this->equalTo( $user_id ),
 				)
 			);
 
@@ -113,14 +114,14 @@ class Test_WP_Stream_Connector_Users extends WP_StreamTestCase {
 					$this->equalTo( $user_id ),
 					$this->equalTo( 'sessions' ),
 					$this->equalTo( 'forgot-password' ),
-					$this->equalTo( $user_id )
+					$this->equalTo( $user_id ),
 				),
 				array(
 					$this->equalTo( __( '%s\'s profile was updated', 'stream' ) ),
 					$this->equalTo( array( 'display_name' => 'TestGuy' ) ),
 					$this->equalTo( $user_id ),
 					$this->equalTo( 'profiles' ),
-					$this->equalTo( 'updated' )
+					$this->equalTo( 'updated' ),
 				)
 			);
 
@@ -171,7 +172,7 @@ class Test_WP_Stream_Connector_Users extends WP_StreamTestCase {
 
 	public function test_callback_deleted_user() {
 		// Create Users.
-		$user_id = self::factory()->user->create( array( 'display_name' => 'TestGuy' ));
+		$user_id = self::factory()->user->create( array( 'display_name' => 'TestGuy' ) );
 		$user    = get_user_by( 'ID', $user_id );
 
 		// Expected log calls.
@@ -195,7 +196,7 @@ class Test_WP_Stream_Connector_Users extends WP_StreamTestCase {
 					$this->equalTo( $user_id ),
 					$this->equalTo( 'users' ),
 					$this->equalTo( 'deleted' ),
-					$this->equalTo( 0 )
+					$this->equalTo( 0 ),
 				),
 				array(
 					$this->equalTo( esc_html__( 'User account #%d was deleted', 'stream' ) ),
@@ -208,7 +209,7 @@ class Test_WP_Stream_Connector_Users extends WP_StreamTestCase {
 					$this->equalTo( $user_id ),
 					$this->equalTo( 'users' ),
 					$this->equalTo( 'deleted' ),
-					$this->equalTo( 0 )
+					$this->equalTo( 0 ),
 				)
 			);
 
@@ -223,7 +224,7 @@ class Test_WP_Stream_Connector_Users extends WP_StreamTestCase {
 
 	public function test_callback_set_user_role() {
 		// Create user.
-		$user_id = self::factory()->user->create( array( 'display_name' => 'TestGuy' ));
+		$user_id = self::factory()->user->create( array( 'display_name' => 'TestGuy' ) );
 		$user    = get_user_by( 'id', $user_id );
 
 		// Expected log calls.

--- a/tests/tests/test-class-admin.php
+++ b/tests/tests/test-class-admin.php
@@ -240,11 +240,11 @@ class Test_Admin extends WP_StreamTestCase {
 		$this->assertNotFalse( $meta_id );
 
 		// Check that records exist
-		$stream_result = $wpdb->get_row( "SELECT * FROM {$wpdb->stream} WHERE ID = $stream_id" );
+		$stream_result = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->stream} WHERE ID = %d", $stream_id ) );
 		$this->assertNotEmpty( $stream_result );
 
 		// Check that meta exists
-		$meta_result = $wpdb->get_row( "SELECT * FROM {$wpdb->streammeta} WHERE meta_id = $meta_id" );
+		$meta_result = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->streammeta} WHERE meta_id = %d", $meta_id ) );
 		$this->assertNotEmpty( $meta_result );
 
 		// Clear records and meta
@@ -298,11 +298,11 @@ class Test_Admin extends WP_StreamTestCase {
 		$this->admin->purge_scheduled_action();
 
 		// Check if the old records have been cleared
-		$stream_results = $wpdb->get_row( "SELECT * FROM {$wpdb->stream} WHERE ID = $stream_id" );
+		$stream_results = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->stream} WHERE ID = %d", $stream_id ) );
 		$this->assertEmpty( $stream_results );
 
 		// Check if the old meta has been cleared
-		$meta_results = $wpdb->get_row( "SELECT * FROM {$wpdb->streammeta} WHERE meta_id = $meta_id" );
+		$meta_results = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->streammeta} WHERE meta_id = %d", $meta_id ) );
 		$this->assertEmpty( $meta_results );
 	}
 

--- a/tests/tests/test-class-admin.php
+++ b/tests/tests/test-class-admin.php
@@ -392,6 +392,7 @@ class Test_Admin extends WP_StreamTestCase {
 		try {
 			$this->_handleAjax( 'wp_stream_filters' );
 		} catch ( WPAjaxDieStopException $e ) {
+			// Do nothing.
 		}
 
 		// Check that the exception was thrown.

--- a/tests/tests/test-class-admin.php
+++ b/tests/tests/test-class-admin.php
@@ -133,8 +133,7 @@ class Test_Admin extends WP_StreamTestCase {
 
 	public function test_register_menu() {
 		global $menu;
-		$menu = array();
-		// phpcs override okay
+		$menu = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		do_action( 'admin_menu' );
 

--- a/tests/tests/test-class-admin.php
+++ b/tests/tests/test-class-admin.php
@@ -15,7 +15,7 @@ class Test_Admin extends WP_StreamTestCase {
 		$this->admin = $this->plugin->admin;
 		$this->assertNotEmpty( $this->admin );
 
-		//Add admin user to test caps
+		// Add admin user to test caps
 		// We need to change user to verify editing option as admin or editor
 		$administrator_id = $this->factory->user->create(
 			array(
@@ -105,8 +105,8 @@ class Test_Admin extends WP_StreamTestCase {
 	}
 
 	public function test_admin_notices() {
-		$allowed_html    = '<progress class="migration" max="100"></progress>';
-		$disallowed_html = '<iframe></iframe>';
+		$allowed_html         = '<progress class="migration" max="100"></progress>';
+		$disallowed_html      = '<iframe></iframe>';
 		$this->admin->notices = array(
 			array(
 				'message'  => "I'm sorry, Dave. I'm afraid I can't do that. $disallowed_html",
@@ -133,7 +133,8 @@ class Test_Admin extends WP_StreamTestCase {
 
 	public function test_register_menu() {
 		global $menu;
-		$menu = array(); //phpcs override okay
+		$menu = array();
+		// phpcs override okay
 
 		do_action( 'admin_menu' );
 
@@ -196,7 +197,7 @@ class Test_Admin extends WP_StreamTestCase {
 		}
 		$_GET['page'] = $this->admin->records_page_slug;
 
-		$classes = 'sit-down-calmy take-a-stress-pill think-things-over';
+		$classes            = 'sit-down-calmy take-a-stress-pill think-things-over';
 		$admin_body_classes = $this->admin->admin_body_class( $classes );
 
 		$this->assertStringContainsString( 'think-things-over ', $admin_body_classes );
@@ -218,7 +219,7 @@ class Test_Admin extends WP_StreamTestCase {
 		$this->assertStringContainsString( "#toplevel_page_{$this->admin->records_page_slug}", $dependency->extra['after'][0] );
 	}
 
-	/*
+	/**
 	 * Also tests private method erase_stream_records
 	 */
 	public function test_wp_ajax_reset() {
@@ -270,11 +271,11 @@ class Test_Admin extends WP_StreamTestCase {
 	public function test_purge_scheduled_action() {
 		// Set the TTL to one day
 		if ( is_multisite() && is_plugin_active_for_network( $this->plugin->locations['plugin'] ) ) {
-			$options = (array) get_site_option( 'wp_stream_network', array() );
+			$options                        = (array) get_site_option( 'wp_stream_network', array() );
 			$options['general_records_ttl'] = '1';
 			update_site_option( 'wp_stream_network', $options );
 		} else {
-			$options = (array) get_option( 'wp_stream', array() );
+			$options                        = (array) get_option( 'wp_stream', array() );
 			$options['general_records_ttl'] = '1';
 			update_option( 'wp_stream', $options );
 		}
@@ -282,7 +283,7 @@ class Test_Admin extends WP_StreamTestCase {
 		global $wpdb;
 
 		// Create (two day old) dummy records
-		$stream_data = $this->dummy_stream_data();
+		$stream_data            = $this->dummy_stream_data();
 		$stream_data['created'] = gmdate( 'Y-m-d h:i:s', strtotime( '2 days ago' ) );
 		$wpdb->insert( $wpdb->stream, $stream_data );
 		$stream_id = $wpdb->insert_id;
@@ -346,7 +347,7 @@ class Test_Admin extends WP_StreamTestCase {
 		$this->assertInstanceOf( '\WP_Stream\List_Table', $this->admin->list_table );
 	}
 
-	/*
+	/**
 	 * Also tests private method role_can_view
 	 */
 	public function test_filter_user_caps() {
@@ -359,7 +360,7 @@ class Test_Admin extends WP_StreamTestCase {
 		$this->assertFalse( $user->has_cap( $this->admin->view_cap ) );
 	}
 
-	/*
+	/**
 	 * Also tests private method role_can_view
 	 */
 	public function test_filter_role_caps() {
@@ -384,14 +385,15 @@ class Test_Admin extends WP_StreamTestCase {
 		$this->_setRole( 'subscriber' );
 
 		$_POST['filter'] = 'user_id';
-		$_POST['q'] = $user->display_name;
-		$_POST['nonce'] = wp_create_nonce( 'stream_filters_user_search_nonce' );
+		$_POST['q']      = $user->display_name;
+		$_POST['nonce']  = wp_create_nonce( 'stream_filters_user_search_nonce' );
 
 		$this->expectException( 'WPAjaxDieStopException' );
 
 		try {
 			$this->_handleAjax( 'wp_stream_filters' );
-		} catch ( WPAjaxDieStopException $e ) {}
+		} catch ( WPAjaxDieStopException $e ) {
+		}
 
 		// Check that the exception was thrown.
 		$this->assertTrue( isset( $e ) );
@@ -403,7 +405,7 @@ class Test_Admin extends WP_StreamTestCase {
 		$this->_setRole( 'administrator' );
 
 		$this->_handleAjax( 'wp_stream_filters' );
-		$json = $this-> _last_response;
+		$json = $this->_last_response;
 
 		$this->assertNotEmpty( $json );
 		$data = json_decode( $json );
@@ -454,16 +456,16 @@ class Test_Admin extends WP_StreamTestCase {
 	private function dummy_stream_data() {
 		return array(
 			'object_id' => null,
-			'site_id' => '1',
-			'blog_id' => get_current_blog_id(),
-			'user_id' => '1',
+			'site_id'   => '1',
+			'blog_id'   => get_current_blog_id(),
+			'user_id'   => '1',
 			'user_role' => 'administrator',
-			'created' => gmdate( 'Y-m-d H:i:s' ),
-			'summary' => '"Hello Dave" plugin activated',
-			'ip' => '192.168.0.1',
+			'created'   => gmdate( 'Y-m-d H:i:s' ),
+			'summary'   => '"Hello Dave" plugin activated',
+			'ip'        => '192.168.0.1',
 			'connector' => 'installer',
-			'context' => 'plugins',
-			'action' => 'activated',
+			'context'   => 'plugins',
+			'action'    => 'activated',
 		);
 	}
 

--- a/tests/tests/test-class-alert-trigger.php
+++ b/tests/tests/test-class-alert-trigger.php
@@ -10,19 +10,19 @@ namespace WP_Stream;
 abstract class Test_Alert_Trigger extends WP_StreamTestCase {
 	public $trigger;
 
-	function test_construct() {
+	public function test_construct() {
 		// assert that 2 actions + 2 filters have been added
 	}
 
-	function test_check_record() {
+	public function test_check_record() {
 		$data   = $this->dummy_stream_data();
 		$status = $this->trigger->check_record( true, null, $data, $this->alert );
 		$this->assertTrue( $status );
 	}
 
-	abstract function test_check_record_bad();
+	abstract public function test_check_record_bad();
 
-	function test_add_fields() {
+	public function test_add_fields() {
 		$form = new Form_Generator();
 		$this->assertCount( 0, $form->fields );
 
@@ -30,9 +30,9 @@ abstract class Test_Alert_Trigger extends WP_StreamTestCase {
 		$this->assertNotCount( 0, $form->fields );
 	}
 
-	abstract function test_save_fields();
+	abstract public function test_save_fields();
 
-	function test_get_display_value() {
+	public function test_get_display_value() {
 		$output = $this->trigger->get_display_value( 'normal', $this->alert );
 		$this->assertNotEmpty( $output );
 	}

--- a/tests/tests/test-class-alert-trigger.php
+++ b/tests/tests/test-class-alert-trigger.php
@@ -1,7 +1,9 @@
 <?php
 namespace WP_Stream;
+
 /**
  * Class Test_Alert_Trigger
+ *
  * @package WP_Stream
  * @group alerts
  */
@@ -13,7 +15,7 @@ abstract class Test_Alert_Trigger extends WP_StreamTestCase {
 	}
 
 	function test_check_record() {
-		$data = $this->dummy_stream_data();
+		$data   = $this->dummy_stream_data();
 		$status = $this->trigger->check_record( true, null, $data, $this->alert );
 		$this->assertTrue( $status );
 	}
@@ -21,7 +23,7 @@ abstract class Test_Alert_Trigger extends WP_StreamTestCase {
 	abstract function test_check_record_bad();
 
 	function test_add_fields() {
-		$form = new Form_Generator;
+		$form = new Form_Generator();
 		$this->assertCount( 0, $form->fields );
 
 		$this->trigger->add_fields( $form, $this->alert );

--- a/tests/tests/test-class-alert.php
+++ b/tests/tests/test-class-alert.php
@@ -9,7 +9,7 @@ namespace WP_Stream;
  */
 class Test_Alert extends WP_StreamTestCase {
 
-	function test_construct() {
+	public function test_construct() {
 		$data  = $this->dummy_alert_data();
 		$alert = new Alert( $data, $this->plugin );
 
@@ -18,7 +18,7 @@ class Test_Alert extends WP_StreamTestCase {
 		}
 	}
 
-	function test_construct_blank() {
+	public function test_construct_blank() {
 		$data  = $this->dummy_alert_data();
 		$alert = new Alert( null, $this->plugin );
 
@@ -31,7 +31,7 @@ class Test_Alert extends WP_StreamTestCase {
 		$this->assertEquals( $alert->alert_meta, array() );
 	}
 
-	function test_save() {
+	public function test_save() {
 		$data     = $this->dummy_alert_data();
 		$data->ID = 0;
 		$alert    = new Alert( $data, $this->plugin );
@@ -46,13 +46,13 @@ class Test_Alert extends WP_StreamTestCase {
 		$this->assertEquals( 'none', $alert_type );
 	}
 
-	function test_process_settings_form() {
+	public function test_process_settings_form() {
 		$this->markTestIncomplete(
 			'Not implemented yet.'
 		);
 	}
 
-	function test_get_meta() {
+	public function test_get_meta() {
 		$data     = $this->dummy_alert_data();
 		$data->ID = 0;
 		$alert    = new Alert( $data, $this->plugin );
@@ -62,7 +62,7 @@ class Test_Alert extends WP_StreamTestCase {
 		$this->assertEquals( 'highlight', $value );
 	}
 
-	function test_update_meta() {
+	public function test_update_meta() {
 		$data     = $this->dummy_alert_data();
 		$data->ID = 0;
 		$alert    = new Alert( $data, $this->plugin );
@@ -77,7 +77,7 @@ class Test_Alert extends WP_StreamTestCase {
 		$this->assertEquals( 'test_value', $value );
 	}
 
-	function test_get_title() {
+	public function test_get_title() {
 		$data  = $this->dummy_alert_data();
 		$alert = new Alert( $data, $this->plugin );
 
@@ -93,7 +93,7 @@ class Test_Alert extends WP_StreamTestCase {
 		$this->assertEquals( 'Any User > Posts > Updated', $alert->get_title() );
 	}
 
-	function test_get_alert_type_obj() {
+	public function test_get_alert_type_obj() {
 		$data  = $this->dummy_alert_data();
 		$alert = new Alert( $data, $this->plugin );
 
@@ -104,7 +104,7 @@ class Test_Alert extends WP_StreamTestCase {
 		$this->assertEquals( new Alert_Type_Highlight( $this->plugin ), $alert->get_alert_type_obj() );
 	}
 
-	function test_check_record() {
+	public function test_check_record() {
 		$action = new \MockAction();
 		$data   = $this->dummy_alert_data();
 		$alert  = new Alert( $data, $this->plugin );
@@ -115,7 +115,7 @@ class Test_Alert extends WP_StreamTestCase {
 		$this->assertEquals( 1, $action->get_call_count() );
 	}
 
-	function test_send_alert() {
+	public function test_send_alert() {
 		$this->markTestIncomplete(
 			'Not implemented yet.'
 		);

--- a/tests/tests/test-class-alert.php
+++ b/tests/tests/test-class-alert.php
@@ -1,14 +1,16 @@
 <?php
 namespace WP_Stream;
+
 /**
  * Class Test_Alert
+ *
  * @package WP_Stream
  * @group alerts
  */
 class Test_Alert extends WP_StreamTestCase {
 
 	function test_construct() {
-		$data	= $this->dummy_alert_data();
+		$data  = $this->dummy_alert_data();
 		$alert = new Alert( $data, $this->plugin );
 
 		foreach ( $data as $field => $value ) {
@@ -17,7 +19,7 @@ class Test_Alert extends WP_StreamTestCase {
 	}
 
 	function test_construct_blank() {
-		$data	= $this->dummy_alert_data();
+		$data  = $this->dummy_alert_data();
 		$alert = new Alert( null, $this->plugin );
 
 		$this->assertEmpty( $alert->ID );
@@ -42,7 +44,6 @@ class Test_Alert extends WP_StreamTestCase {
 		$alert->save();
 		$alert_type = $alert->get_meta( 'alert_type', true );
 		$this->assertEquals( 'none', $alert_type );
-
 	}
 
 	function test_process_settings_form() {
@@ -52,9 +53,9 @@ class Test_Alert extends WP_StreamTestCase {
 	}
 
 	function test_get_meta() {
-		$data  = $this->dummy_alert_data();
+		$data     = $this->dummy_alert_data();
 		$data->ID = 0;
-		$alert = new Alert( $data, $this->plugin );
+		$alert    = new Alert( $data, $this->plugin );
 		$alert->save();
 
 		$value = $alert->get_meta( 'alert_type', true );
@@ -77,8 +78,8 @@ class Test_Alert extends WP_StreamTestCase {
 	}
 
 	function test_get_title() {
-		$data		 = $this->dummy_alert_data();
-		$alert		= new Alert( $data, $this->plugin );
+		$data  = $this->dummy_alert_data();
+		$alert = new Alert( $data, $this->plugin );
 
 		$this->assertEquals( 'Administrator > Plugins > Activated', $alert->get_title() );
 
@@ -128,8 +129,8 @@ class Test_Alert extends WP_StreamTestCase {
 			'author'     => '1',
 			'alert_type' => 'highlight',
 			'alert_meta' => array(
-				'trigger_action'	=> 'activated',
-				'trigger_author'	=> 'administrator',
+				'trigger_action'  => 'activated',
+				'trigger_author'  => 'administrator',
 				'trigger_context' => 'plugins',
 			),
 		);

--- a/tests/tests/test-class-alerts-list.php
+++ b/tests/tests/test-class-alerts-list.php
@@ -9,12 +9,12 @@ namespace WP_Stream;
  */
 class Test_Alerts_List extends WP_StreamTestCase {
 
-	function test_construct() {
+	public function test_construct() {
 		$alerts_list = new Alerts_List( $this->plugin );
 		$this->assertNotEmpty( $alerts_list->plugin );
 	}
 
-	function test_suppress_bulk_actions() {
+	public function test_suppress_bulk_actions() {
 		$alerts_list      = new Alerts_List( $this->plugin );
 		$actions          = array(
 			'edit'          => 'edit',
@@ -29,7 +29,7 @@ class Test_Alerts_List extends WP_StreamTestCase {
 		$this->assertEquals( $expected_actions, $filtered_actions );
 	}
 
-	function test_suppress_quick_edit() {
+	public function test_suppress_quick_edit() {
 		$alerts_list      = new Alerts_List( $this->plugin );
 		$actions          = array(
 			'edit'                 => 'edit',
@@ -42,19 +42,19 @@ class Test_Alerts_List extends WP_StreamTestCase {
 		$this->assertEquals( $actions, $filtered_actions );
 	}
 
-	function test_custom_column_actions() {
+	public function test_custom_column_actions() {
 		$alerts_list                = new Alerts_List( $this->plugin );
 		$custom_column_actions_html = $alerts_list->custom_column_actions( 42 );
 		$this->assertNotEmpty( $custom_column_actions_html );
 	}
-	function test_display_custom_quick_edit() {
+	public function test_display_custom_quick_edit() {
 		$alerts_list = new Alerts_List( $this->plugin );
 		ob_start();
 		$alerts_list->display_custom_quick_edit();
 		$output = ob_get_clean();
 		$this->assertEmpty( $output );
 	}
-	function test_enqueue_scripts() {
+	public function test_enqueue_scripts() {
 		$alerts_list = new Alerts_List( $this->plugin );
 		global $current_screen;
 		$current_screen->id = 'edit-wp_stream_alerts';

--- a/tests/tests/test-class-alerts-list.php
+++ b/tests/tests/test-class-alerts-list.php
@@ -1,11 +1,12 @@
 <?php
 namespace WP_Stream;
+
 /**
  * Class Test_Alerts_List
+ *
  * @package WP_Stream
  * @group   alerts
  */
-
 class Test_Alerts_List extends WP_StreamTestCase {
 
 	function test_construct() {
@@ -42,19 +43,19 @@ class Test_Alerts_List extends WP_StreamTestCase {
 	}
 
 	function test_custom_column_actions() {
-		$alerts_list      = new Alerts_List( $this->plugin );
-		$custom_column_actions_html =  $alerts_list->custom_column_actions( 42 );
+		$alerts_list                = new Alerts_List( $this->plugin );
+		$custom_column_actions_html = $alerts_list->custom_column_actions( 42 );
 		$this->assertNotEmpty( $custom_column_actions_html );
 	}
 	function test_display_custom_quick_edit() {
-		$alerts_list      = new Alerts_List( $this->plugin );
+		$alerts_list = new Alerts_List( $this->plugin );
 		ob_start();
 		$alerts_list->display_custom_quick_edit();
 		$output = ob_get_clean();
 		$this->assertEmpty( $output );
 	}
 	function test_enqueue_scripts() {
-		$alerts_list      = new Alerts_List( $this->plugin );
+		$alerts_list = new Alerts_List( $this->plugin );
 		global $current_screen;
 		$current_screen->id = 'edit-wp_stream_alerts';
 		$alerts_list->enqueue_scripts( '' );

--- a/tests/tests/test-class-alerts.php
+++ b/tests/tests/test-class-alerts.php
@@ -9,18 +9,18 @@ namespace WP_Stream;
  */
 class Test_Alerts extends WP_StreamTestCase {
 
-	function tearDown(): void {
+	public function tearDown(): void {
 		// See test_load_bad_alert_type() and test_load_bad_alert_trigger.
 		remove_filter( 'wp_stream_alert_types', array( $this, 'callback_load_bad_alert_register' ), 10, 1 );
 		remove_filter( 'wp_stream_alert_triggers', array( $this, 'callback_load_bad_alert_register' ), 10, 1 );
 	}
 
-	function test_construct() {
+	public function test_construct() {
 		$alerts = new Alerts( $this->plugin );
 		$this->assertNotEmpty( $alerts->plugin );
 	}
 
-	function test_load_alert_types() {
+	public function test_load_alert_types() {
 		$action = new \MockAction();
 		add_filter( 'wp_stream_alert_types', array( $action, 'filter' ) );
 
@@ -40,7 +40,7 @@ class Test_Alerts extends WP_StreamTestCase {
 	 *
 	 * @requires PHPUnit 5.7
 	 */
-	function test_load_bad_alert_type() {
+	public function test_load_bad_alert_type() {
 		$alerts                    = new Alerts( $this->plugin );
 		$alert_types_before_filter = count( $alerts->alert_types );
 		unset( $alerts );
@@ -52,7 +52,7 @@ class Test_Alerts extends WP_StreamTestCase {
 		$this->assertEquals( $alert_types_before_filter, $alert_types_after_filter );
 	}
 
-	function test_load_alert_triggers() {
+	public function test_load_alert_triggers() {
 		$action = new \MockAction();
 		add_filter( 'wp_stream_alert_triggers', array( $action, 'filter' ) );
 
@@ -70,7 +70,7 @@ class Test_Alerts extends WP_StreamTestCase {
 	/**
 	 * Test bad trigger is not added.
 	 */
-	function test_load_bad_alert_trigger() {
+	public function test_load_bad_alert_trigger() {
 		$alerts                       = new Alerts( $this->plugin );
 		$alert_triggers_before_filter = count( $alerts->alert_triggers );
 		unset( $alerts );
@@ -82,24 +82,24 @@ class Test_Alerts extends WP_StreamTestCase {
 		$this->assertEquals( $alert_triggers_before_filter, $alert_triggers_after_filter );
 	}
 
-	function callback_load_bad_alert_register( $classes ) {
+	public function callback_load_bad_alert_register( $classes ) {
 		$classes['bad_alert_trigger'] = new \stdClass();
 		return $classes;
 	}
 
-	function test_is_valid_alert_type() {
+	public function test_is_valid_alert_type() {
 		$alerts = new Alerts( $this->plugin );
 		$this->assertFalse( $alerts->is_valid_alert_type( new \stdClass() ) );
 		$this->assertFalse( $alerts->is_valid_alert_type( new Alert_Trigger_Action( $this->plugin ) ) );
 	}
 
-	function test_is_valid_alert_trigger() {
+	public function test_is_valid_alert_trigger() {
 		$alerts = new Alerts( $this->plugin );
 		$this->assertFalse( $alerts->is_valid_alert_trigger( new \stdClass() ) );
 		$this->assertFalse( $alerts->is_valid_alert_trigger( new Alert_Type_None( $this->plugin ) ) );
 	}
 
-	function test_check_records() {
+	public function test_check_records() {
 		$this->markTestIncomplete(
 			'This test is incomplete.'
 		);
@@ -117,7 +117,7 @@ class Test_Alerts extends WP_StreamTestCase {
 		$this->assertEquals( 1, $action->get_call_count() );
 	}
 
-	function test_register_post_type() {
+	public function test_register_post_type() {
 		global $wp_post_types, $wp_post_statuses;
 		if ( isset( $wp_post_types['wp_stream_alerts'] ) ) {
 			unset( $wp_post_types['wp_stream_alerts'] );
@@ -158,7 +158,7 @@ class Test_Alerts extends WP_StreamTestCase {
 		$this->assertTrue( $post_status_obj->show_in_admin_status_list );
 	}
 
-	function test_get_alert() {
+	public function test_get_alert() {
 		$alerts = new Alerts( $this->plugin );
 
 		$data           = $this->dummy_alert_data();
@@ -170,7 +170,7 @@ class Test_Alerts extends WP_StreamTestCase {
 		$this->assertEquals( $original_alert, $alert );
 	}
 
-	function test_get_alert_blank() {
+	public function test_get_alert_blank() {
 		$alerts = new Alerts( $this->plugin );
 		$alert  = $alerts->get_alert();
 
@@ -183,7 +183,7 @@ class Test_Alerts extends WP_StreamTestCase {
 		$this->assertEquals( $alert->alert_meta, array() );
 	}
 
-	function test_register_menu() {
+	public function test_register_menu() {
 		global $submenu;
 
 		$this->markTestIncomplete();
@@ -197,7 +197,7 @@ class Test_Alerts extends WP_StreamTestCase {
 		$this->assertNotEmpty( $submenu[ $this->plugin->admin->records_page_slug ] );
 	}
 
-	function test_display_notification_box() {
+	public function test_display_notification_box() {
 		$alerts = new Alerts( $this->plugin );
 
 		$data     = $this->dummy_alert_data();
@@ -220,7 +220,7 @@ class Test_Alerts extends WP_StreamTestCase {
 		$this->assertTrue( $form_test, 'Alert type settings form is present' );
 	}
 
-	function test_load_alerts_settings() {
+	public function test_load_alerts_settings() {
 		$alerts = new Alerts( $this->plugin );
 
 		// Create administrator user to test with.
@@ -249,7 +249,7 @@ class Test_Alerts extends WP_StreamTestCase {
 		$this->assertStringContainsString( 'Highlight this alert on the Stream records page.', $response->data->html );
 	}
 
-	function test_load_alerts_settings_bad_alert_type() {
+	public function test_load_alerts_settings_bad_alert_type() {
 		$alerts = new Alerts( $this->plugin );
 
 		// Create administrator user to test with.
@@ -278,7 +278,7 @@ class Test_Alerts extends WP_StreamTestCase {
 		$this->assertEmpty( $response->data->html );
 	}
 
-	function test_load_alerts_settings_missing_caps() {
+	public function test_load_alerts_settings_missing_caps() {
 		$alerts = new Alerts( $this->plugin );
 
 		// Create a regular user for testing.
@@ -307,7 +307,7 @@ class Test_Alerts extends WP_StreamTestCase {
 		$this->assertEquals( 'You do not have permission to do this.', $response->data->message );
 	}
 
-	function test_display_triggers_box() {
+	public function test_display_triggers_box() {
 		$alerts = new Alerts( $this->plugin );
 
 		$data     = $this->dummy_alert_data();
@@ -327,7 +327,7 @@ class Test_Alerts extends WP_StreamTestCase {
 		$this->assertTrue( $len_test, 'Nonce field is present.' );
 	}
 
-	function test_display_submit_box() {
+	public function test_display_submit_box() {
 		$alerts = new Alerts( $this->plugin );
 
 		$data     = $this->dummy_alert_data();
@@ -347,7 +347,7 @@ class Test_Alerts extends WP_StreamTestCase {
 		$this->assertTrue( $len_test, 'Alert is shown as enabled.' );
 	}
 
-	function test_get_notification_values() {
+	public function test_get_notification_values() {
 		$alerts = new Alerts( $this->plugin );
 
 		$count  = count( $alerts->alert_types );
@@ -355,13 +355,13 @@ class Test_Alerts extends WP_StreamTestCase {
 		$this->assertEquals( $count, count( $output ) );
 	}
 
-	function test_save_post_info() {
+	public function test_save_post_info() {
 		$this->markTestIncomplete(
 			'This test is incomplete'
 		);
 	}
 
-	function test_get_actions() {
+	public function test_get_actions() {
 		$alerts = new Alerts( $this->plugin );
 		try {
 			$_POST['connector'] = '';
@@ -376,7 +376,7 @@ class Test_Alerts extends WP_StreamTestCase {
 		$this->assertTrue( $response->success );
 		$this->assertNotEmpty( $response->data );
 	}
-	function test_save_new_alert_with_parent_context() {
+	public function test_save_new_alert_with_parent_context() {
 		// Switch current user to an administrator.
 		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );
@@ -398,7 +398,7 @@ class Test_Alerts extends WP_StreamTestCase {
 		$this->assertObjectHasProperty( 'success', $response );
 		$this->assertTrue( $response->success );
 	}
-	function test_save_new_alert_with_child_context() {
+	public function test_save_new_alert_with_child_context() {
 		// Switch current user to an administrator.
 		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );
@@ -426,7 +426,7 @@ class Test_Alerts extends WP_StreamTestCase {
 	 *
 	 * @requires PHPUnit 5.7
 	 */
-	function test_save_new_alert_no_nonce() {
+	public function test_save_new_alert_no_nonce() {
 		// Switch current user to an administrator.
 		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );
@@ -455,7 +455,7 @@ class Test_Alerts extends WP_StreamTestCase {
 	 *
 	 * @requires PHPUnit 5.7
 	 */
-	function test_save_new_alert_invalid_nonce() {
+	public function test_save_new_alert_invalid_nonce() {
 		// Switch current user to an administrator.
 		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );
@@ -485,7 +485,7 @@ class Test_Alerts extends WP_StreamTestCase {
 	 *
 	 * @requires PHPUnit 5.7
 	 */
-	function test_save_new_alert_mismatched_nonce() {
+	public function test_save_new_alert_mismatched_nonce() {
 		// Switch current user to an administrator.
 		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );
@@ -515,7 +515,7 @@ class Test_Alerts extends WP_StreamTestCase {
 	 *
 	 * @requires PHPUnit 5.7
 	 */
-	function test_save_new_alert_missing_caps() {
+	public function test_save_new_alert_missing_caps() {
 		// Switch current user to a subscriber.
 		$user_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
 		wp_set_current_user( $user_id );
@@ -540,7 +540,7 @@ class Test_Alerts extends WP_StreamTestCase {
 		}
 	}
 
-	function test_get_new_alert_triggers_notifications() {
+	public function test_get_new_alert_triggers_notifications() {
 		// Switch current user to an administrator.
 		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );
@@ -563,7 +563,7 @@ class Test_Alerts extends WP_StreamTestCase {
 		$this->assertTrue( $response->success );
 	}
 
-	function test_get_new_alert_triggers_notifications_missing_caps() {
+	public function test_get_new_alert_triggers_notifications_missing_caps() {
 		// Switch current user to a subscriber.
 		$user_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
 		wp_set_current_user( $user_id );

--- a/tests/tests/test-class-alerts.php
+++ b/tests/tests/test-class-alerts.php
@@ -1,7 +1,9 @@
 <?php
 namespace WP_Stream;
+
 /**
  * Class Test_Alerts
+ *
  * @package WP_Stream
  * @group alerts
  */
@@ -34,15 +36,17 @@ class Test_Alerts extends WP_StreamTestCase {
 	}
 
 	/**
+	 * Test bad alert type is not added.
+	 *
 	 * @requires PHPUnit 5.7
 	 */
 	function test_load_bad_alert_type() {
-		$alerts = new Alerts( $this->plugin );
+		$alerts                    = new Alerts( $this->plugin );
 		$alert_types_before_filter = count( $alerts->alert_types );
 		unset( $alerts );
 
 		add_filter( 'wp_stream_alert_types', array( $this, 'callback_load_bad_alert_register' ), 10, 1 );
-		$alerts = new Alerts( $this->plugin );
+		$alerts                   = new Alerts( $this->plugin );
 		$alert_types_after_filter = count( $alerts->alert_types );
 
 		$this->assertEquals( $alert_types_before_filter, $alert_types_after_filter );
@@ -67,12 +71,12 @@ class Test_Alerts extends WP_StreamTestCase {
 	 * Test bad trigger is not added.
 	 */
 	function test_load_bad_alert_trigger() {
-		$alerts = new Alerts( $this->plugin );
+		$alerts                       = new Alerts( $this->plugin );
 		$alert_triggers_before_filter = count( $alerts->alert_triggers );
 		unset( $alerts );
 
 		add_filter( 'wp_stream_alert_triggers', array( $this, 'callback_load_bad_alert_register' ), 10, 1 );
-		$alerts = new Alerts( $this->plugin );
+		$alerts                      = new Alerts( $this->plugin );
 		$alert_triggers_after_filter = count( $alerts->alert_triggers );
 
 		$this->assertEquals( $alert_triggers_before_filter, $alert_triggers_after_filter );
@@ -85,26 +89,27 @@ class Test_Alerts extends WP_StreamTestCase {
 
 	function test_is_valid_alert_type() {
 		$alerts = new Alerts( $this->plugin );
-		$this->assertFalse( $alerts->is_valid_alert_type( new \stdClass ) );
+		$this->assertFalse( $alerts->is_valid_alert_type( new \stdClass() ) );
 		$this->assertFalse( $alerts->is_valid_alert_type( new Alert_Trigger_Action( $this->plugin ) ) );
 	}
 
 	function test_is_valid_alert_trigger() {
 		$alerts = new Alerts( $this->plugin );
-		$this->assertFalse( $alerts->is_valid_alert_trigger( new \stdClass ) );
+		$this->assertFalse( $alerts->is_valid_alert_trigger( new \stdClass() ) );
 		$this->assertFalse( $alerts->is_valid_alert_trigger( new Alert_Type_None( $this->plugin ) ) );
 	}
 
 	function test_check_records() {
 		$this->markTestIncomplete(
 			'This test is incomplete.'
-		); // WP_Query not finding active alerts.
+		);
+		// WP_Query not finding active alerts.
 
 		$alerts = new Alerts( $this->plugin );
 		$alert  = new Alert( $this->dummy_alert_data(), $this->plugin );
 		$alert->save();
 
-		$action = new \MockAction;
+		$action = new \MockAction();
 		add_filter( 'wp_stream_alert_trigger_check', array( $action, 'filter' ) );
 
 		$alerts->check_records( 0, $this->dummy_stream_data() );
@@ -151,16 +156,15 @@ class Test_Alerts extends WP_StreamTestCase {
 		$this->assertFalse( $post_status_obj->public );
 		$this->assertTrue( $post_status_obj->show_in_admin_all_list );
 		$this->assertTrue( $post_status_obj->show_in_admin_status_list );
-
 	}
 
 	function test_get_alert() {
 		$alerts = new Alerts( $this->plugin );
 
-		$data = $this->dummy_alert_data();
-		$data->ID = 0;
+		$data           = $this->dummy_alert_data();
+		$data->ID       = 0;
 		$original_alert = new Alert( $data, $this->plugin );
-		$post_id = $original_alert->save();
+		$post_id        = $original_alert->save();
 
 		$alert = $alerts->get_alert( $post_id );
 		$this->assertEquals( $original_alert, $alert );
@@ -168,7 +172,7 @@ class Test_Alerts extends WP_StreamTestCase {
 
 	function test_get_alert_blank() {
 		$alerts = new Alerts( $this->plugin );
-		$alert = $alerts->get_alert();
+		$alert  = $alerts->get_alert();
 
 		$this->assertEmpty( $alert->ID );
 		$this->assertEmpty( $alert->date );
@@ -196,10 +200,10 @@ class Test_Alerts extends WP_StreamTestCase {
 	function test_display_notification_box() {
 		$alerts = new Alerts( $this->plugin );
 
-		$data = $this->dummy_alert_data();
+		$data     = $this->dummy_alert_data();
 		$data->ID = 0;
-		$alert = new Alert( $data, $this->plugin );
-		$post_id = $alert->save();
+		$alert    = new Alert( $data, $this->plugin );
+		$post_id  = $alert->save();
 
 		ob_start();
 		$alerts->display_notification_box( get_post( $alert->ID ) );
@@ -223,13 +227,13 @@ class Test_Alerts extends WP_StreamTestCase {
 		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );
 
-		$data = $this->dummy_alert_data();
+		$data     = $this->dummy_alert_data();
 		$data->ID = 0;
-		$alert = new Alert( $data, $this->plugin );
-		$post_id = $alert->save();
+		$alert    = new Alert( $data, $this->plugin );
+		$post_id  = $alert->save();
 
 		try {
-			$_POST['post_id'] = $post_id;
+			$_POST['post_id']    = $post_id;
 			$_POST['alert_type'] = 'highlight';
 			$this->_handleAjax( 'load_alerts_settings' );
 		} catch ( \WPAjaxDieContinueException $e ) {
@@ -252,10 +256,10 @@ class Test_Alerts extends WP_StreamTestCase {
 		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );
 
-		$data = $this->dummy_alert_data();
+		$data     = $this->dummy_alert_data();
 		$data->ID = 0;
-		$alert = new Alert( $data, $this->plugin );
-		$post_id = $alert->save();
+		$alert    = new Alert( $data, $this->plugin );
+		$post_id  = $alert->save();
 
 		try {
 			$_POST['post_id'] = $post_id;
@@ -281,10 +285,10 @@ class Test_Alerts extends WP_StreamTestCase {
 		$user_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
 		wp_set_current_user( $user_id );
 
-		$data = $this->dummy_alert_data();
+		$data     = $this->dummy_alert_data();
 		$data->ID = 0;
-		$alert = new Alert( $data, $this->plugin );
-		$post_id = $alert->save();
+		$alert    = new Alert( $data, $this->plugin );
+		$post_id  = $alert->save();
 
 		try {
 			$_POST['post_id']    = $post_id;
@@ -306,10 +310,10 @@ class Test_Alerts extends WP_StreamTestCase {
 	function test_display_triggers_box() {
 		$alerts = new Alerts( $this->plugin );
 
-		$data = $this->dummy_alert_data();
+		$data     = $this->dummy_alert_data();
 		$data->ID = 0;
-		$alert = new Alert( $data, $this->plugin );
-		$post_id = $alert->save();
+		$alert    = new Alert( $data, $this->plugin );
+		$post_id  = $alert->save();
 
 		ob_start();
 		$alerts->display_triggers_box( get_post( $alert->ID ) );
@@ -326,10 +330,10 @@ class Test_Alerts extends WP_StreamTestCase {
 	function test_display_submit_box() {
 		$alerts = new Alerts( $this->plugin );
 
-		$data = $this->dummy_alert_data();
+		$data     = $this->dummy_alert_data();
 		$data->ID = 0;
-		$alert = new Alert( $data, $this->plugin );
-		$post_id = $alert->save();
+		$alert    = new Alert( $data, $this->plugin );
+		$post_id  = $alert->save();
 
 		ob_start();
 		$alerts->display_submit_box( get_post( $alert->ID ) );
@@ -379,11 +383,11 @@ class Test_Alerts extends WP_StreamTestCase {
 
 		$alerts = new Alerts( $this->plugin );
 		try {
-			$_POST['wp_stream_trigger_author'] = 'me';
+			$_POST['wp_stream_trigger_author']  = 'me';
 			$_POST['wp_stream_trigger_context'] = 'posts';
-			$_POST['wp_stream_trigger_action'] = 'edit';
-			$_POST['wp_stream_alert_type'] = 'highlight';
-			$_POST['wp_stream_alerts_nonce'] = wp_create_nonce( 'save_alert' );
+			$_POST['wp_stream_trigger_action']  = 'edit';
+			$_POST['wp_stream_alert_type']      = 'highlight';
+			$_POST['wp_stream_alerts_nonce']    = wp_create_nonce( 'save_alert' );
 			$this->_handleAjax( 'save_new_alert' );
 		} catch ( \WPAjaxDieContinueException $e ) {
 			$exception = $e;
@@ -401,11 +405,11 @@ class Test_Alerts extends WP_StreamTestCase {
 
 		$alerts = new Alerts( $this->plugin );
 		try {
-			$_POST['wp_stream_trigger_author'] = 'me';
+			$_POST['wp_stream_trigger_author']  = 'me';
 			$_POST['wp_stream_trigger_context'] = 'posts-post';
-			$_POST['wp_stream_trigger_action'] = 'edit';
-			$_POST['wp_stream_alert_type'] = 'highlight';
-			$_POST['wp_stream_alerts_nonce'] = wp_create_nonce( 'save_alert' );
+			$_POST['wp_stream_trigger_action']  = 'edit';
+			$_POST['wp_stream_alert_type']      = 'highlight';
+			$_POST['wp_stream_alerts_nonce']    = wp_create_nonce( 'save_alert' );
 			$this->_handleAjax( 'save_new_alert' );
 		} catch ( \WPAjaxDieContinueException $e ) {
 			$exception = $e;
@@ -418,6 +422,8 @@ class Test_Alerts extends WP_StreamTestCase {
 	}
 
 	/**
+	 * Test saving a new alert with no nonce.
+	 *
 	 * @requires PHPUnit 5.7
 	 */
 	function test_save_new_alert_no_nonce() {
@@ -427,10 +433,10 @@ class Test_Alerts extends WP_StreamTestCase {
 
 		$alerts = new Alerts( $this->plugin );
 		try {
-			$_POST['wp_stream_trigger_author'] = 'me';
+			$_POST['wp_stream_trigger_author']  = 'me';
 			$_POST['wp_stream_trigger_context'] = 'posts-post';
-			$_POST['wp_stream_trigger_action'] = 'edit';
-			$_POST['wp_stream_alert_type'] = 'highlight';
+			$_POST['wp_stream_trigger_action']  = 'edit';
+			$_POST['wp_stream_alert_type']      = 'highlight';
 
 			$this->expectException( 'WPAjaxDieStopException' );
 			$this->_handleAjax( 'save_new_alert' );
@@ -445,6 +451,8 @@ class Test_Alerts extends WP_StreamTestCase {
 	}
 
 	/**
+	 * Test saving a new alert with an invalid nonce.
+	 *
 	 * @requires PHPUnit 5.7
 	 */
 	function test_save_new_alert_invalid_nonce() {
@@ -454,11 +462,11 @@ class Test_Alerts extends WP_StreamTestCase {
 
 		$alerts = new Alerts( $this->plugin );
 		try {
-			$_POST['wp_stream_trigger_author'] = 'me';
+			$_POST['wp_stream_trigger_author']  = 'me';
 			$_POST['wp_stream_trigger_context'] = 'posts-post';
-			$_POST['wp_stream_trigger_action'] = 'edit';
-			$_POST['wp_stream_alert_type'] = 'highlight';
-			$_POST['wp_stream_alerts_nonce'] = 'invalid';
+			$_POST['wp_stream_trigger_action']  = 'edit';
+			$_POST['wp_stream_alert_type']      = 'highlight';
+			$_POST['wp_stream_alerts_nonce']    = 'invalid';
 
 			$this->expectException( 'WPAjaxDieStopException' );
 			$this->_handleAjax( 'save_new_alert' );
@@ -473,6 +481,8 @@ class Test_Alerts extends WP_StreamTestCase {
 	}
 
 	/**
+	 * Test saving a new alert with a mismatched nonce.
+	 *
 	 * @requires PHPUnit 5.7
 	 */
 	function test_save_new_alert_mismatched_nonce() {
@@ -482,11 +492,11 @@ class Test_Alerts extends WP_StreamTestCase {
 
 		$alerts = new Alerts( $this->plugin );
 		try {
-			$_POST['wp_stream_trigger_author'] = 'me';
+			$_POST['wp_stream_trigger_author']  = 'me';
 			$_POST['wp_stream_trigger_context'] = 'posts-post';
-			$_POST['wp_stream_trigger_action'] = 'edit';
-			$_POST['wp_stream_alert_type'] = 'highlight';
-			$_POST['wp_stream_alerts_nonce'] = wp_create_nonce( 'some_nonce' );
+			$_POST['wp_stream_trigger_action']  = 'edit';
+			$_POST['wp_stream_alert_type']      = 'highlight';
+			$_POST['wp_stream_alerts_nonce']    = wp_create_nonce( 'some_nonce' );
 
 			$this->expectException( 'WPAjaxDieStopException' );
 			$this->_handleAjax( 'save_new_alert' );
@@ -501,6 +511,8 @@ class Test_Alerts extends WP_StreamTestCase {
 	}
 
 	/**
+	 * Test saving a new alert with missing capabilities.
+	 *
 	 * @requires PHPUnit 5.7
 	 */
 	function test_save_new_alert_missing_caps() {
@@ -510,11 +522,11 @@ class Test_Alerts extends WP_StreamTestCase {
 
 		$alerts = new Alerts( $this->plugin );
 		try {
-			$_POST['wp_stream_trigger_author'] = 'me';
+			$_POST['wp_stream_trigger_author']  = 'me';
 			$_POST['wp_stream_trigger_context'] = 'posts-post';
-			$_POST['wp_stream_trigger_action'] = 'edit';
-			$_POST['wp_stream_alert_type'] = 'highlight';
-			$_POST['wp_stream_alerts_nonce'] = wp_create_nonce( 'save_alert' );
+			$_POST['wp_stream_trigger_action']  = 'edit';
+			$_POST['wp_stream_alert_type']      = 'highlight';
+			$_POST['wp_stream_alerts_nonce']    = wp_create_nonce( 'save_alert' );
 
 			$this->expectException( 'WPAjaxDieStopException' );
 			$this->_handleAjax( 'save_new_alert' );
@@ -535,11 +547,11 @@ class Test_Alerts extends WP_StreamTestCase {
 
 		$alerts = new Alerts( $this->plugin );
 		try {
-			$_POST['wp_stream_trigger_author'] = 'me';
+			$_POST['wp_stream_trigger_author']  = 'me';
 			$_POST['wp_stream_trigger_context'] = 'posts-post';
-			$_POST['wp_stream_trigger_action'] = 'edit';
-			$_POST['wp_stream_alert_type'] = 'highlight';
-			$_POST['wp_stream_alerts_nonce'] = wp_create_nonce( 'save_alert' );
+			$_POST['wp_stream_trigger_action']  = 'edit';
+			$_POST['wp_stream_alert_type']      = 'highlight';
+			$_POST['wp_stream_alerts_nonce']    = wp_create_nonce( 'save_alert' );
 			$this->_handleAjax( 'get_new_alert_triggers_notifications' );
 		} catch ( \WPAjaxDieContinueException $e ) {
 			$exception = $e;
@@ -558,11 +570,11 @@ class Test_Alerts extends WP_StreamTestCase {
 
 		$alerts = new Alerts( $this->plugin );
 		try {
-			$_POST['wp_stream_trigger_author'] = 'me';
+			$_POST['wp_stream_trigger_author']  = 'me';
 			$_POST['wp_stream_trigger_context'] = 'posts-post';
-			$_POST['wp_stream_trigger_action'] = 'edit';
-			$_POST['wp_stream_alert_type'] = 'highlight';
-			$_POST['wp_stream_alerts_nonce'] = wp_create_nonce( 'save_alert' );
+			$_POST['wp_stream_trigger_action']  = 'edit';
+			$_POST['wp_stream_alert_type']      = 'highlight';
+			$_POST['wp_stream_alerts_nonce']    = wp_create_nonce( 'save_alert' );
 
 			$this->expectException( 'WPAjaxDieStopException' );
 			$this->_handleAjax( 'get_new_alert_triggers_notifications' );
@@ -584,7 +596,7 @@ class Test_Alerts extends WP_StreamTestCase {
 			'author'     => '1',
 			'alert_type' => 'highlight',
 			'alert_meta' => array(
-				'trigger_action' => 'activated',
+				'trigger_action'  => 'activated',
 				'trigger_author'  => 'administrator',
 				'trigger_context' => 'plugins',
 			),

--- a/tests/tests/test-class-alerts.php
+++ b/tests/tests/test-class-alerts.php
@@ -189,7 +189,7 @@ class Test_Alerts extends WP_StreamTestCase {
 		$this->markTestIncomplete();
 
 		$this->assertEquals( array(), $submenu[ $this->plugin->admin->records_page_slug ] );
-		$submenu[ $this->plugin->admin->records_page_slug ] = array();
+		$submenu[ $this->plugin->admin->records_page_slug ] = array(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		$this->assertEmpty( $submenu[ $this->plugin->admin->records_page_slug ] );
 
 		$alerts = new Alerts( $this->plugin );

--- a/tests/tests/test-class-author.php
+++ b/tests/tests/test-class-author.php
@@ -12,7 +12,7 @@ class Test_Author extends WP_StreamTestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		//Add admin user to test caps
+		// Add admin user to test caps
 		// We need to change user to verify editing option as admin or editor
 		$administrator_id = $this->factory->user->create(
 			array(
@@ -27,7 +27,7 @@ class Test_Author extends WP_StreamTestCase {
 		$this->assertNotEmpty( $this->author );
 	}
 
-	/*
+	/**
 	 * Also tests private method locate_plugin
 	 */
 	public function test_construct() {
@@ -53,7 +53,7 @@ class Test_Author extends WP_StreamTestCase {
 	}
 
 	public function test_get_agent() {
-		$agent = 'Heuristically programmed algorithmic computer';
+		$agent                       = 'Heuristically programmed algorithmic computer';
 		$this->author->meta['agent'] = $agent;
 		$this->assertEquals( $agent, $this->author->get_agent() );
 	}
@@ -79,11 +79,11 @@ class Test_Author extends WP_StreamTestCase {
 	}
 
 	public function test_is_wp_cli() {
-		$agent = 'wp_cli';
+		$agent                       = 'wp_cli';
 		$this->author->meta['agent'] = $agent;
 		$this->assertTrue( $this->author->is_wp_cli() );
 
-		$agent = 'Heuristically programmed algorithmic computer';
+		$agent                       = 'Heuristically programmed algorithmic computer';
 		$this->author->meta['agent'] = $agent;
 		$this->assertFalse( $this->author->is_wp_cli() );
 	}

--- a/tests/tests/test-class-connector.php
+++ b/tests/tests/test-class-connector.php
@@ -45,7 +45,7 @@ class Test_Connector extends WP_StreamTestCase {
 	public function test_callback() {
 		global $wp_current_filter;
 		$action              = $this->connector->actions[0];
-		$wp_current_filter[] = $action;
+		$wp_current_filter[] = $action; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		$this->connector->callback();
 

--- a/tests/tests/test-class-connector.php
+++ b/tests/tests/test-class-connector.php
@@ -44,7 +44,7 @@ class Test_Connector extends WP_StreamTestCase {
 
 	public function test_callback() {
 		global $wp_current_filter;
-		$action = $this->connector->actions[0];
+		$action              = $this->connector->actions[0];
 		$wp_current_filter[] = $action;
 
 		$this->connector->callback();
@@ -158,7 +158,7 @@ class Test_Connector extends WP_StreamTestCase {
 	public function test_get_changed_keys() {
 		$array_one = array(
 			'one' => 'foo',
-			'two'  => array(
+			'two' => array(
 				'a' => 'alpha',
 				'b' => 'beta',
 			),

--- a/tests/tests/test-class-connector.php
+++ b/tests/tests/test-class-connector.php
@@ -12,7 +12,65 @@ class Test_Connector extends WP_StreamTestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->connector = new Connector_Maintenance();
+		$this->connector = new class() extends Connector {
+			/**
+			 * Connector slug
+			 *
+			 * @var string
+			 */
+			public $name = 'maintenance';
+
+			/**
+			 * Actions registered for this connector
+			 *
+			 * @var array
+			 */
+			public $actions = array(
+				'simulate_fault',
+			);
+
+			/**
+			 * Return translated connector label
+			 *
+			 * @return string Translated connector label
+			 */
+			public function get_label() {
+				return esc_html__( 'Maintenance', 'stream' );
+			}
+
+			/**
+			 * Return translated action labels
+			 *
+			 * @return array Action label translations
+			 */
+			public function get_action_labels() {
+				return array(
+					'simulated_fault' => esc_html__( 'Fault', 'stream' ),
+				);
+			}
+
+			/**
+			 * Return translated context labels
+			 *
+			 * @return array Context label translations
+			 */
+			public function get_context_labels() {
+				return array(
+					'ae35' => esc_html__( 'AE35 Unit', 'stream' ),
+				);
+			}
+
+			/**
+			 * Log the ae35 test result
+			 *
+			 * @action ae35_test
+			 */
+			public function callback_simulate_fault() {
+				// This is used to check if this callback method actually ran
+				do_action( 'wp_stream_test_child_callback_simulate_fault' );
+			}
+		};
+
 		$this->assertNotEmpty( $this->connector );
 	}
 
@@ -176,64 +234,5 @@ class Test_Connector extends WP_StreamTestCase {
 
 	public function test_is_dependency_satisfied() {
 		$this->assertTrue( $this->connector->is_dependency_satisfied() );
-	}
-}
-
-class Connector_Maintenance extends Connector {
-	/**
-	 * Connector slug
-	 *
-	 * @var string
-	 */
-	public $name = 'maintenance';
-
-	/**
-	 * Actions registered for this connector
-	 *
-	 * @var array
-	 */
-	public $actions = array(
-		'simulate_fault',
-	);
-
-	/**
-	 * Return translated connector label
-	 *
-	 * @return string Translated connector label
-	 */
-	public function get_label() {
-		return esc_html__( 'Maintenance', 'stream' );
-	}
-
-	/**
-	 * Return translated action labels
-	 *
-	 * @return array Action label translations
-	 */
-	public function get_action_labels() {
-		return array(
-			'simulated_fault' => esc_html__( 'Fault', 'stream' ),
-		);
-	}
-
-	/**
-	 * Return translated context labels
-	 *
-	 * @return array Context label translations
-	 */
-	public function get_context_labels() {
-		return array(
-			'ae35' => esc_html__( 'AE35 Unit', 'stream' ),
-		);
-	}
-
-	/**
-	 * Log the ae35 test result
-	 *
-	 * @action ae35_test
-	 */
-	public function callback_simulate_fault() {
-		// This is used to check if this callback method actually ran
-		do_action( 'wp_stream_test_child_callback_simulate_fault' );
 	}
 }

--- a/tests/tests/test-class-connectors.php
+++ b/tests/tests/test-class-connectors.php
@@ -40,12 +40,12 @@ class Test_Connectors extends WP_StreamTestCase {
 		$this->connectors->load_connectors();
 		$this->assertNotEmpty( $this->connectors->connectors );
 
-		foreach( $this->connectors->connectors as $connector ) {
+		foreach ( $this->connectors->connectors as $connector ) {
 			$this->assertTrue( $connector->is_registered() );
 		}
 
 		$this->connectors->unload_connectors();
-		foreach( $this->connectors->connectors as $connector ) {
+		foreach ( $this->connectors->connectors as $connector ) {
 			$this->assertFalse( $connector->is_registered() );
 		}
 	}
@@ -54,12 +54,12 @@ class Test_Connectors extends WP_StreamTestCase {
 		$this->connectors->load_connectors();
 		$this->assertNotEmpty( $this->connectors->connectors );
 		$this->connectors->unload_connectors();
-		foreach( $this->connectors->connectors as $connector ) {
+		foreach ( $this->connectors->connectors as $connector ) {
 			$this->assertFalse( $connector->is_registered() );
 		}
 
 		$this->connectors->reload_connectors();
-		foreach( $this->connectors->connectors as $connector ) {
+		foreach ( $this->connectors->connectors as $connector ) {
 			$this->assertTrue( $connector->is_registered() );
 		}
 	}

--- a/tests/tests/test-class-db-driver-wpdb.php
+++ b/tests/tests/test-class-db-driver-wpdb.php
@@ -25,7 +25,7 @@ class Test_DB_Driver_WPDB extends WP_StreamTestCase {
 		$this->assertEquals( $this->driver->table_meta, $wpdb->recordmeta );
 	}
 
-	/*
+	/**
 	 * Also tests the insert_meta method
 	 */
 	public function test_insert() {
@@ -100,23 +100,23 @@ class Test_DB_Driver_WPDB extends WP_StreamTestCase {
 
 	private function dummy_stream_data() {
 		return array(
-				'object_id' => 10,
-				'site_id' => '1',
-				'blog_id' => get_current_blog_id(),
-				'user_id' => '1',
-				'user_role' => 'administrator',
-				'created' => gmdate( 'Y-m-d h:i:s' ),
-				'summary' => '"Hello Dave" plugin activated',
-				'ip' => '192.168.0.1',
-				'connector' => 'installer',
-				'context' => 'plugins',
-				'action' => 'activated',
+			'object_id' => 10,
+			'site_id'   => '1',
+			'blog_id'   => get_current_blog_id(),
+			'user_id'   => '1',
+			'user_role' => 'administrator',
+			'created'   => gmdate( 'Y-m-d h:i:s' ),
+			'summary'   => '"Hello Dave" plugin activated',
+			'ip'        => '192.168.0.1',
+			'connector' => 'installer',
+			'context'   => 'plugins',
+			'action'    => 'activated',
 		);
 	}
 
 	private function dummy_meta_data() {
 		return array(
-				'space_helmet' => 'false',
+			'space_helmet' => 'false',
 		);
 	}
 }

--- a/tests/tests/test-class-db-driver-wpdb.php
+++ b/tests/tests/test-class-db-driver-wpdb.php
@@ -43,7 +43,10 @@ class Test_DB_Driver_WPDB extends WP_StreamTestCase {
 		global $wpdb;
 
 		// Check that records exist
-		$stream_result = $wpdb->get_row( "SELECT * FROM {$wpdb->stream} WHERE ID = $stream_id", ARRAY_A );
+		$stream_result = $wpdb->get_row(
+			$wpdb->prepare( "SELECT * FROM {$wpdb->stream} WHERE ID = %d", $stream_id ),
+			ARRAY_A
+		);
 		$this->assertNotEmpty( $stream_result );
 
 		foreach ( $this->dummy_stream_data() as $dummy_key => $dummy_value ) {
@@ -62,7 +65,10 @@ class Test_DB_Driver_WPDB extends WP_StreamTestCase {
 		}
 
 		// Check that meta exists
-		$meta_result = $wpdb->get_results( "SELECT * FROM {$wpdb->streammeta} WHERE record_id = $stream_id", ARRAY_A );
+		$meta_result = $wpdb->get_results(
+			$wpdb->prepare( "SELECT * FROM {$wpdb->streammeta} WHERE record_id = %d", $stream_id ),
+			ARRAY_A
+		);
 		$this->assertNotEmpty( $meta_result );
 
 		$found_all_keys = true;

--- a/tests/tests/test-class-db.php
+++ b/tests/tests/test-class-db.php
@@ -16,7 +16,7 @@ class Test_DB extends WP_StreamTestCase {
 		$this->assertNotEmpty( $this->db );
 	}
 
-	/*
+	/**
 	 * Also tests the insert_meta method
 	 */
 	public function test_insert() {
@@ -80,7 +80,7 @@ class Test_DB extends WP_StreamTestCase {
 
 		// Attempt to store something with HTML in there.
 		$record = array(
-			'summary' => '<b>This is a <strong>very</strong> bold attempt!</b>'
+			'summary' => '<b>This is a <strong>very</strong> bold attempt!</b>',
 		);
 
 		$record_id = $this->db->insert( $record );
@@ -92,8 +92,8 @@ class Test_DB extends WP_StreamTestCase {
 
 		$record_stored = $this->db->query(
 			array(
-				'search' => $record_id,
-				'search_field' => 'ID'
+				'search'       => $record_id,
+				'search_field' => 'ID',
 			)
 		);
 
@@ -119,16 +119,16 @@ class Test_DB extends WP_StreamTestCase {
 	private function dummy_stream_data() {
 		return array(
 			'object_id' => 9,
-			'site_id' => '1',
-			'blog_id' => get_current_blog_id(),
-			'user_id' => '1',
+			'site_id'   => '1',
+			'blog_id'   => get_current_blog_id(),
+			'user_id'   => '1',
 			'user_role' => 'administrator',
-			'created' => gmdate( 'Y-m-d h:i:s' ),
-			'summary' => '"Hello Dave" plugin activated',
-			'ip' => '192.168.0.1',
+			'created'   => gmdate( 'Y-m-d h:i:s' ),
+			'summary'   => '"Hello Dave" plugin activated',
+			'ip'        => '192.168.0.1',
 			'connector' => 'installer',
-			'context' => 'plugins',
-			'action' => 'activated',
+			'context'   => 'plugins',
+			'action'    => 'activated',
 		);
 	}
 

--- a/tests/tests/test-class-db.php
+++ b/tests/tests/test-class-db.php
@@ -34,7 +34,10 @@ class Test_DB extends WP_StreamTestCase {
 		global $wpdb;
 
 		// Check that records exist
-		$stream_result = $wpdb->get_row( "SELECT * FROM {$wpdb->stream} WHERE ID = $stream_id", ARRAY_A );
+		$stream_result = $wpdb->get_row(
+			$wpdb->prepare( "SELECT * FROM {$wpdb->stream} WHERE ID = %d", $stream_id ),
+			ARRAY_A
+		);
 		$this->assertNotEmpty( $stream_result );
 
 		foreach ( $this->dummy_stream_data() as $dummy_key => $dummy_value ) {
@@ -53,7 +56,10 @@ class Test_DB extends WP_StreamTestCase {
 		}
 
 		// Check that meta exists
-		$meta_result = $wpdb->get_results( "SELECT * FROM {$wpdb->streammeta} WHERE record_id = $stream_id", ARRAY_A );
+		$meta_result = $wpdb->get_results(
+			$wpdb->prepare( "SELECT * FROM {$wpdb->streammeta} WHERE record_id = %d", $stream_id ),
+			ARRAY_A
+		);
 		$this->assertNotEmpty( $meta_result );
 
 		$found_all_keys = true;

--- a/tests/tests/test-class-export.php
+++ b/tests/tests/test-class-export.php
@@ -84,7 +84,7 @@ class Test_Export extends WP_StreamTestCase {
 	 * Test pagination limit is increased
 	 */
 	public function test_disable_paginate() {
-		$limit = $this->export->disable_paginate( 0 );
+		$limit = $this->export->disable_paginate();
 		$this->assertEquals( $limit, 10000 );
 	}
 

--- a/tests/tests/test-class-export.php
+++ b/tests/tests/test-class-export.php
@@ -35,7 +35,7 @@ class Test_Export extends WP_StreamTestCase {
 	 * Test that render download uses selected renderer
 	 */
 	public function test_render_download() {
-		$_GET['record-actions'] = 'export-csv';
+		$_GET['record-actions']              = 'export-csv';
 		$_GET['stream_record_actions_nonce'] = wp_create_nonce( 'stream_record_actions_nonce' );
 
 		ob_start();
@@ -100,7 +100,7 @@ class Test_Export extends WP_StreamTestCase {
 			'action'  => '',
 			'ip'      => '',
 		);
-		$columns = $this->export->expand_columns( $test_data );
+		$columns   = $this->export->expand_columns( $test_data );
 
 		$this->assertArrayHasKey( 'date', $columns );
 		$this->assertArrayHasKey( 'summary', $columns );
@@ -128,14 +128,18 @@ class Test_Export extends WP_StreamTestCase {
 
 	/**
 	 * Test registering a invalid class type produces an error
+	 *
 	 * @requires PHPUnit 5.7
 	 */
 	public function test_register_exporter_invalid_class() {
-		add_filter( 'wp_stream_exporters', function( $exporters ) {
-			$exporters['test'] = new \stdClass();
-			remove_all_filters( 'wp_stream_exporters' );
-			return $exporters;
-		});
+		add_filter(
+			'wp_stream_exporters',
+			function ( $exporters ) {
+				$exporters['test'] = new \stdClass();
+				remove_all_filters( 'wp_stream_exporters' );
+				return $exporters;
+			}
+		);
 		$this->export->register_exporters();
 
 		$exporters = $this->export->get_exporters();
@@ -155,7 +159,7 @@ class Test_Export extends WP_StreamTestCase {
 	 * Test exporter validation produces false
 	 */
 	public function test_is_not_valid_exporter() {
-		$this->assertFalse( $this->export->is_valid_exporter( new \stdClass ) );
+		$this->assertFalse( $this->export->is_valid_exporter( new \stdClass() ) );
 	}
 
 	/**

--- a/tests/tests/test-class-exporter-csv.php
+++ b/tests/tests/test-class-exporter-csv.php
@@ -28,8 +28,16 @@ class Test_Exporter_CSV extends WP_StreamTestCase {
 	 * Test CSV exporter output
 	 */
 	public function test_output_file() {
-		$array   = array( array( 'key' => 'value', 'key2' => 'value2' ) );
-		$columns = array( 'key' => 'Key', 'key2' => 'Key2' );
+		$array   = array(
+			array(
+				'key'  => 'value',
+				'key2' => 'value2',
+			),
+		);
+		$columns = array(
+			'key'  => 'Key',
+			'key2' => 'Key2',
+		);
 
 		$this->expectOutputString( "Key,Key2\nvalue,value2\n" );
 		$this->csv_exporter->output_file( $array, $columns );

--- a/tests/tests/test-class-filter-input.php
+++ b/tests/tests/test-class-filter-input.php
@@ -18,10 +18,10 @@ class Test_Filter_Input extends WP_StreamTestCase {
 
 	public function test_super() {
 		$_POST['pod_bay_doors'] = 'closed';
-		$this->assertEquals( $_POST['pod_bay_doors'], $this->filter->super( INPUT_POST, 'pod_bay_doors' ) );
+		$this->assertEquals( $_POST['pod_bay_doors'], $this->filter->super( INPUT_POST, 'pod_bay_doors' ) ); // phpcs:ignore WordPress.Security.NonceVerification
 
 		$_GET['cause_of_failure'] = 'human error';
-		$this->assertEquals( $_GET['cause_of_failure'], $this->filter->super( INPUT_GET, 'cause_of_failure' ) );
+		$this->assertEquals( $_GET['cause_of_failure'], $this->filter->super( INPUT_GET, 'cause_of_failure' ) ); // phpcs:ignore WordPress.Security.NonceVerification
 
 		$this->setExpectedException( 'Exception', 'Invalid use, type must be one of INPUT_* family.' );
 		$this->filter->super( 42, 'What do you get if you multiply six by nine?' );

--- a/tests/tests/test-class-filter-input.php
+++ b/tests/tests/test-class-filter-input.php
@@ -12,7 +12,7 @@ class Test_Filter_Input extends WP_StreamTestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->filter = new Filter_Input;
+		$this->filter = new Filter_Input();
 		$this->assertNotEmpty( $this->filter );
 	}
 

--- a/tests/tests/test-class-log.php
+++ b/tests/tests/test-class-log.php
@@ -22,7 +22,7 @@ class Test_Log extends WP_StreamTestCase {
 			);
 		}
 
-		$role = 'this_is_a_really_long_user_role_slug_that_will_not_be_logged_in_stream';
+		$role       = 'this_is_a_really_long_user_role_slug_that_will_not_be_logged_in_stream';
 		$extra_long = get_role( $role );
 		if ( ! $extra_long ) {
 			$extra_long = add_role(
@@ -36,10 +36,20 @@ class Test_Log extends WP_StreamTestCase {
 		 * Add users for testing and assign roles.
 		 */
 		$user_id = wp_create_user( 'test1', 'password', 'test1@example.com' );
-		wp_update_user( array( 'ID' => $user_id, 'role' => $long->name ) );
+		wp_update_user(
+			array(
+				'ID'   => $user_id,
+				'role' => $long->name,
+			)
+		);
 
 		$user_id = wp_create_user( 'test2', 'password', 'test2@example.com' );
-		wp_update_user( array( 'ID' => $user_id, 'role' => $extra_long->name ) );
+		wp_update_user(
+			array(
+				'ID'   => $user_id,
+				'role' => $extra_long->name,
+			)
+		);
 	}
 
 	public function test_field_lengths() {
@@ -50,7 +60,12 @@ class Test_Log extends WP_StreamTestCase {
 		// Test user_role length (<=50)
 		$result = $this->plugin->log->log( 'test_connector', 'Test user_role 1', array(), 0, 'settings', 'test', $user1->ID );
 		$this->assertNotEmpty( $result );
-		$record = $this->plugin->db->query( array( 'search' => $result, 'search_field' => 'ID' ) );
+		$record = $this->plugin->db->query(
+			array(
+				'search'       => $result,
+				'search_field' => 'ID',
+			)
+		);
 		$this->assertEquals( $result, $record[0]->ID );
 
 		// Test user_role length (>50)
@@ -64,7 +79,6 @@ class Test_Log extends WP_StreamTestCase {
 		// Test action length
 
 		// Test IP length
-
 	}
 
 	public function test_can_map_exclude_rules_settings_to_rows() {
@@ -73,31 +87,31 @@ class Test_Log extends WP_StreamTestCase {
 				null,
 				null,
 			),
-			'action' => array(
+			'action'      => array(
 				'one',
 				null,
-				'three'
-			)
+				'three',
+			),
 		);
 
 		$this->assertEquals(
 			array(
 				array(
-					'exclude_row' => null,
-					'action' => 'one',
+					'exclude_row'    => null,
+					'action'         => 'one',
 					'author_or_role' => null,
-					'connector' => null,
-					'context' => null,
-					'ip_address' => null,
+					'connector'      => null,
+					'context'        => null,
+					'ip_address'     => null,
 				),
 				array(
-					'exclude_row' => null,
-					'action' => null,
+					'exclude_row'    => null,
+					'action'         => null,
 					'author_or_role' => null,
-					'connector' => null,
-					'context' => null,
-					'ip_address' => null,
-				)
+					'connector'      => null,
+					'context'        => null,
+					'ip_address'     => null,
+				),
 			),
 			$this->plugin->log->exclude_rules_by_rows( $rules_settings )
 		);
@@ -111,7 +125,7 @@ class Test_Log extends WP_StreamTestCase {
 		$this->assertTrue(
 			$this->plugin->log->record_matches_rules(
 				array(
-					'action' => 'mega_action',
+					'action'     => 'mega_action',
 					'ip_address' => '1.1.1.1',
 				),
 				$rules
@@ -143,24 +157,28 @@ class Test_Log extends WP_StreamTestCase {
 			'Record IP address is different'
 		);
 
-		$this->assertTrue( $this->plugin->log->record_matches_rules(
-			array(
-				'ip_address' => '1.1.1.1',
-			),
-			array(
-				'ip_address' => '1.1.1.1',
-			),
-			'Record and rule IP addresses match'
-		) );
+		$this->assertTrue(
+			$this->plugin->log->record_matches_rules(
+				array(
+					'ip_address' => '1.1.1.1',
+				),
+				array(
+					'ip_address' => '1.1.1.1',
+				),
+				'Record and rule IP addresses match'
+			)
+		);
 
-		$this->assertTrue( $this->plugin->log->record_matches_rules(
-			array(
-				'ip_address' => '1.1.1.1',
-			),
-			array(
-				'ip_address' => '8.8.8.8,1.1.1.1',
-			),
-			'Record IP address is one of the IP addresses in the rule'
-		) );
+		$this->assertTrue(
+			$this->plugin->log->record_matches_rules(
+				array(
+					'ip_address' => '1.1.1.1',
+				),
+				array(
+					'ip_address' => '8.8.8.8,1.1.1.1',
+				),
+				'Record IP address is one of the IP addresses in the rule'
+			)
+		);
 	}
 }

--- a/tests/tests/test-class-plugin.php
+++ b/tests/tests/test-class-plugin.php
@@ -7,10 +7,10 @@ class Test_Plugin extends WP_StreamTestCase {
 	 * Make sure the plugin is initialized with it's global variable.
 	 */
 	public function test_plugin_initialized() {
-		$this->assertFalse( null == $this->plugin );
+		$this->assertNotNull( $this->plugin );
 	}
 
-	/*
+	/**
 	 * Also tests private method locate_plugin
 	 */
 	public function test_construct() {
@@ -45,11 +45,14 @@ class Test_Plugin extends WP_StreamTestCase {
 		 * Make sure we get the correct MO file during tests.
 		 * WP looks in develop installation where MO file is not found.
 		 */
-		add_filter( 'load_textdomain_mofile', function( $mofile ) {
-			$locale = get_locale();
-			$mofile = sprintf( '%s/languages/stream-%s.mo', $this->plugin->locations['dir'], $locale );
-			return $mofile;
-		} );
+		add_filter(
+			'load_textdomain_mofile',
+			function ( $mofile ) {
+				$locale = get_locale();
+				$mofile = sprintf( '%s/languages/stream-%s.mo', $this->plugin->locations['dir'], $locale );
+				return $mofile;
+			}
+		);
 
 		$this->plugin->i18n();
 		$this->assertArrayHasKey( 'stream', $l10n );

--- a/tests/tests/test-functions.php
+++ b/tests/tests/test-functions.php
@@ -5,7 +5,7 @@ class Test_Functions extends WP_StreamTestCase {
 	public function test_wp_stream_get_iso_8601_extended_date() {
 		$time = '1095379198';
 
-		$date 		 = wp_stream_get_iso_8601_extended_date( $time );
+		$date = wp_stream_get_iso_8601_extended_date( $time );
 		$this->assertSame( $date, '2004-09-16T23:59:58+0000' );
 
 		$offset_date = wp_stream_get_iso_8601_extended_date( $time, 5 );


### PR DESCRIPTION
# Checklist

- [x] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [x] I have added phpunit tests.


## Release Changelog

- Fix: Add `phpcs` linting to the PHPUnit test files
