### PR TITLE
Replace `strlen` with custom callback that accepts `null`

### DIFF
--- a/classes/class-log.php
+++ b/classes/class-log.php
@@ -197,7 +197,7 @@ class Log {
 			$exclude_rules = array_filter(
 				$exclude,
 				function ( $value ) {
-					return ! is_null( $value ) && '' !== $value;
+					return ! is_null( $value );
 				}
 			);
 

--- a/classes/class-log.php
+++ b/classes/class-log.php
@@ -194,7 +194,12 @@ class Log {
 				'role'       => ( ! empty( $exclude_rule['author_or_role'] ) && ! is_numeric( $exclude_rule['author_or_role'] ) ) ? $exclude_rule['author_or_role'] : null,
 			);
 
-			$exclude_rules = array_filter( $exclude, 'strlen' );
+			$exclude_rules = array_filter(
+				$exclude,
+				function ( $value ) {
+					return ! is_null( $value ) && '' !== $value;
+				}
+			);
 
 			if ( $this->record_matches_rules( $record, $exclude_rules ) ) {
 				$exclude_record = true;


### PR DESCRIPTION
Fixes #1349
Supersedes #1466

This fixes a deprecation notice in PHP 8:

> PHP Deprecated: strlen(): Passing null to parameter https://github.com/xwp/stream/issues/1 ($string) of type string is deprecated in classes/class-log.php on line 217

It addressed the [review feedback](https://github.com/xwp/stream/pull/1466#discussion_r1393806661) left on #1466 which pointed out that `null` values should be filtered out from the array.

In the end, keeping or removing `null` values in this particular scenario does not seem to matter. The `$exclude_rules` array is only passed to the `record_matches_rules()` method which ignores `null` values anyway:

https://github.com/xwp/stream/blob/d6d707ee02d07b9f085523c6020fef503ccd9cb9/classes/class-log.php#L235

However, for the sake of keeping the business logic the same, I've opted for this approach instead of the one in #1466.

# Checklist

- [x] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.
