### PR TITLE
Require PHP ≥ 7.0 and WordPress ≥ 4.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "php": ">=5.6.20",
+    "php": ">=7.0",
     "composer/installers": "~1.0",
     "ext-json": "*"
   },
@@ -23,7 +23,7 @@
     "phpcompatibility/php-compatibility": "dev-develop as 9.99.99",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
     "phpunit/phpunit": "^9.6",
-    "roots/wordpress": "^6.5",
+    "roots/wordpress": "^6.6",
     "wp-cli/wp-cli-bundle": "^2.6",
     "wp-coding-standards/wpcs": "^3.1",
     "wp-phpunit/wp-phpunit": "^6.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8e415ec47436f6af387de15534224042",
+    "content-hash": "735291b73e1d9e13c7c854fbfdd74ca3",
     "packages": [
         {
             "name": "composer/installers",
@@ -8549,12 +8549,12 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.6.20",
+        "php": ">=7.0",
         "ext-json": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,7 +7,7 @@
 	<arg value="sp" /><!-- Show sniff codes in all reports and progress. -->
 
 	<rule ref="PHPCompatibilityWP" />
-	<config name="testVersion" value="5.6-" /><!-- Test for PHP compatibility for 5.6 and above. -->
+	<config name="testVersion" value="7.0-" /><!-- Test for PHP compatibility for 7.0 and above. -->
 
 	<rule ref="WordPress-Docs">
 		<type>warning</type><!-- FIXME Report but ignore for now. -->

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Stream ===
 Contributors: xwp
 Tags: wp stream, stream, activity, logs, track
-Requires at least: 4.5
-Tested up to: 6.4
+Requires at least: 4.6
+Tested up to: 6.6
 Stable tag: 4.0.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/stream.php
+++ b/stream.php
@@ -31,7 +31,9 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-if ( version_compare( PHP_VERSION, '5.3', '<' ) ) {
+const WP_STREAM_MIN_PHP_VERSION = '7.0';
+
+if ( version_compare( PHP_VERSION, WP_STREAM_MIN_PHP_VERSION, '<' ) ) {
 	add_action( 'shutdown', 'wp_stream_fail_php_version' );
 } else {
 	require __DIR__ . '/classes/class-plugin.php';
@@ -49,7 +51,8 @@ if ( version_compare( PHP_VERSION, '5.3', '<' ) ) {
 function wp_stream_fail_php_version() {
 	load_plugin_textdomain( 'stream', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
 
-	$message      = esc_html__( 'Stream requires PHP version 5.3+, plugin is currently NOT ACTIVE.', 'stream' );
+	/* translators: %s is the minimum PHP version. */
+	$message      = sprintf( __( 'Stream requires PHP version %s or newer. Plugin is currently NOT ACTIVE.', 'stream' ), WP_STREAM_MIN_PHP_VERSION );
 	$html_message = sprintf( '<div class="error">%s</div>', wpautop( $message ) );
 
 	echo wp_kses_post( $html_message );


### PR DESCRIPTION
Fixes #1499

This PR updates the minimum PHP version requirement to 7.0. I tested this locally and besides getting some PHP notices from non-plugin related code everything seemed to be working as expected.

I also tried downgrading WordPress core to 4.5, which is the version we required so far, but it failed. WP admin did not load and I got dozens of issues (I tried on PHP 7.1) Maybe it's something about my setup so I'd appreciate someone else double-checking that as well.

When I upgraded to 4.6, everything went back to normal. That's why, at least for now, I've bumped the minimal requirement to 4.6 for WordPress core.

I also did some quick smoke test of WordPress 6.6 and did not notice any issues. That's why I increased the "Tested up to" label to 6.6.

# Checklist

- [x] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Update: Set minimum PHP version requirement to 7.0 and WordPress core version to 4.6.
- Update: Test the plugin on WordPress 6.6 and update the "tested up to" label accordingly.
