### PR TITLE
Remove duplicate logs when saving posts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     "wp-coding-standards/wpcs": "^3.1",
     "wp-phpunit/wp-phpunit": "^6.6",
     "wpackagist-plugin/advanced-custom-fields": "6.3.4",
+    "wpackagist-plugin/classic-editor": "1.6.4",
     "wpackagist-plugin/easy-digital-downloads": "3.3.1",
     "wpackagist-plugin/jetpack": "13.6",
     "wpackagist-plugin/user-switching": "1.8.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4fd521717953b78b94e36ed66a25a916",
+    "content-hash": "e9feaee6b5238455831561812753af61",
     "packages": [
         {
             "name": "composer/installers",
@@ -8424,6 +8424,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/advanced-custom-fields/"
+        },
+        {
+            "name": "wpackagist-plugin/classic-editor",
+            "version": "1.6.4",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/classic-editor/",
+                "reference": "tags/1.6.4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/classic-editor.1.6.4.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/classic-editor/"
         },
         {
             "name": "wpackagist-plugin/easy-digital-downloads",

--- a/connectors/class-connector-posts.php
+++ b/connectors/class-connector-posts.php
@@ -159,7 +159,13 @@ class Connector_Posts extends Connector {
 	 * @param \WP_Post $post       Post object.
 	 */
 	public function callback_transition_post_status( $new_status, $old_status, $post ) {
+
 		if ( in_array( $post->post_type, $this->get_excluded_post_types(), true ) ) {
+			return;
+		}
+
+		// We don't want the meta box update request, just the post update.
+		if ( ! empty( wp_stream_filter_input( INPUT_GET, 'meta-box-loader' ) ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #1525 

The block editor makes two requests each time a post is saved: once to save the post and once to save the legacy metaboxes. This PR checks for the `meta-box-loader` query variable and does not add a log if that is present.

This also adds the Classic Editor plugin for local testing.