### PR TITLE
Do not start Xdebug automatically, use sessionkey instead

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -30,6 +30,8 @@ We suggest using the [Homebrew package manager](https://brew.sh) on macOS to ins
 
 The WordPress container includes the [Xdebug PHP extension](https://xdebug.org). It is configured in the [`php.ini`](./local/docker/wordpress/php.ini) file to work in the [develop, debug and coverage modes](https://xdebug.org/docs/step_debug#mode).
 
+To enable Xdebug, a request must include a _sessionkey_. This can be easily achieved with a browser extension like [Xdebug helper](https://chromewebstore.google.com/detail/xdebug-helper/eadndfjplgieldjbigjakmdgkmoaaaoc?hl=en).
+
 [Step Debugging](https://xdebug.org/docs/step_debug) should work out of the box in VSCode thanks to the configuration file, [`.vscode/launch.json`](.vscode/launch.json). It contains the directory mapping from the WordPress container to the project directory in your code editor.
 
 In order to set up Step Debugging in PhpStorm, follow the [official guide](https://www.jetbrains.com/help/phpstorm/configuring-xdebug.html). Make sure to set up the same directory mappings as defined for VSCode in [`.vscode/launch.json`](.vscode/launch.json), e.g.:

--- a/local/docker/wordpress/php.ini
+++ b/local/docker/wordpress/php.ini
@@ -9,7 +9,6 @@ sendmail_path = "/usr/bin/msmtp --port=1025 --read-recipients"
 ; Enable remote Xdebug.
 [xdebug]
 xdebug.mode = coverage,debug,develop
-xdebug.start_with_request = yes
 xdebug.client_host = host.docker.internal
 xdebug.discover_client_host = 0
 xdebug.remote_enable = 1


### PR DESCRIPTION
This change prevents console errors when running PHPUnit tests as described in https://github.com/xwp/stream/pull/1508#discussion_r1682716907

Xdebug will no longer be automatically enabled whenever a request comes in. Instead, a request should contain a sessionkey added by a browser extension like [Xdebug helper](https://chromewebstore.google.com/detail/xdebug-helper/eadndfjplgieldjbigjakmdgkmoaaaoc?hl=en).

# Checklist

- [x] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
