### PR TITLE
Use `$column_name` instead of `$column_title` and deprecate redundant filter

### DIFF
--- a/classes/class-list-table.php
+++ b/classes/class-list-table.php
@@ -391,37 +391,33 @@ class List_Table extends \WP_List_Table {
 				 * Registers new Columns to be inserted into the table. The cell contents of this column is set
 				 * below with 'wp_stream_insert_column_default_'
 				 *
-				 * @param array $new_columns  Columns injected in the table.
+				 * @since      3.5.1
+				 * @deprecated 4.0.1 Use the {@see 'wp_stream_list_table_columns'} filter instead.
+				 *
+				 * @param array $new_columns Columns injected in the table.
 				 *
 				 * @return array
 				 */
-				$inserted_columns = apply_filters( 'wp_stream_register_column_defaults', array() );
+				apply_filters_deprecated(
+					'wp_stream_register_column_defaults',
+					array( array() ),
+					/* translators: %s is the Stream version number. It is part of a filter deprecation notice and is preceded by: "{hook_name} is deprecated since version %s of Stream". */
+					sprintf( __( '%s of Stream', 'stream' ), '4.0.1' ),
+					'wp_stream_list_table_columns',
+					__( 'Usage of this filter is redundant. Instead, define custom column name and title using the `wp_stream_list_table_columns` filter and provide the default value using the `wp_stream_insert_column_default_{$column_name}` filter.', 'stream' )
+				);
 
-				if ( ! empty( $inserted_columns ) && is_array( $inserted_columns ) ) {
-					foreach ( $inserted_columns as $column_title ) {
-						/**
-						 * If column title inserted via wp_stream_register_column_defaults ($column_title) exists
-						 * among columns registered with get_columns ($column_name) and there is an action associated
-						 * with this column, do the action
-						 *
-						 * Also, note that the action name must include the $column_title registered
-						 * with wp_stream_register_column_defaults
-						 */
-						if ( $column_title === $column_name ) {
-							/**
-							 * Allows for the addition of content under a specified column.
-							 *
-							 * @param string $out          Column content.
-							 * @param object $record       Record with row content.
-							 * @param string $column_name  Column name.
-							 *
-							 * @return string
-							 */
-							$out = apply_filters( "wp_stream_insert_column_default_{$column_title}", $out, $record, $column_name );
-							break;
-						}
-					}
-				}
+				/**
+				 * Allows for the addition of content under a specified column.
+				 *
+				 * @param string $out         Column content.
+				 * @param object $record      Record with row content.
+				 * @param string $column_name Column name.
+				 *
+				 * @return string
+				 */
+				$out = (string) apply_filters( "wp_stream_insert_column_default_{$column_name}", $out, $record, $column_name );
+				break;
 		}
 
 		$allowed_tags                  = wp_kses_allowed_html( 'post' );


### PR DESCRIPTION
Fixes #1295.

The issue originally described in #1184 has been addressed by #1185. According to #1295, the issue was still present.

---

Adding custom columns to the Stream list table consisted of 3 steps:
1. Hooking into the `wp_stream_list_table_columns` filter, where a new column name (slug) and title (label) should be added.
2. Hooking into the `wp_stream_register_column_defaults` filter, where the column name (slug) should be added again.
3. Hooking into the `wp_stream_insert_column_default_{$column_name}` filter, where the column default value should be returned.

The issue described in #1295 and the solution proposed in https://github.com/xwp/stream/pull/1185/files#r731374767 replaced the the `$column_title` with the `$column_name` in the `wp_stream_insert_column_default_{$column_name}` filter. This is the correct and desired behavior since we want to use a name (slug) instead of a title (label) in the hook name.

When reviewing the entire process of adding new columns, I realized that the second step (as described above) is redundant and can be dropped. There is no need to register column names in the `wp_stream_register_column_defaults` again. This is already done in `wp_stream_list_table_columns` (please correct me if I'm wrong).

Because of that, I decided to deprecate `wp_stream_register_column_defaults` filter so that the current process for adding new custom column looks like this:
1. Hook into the `wp_stream_list_table_columns` filter, where a new column name (slug) and title (label) is added.
2. Hook into the `wp_stream_insert_column_default_{$column_name}` filter, where the column default value is returned.

# Checklist

- [x] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: Use `$column_name` instead of `$column_title` in the `wp_stream_insert_column_default_{$column_name}` filter
- Deprecate: `wp_stream_register_column_defaults` filter in favor of `wp_stream_list_table_columns`