### PR TITLE
fix offset warning in Slack alert when there is no custom logo

### DIFF
--- a/alerts/class-alert-type-slack.php
+++ b/alerts/class-alert-type-slack.php
@@ -74,11 +74,12 @@ class Alert_Type_Slack extends Alert_Type {
 		if ( empty( $options['webhook'] ) ) {
 			return;
 		}
-		$user_id = (int) $recordarr['user_id'];
-		$user    = get_userdata( $user_id );
-		$logo    = wp_get_attachment_image_src( get_theme_mod( 'custom_logo' ), 'full' );
-		$context = $recordarr['context'];
-		$action  = $recordarr['action'];
+		$user_id           = (int) $recordarr['user_id'];
+		$user              = get_userdata( $user_id );
+		$maybe_custom_logo = get_theme_mod( 'custom_logo' );
+		$default_logo_url  = ( ! empty( $maybe_custom_logo ) ) ? wp_get_attachment_image_url( $maybe_custom_logo, 'full' ) : '';
+		$context           = $recordarr['context'];
+		$action            = $recordarr['action'];
 
 		if ( ! empty( $alert->alert_meta['trigger_context'] ) ) {
 			$context = $this->plugin->alerts->alert_triggers['context']->get_display_value( 'list_table', $alert );
@@ -145,7 +146,7 @@ class Alert_Type_Slack extends Alert_Type {
 			'fallback'    => html_entity_decode( $recordarr['summary'], ENT_COMPAT ),
 			'fields'      => $fields,
 			'footer'      => get_bloginfo( 'name' ),
-			'footer_icon' => get_site_icon_url( 16, $logo[0], $recordarr['blog_id'] ),
+			'footer_icon' => get_site_icon_url( 16, $default_logo_url, $recordarr['blog_id'] ),
 			'title'       => html_entity_decode( $recordarr['summary'], ENT_COMPAT ),
 			'ts'          => strtotime( $recordarr['created'] ),
 		);

--- a/local/public/.gitignore
+++ b/local/public/.gitignore
@@ -1,1 +1,2 @@
 /wp/
+/wp-content/db.php


### PR DESCRIPTION
Fixes #1371 .

This does a slight amount of refactoring to make the logic clearer as well as fix the array offset error.

It also adds in `wp-content/db.php` to the gitignore file in `local/public` so if you add Query Monitor then remove it, you don't accidentally commit it

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [ ] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: PHP Warning about offset error in Slack Alert

