### PR TITLE
Add object ID and user ID to exports

### DIFF
--- a/classes/class-export.php
+++ b/classes/class-export.php
@@ -118,9 +118,13 @@ class Export {
 					$row_out[ $column_name ] = $record->summary;
 					break;
 
-				case 'user_id':
+				case 'user':
 					$user                    = new Author( (int) $record->user_id, (array) $record->user_meta );
 					$row_out[ $column_name ] = $user->get_display_name();
+					break;
+
+				case 'user_id':
+					$row_out[ $column_name ] = $record->user_id;
 					break;
 
 				case 'connector':
@@ -129,6 +133,10 @@ class Export {
 
 				case 'context':
 					$row_out[ $column_name ] = $record->context;
+					break;
+
+				case 'object_id':
+					$row_out[ $column_name ] = $record->object_id;
 					break;
 
 				case 'action':
@@ -167,9 +175,11 @@ class Export {
 		$new_columns = array(
 			'date'      => $columns['date'],
 			'summary'   => $columns['summary'],
-			'user_id'   => $columns['user_id'],
+			'user'      => $columns['user_id'],
+			'user_id'   => __( 'User ID', 'stream' ),
 			'connector' => __( 'Connector', 'stream' ),
 			'context'   => $columns['context'],
+			'object_id' => __( 'Object ID', 'stream' ),
 			'action'    => $columns['action'],
 			'ip'        => $columns['ip'],
 		);

--- a/tests/tests/test-class-export.php
+++ b/tests/tests/test-class-export.php
@@ -43,7 +43,7 @@ class Test_Export extends WP_StreamTestCase {
 		$output = ob_get_clean();
 
 		$this->assertNotEmpty( $output );
-		$this->assertStringStartsWith( 'Date,Summary,User,Connector,Context,Action,IP Address', $output );
+		$this->assertStringStartsWith( 'Date,Summary,User,User ID,Connector,Context,Object ID,Action,IP Address', $output );
 
 		unset( $_GET['action'] );
 	}


### PR DESCRIPTION
Fixes #1413 .

This adds the object id and the user id to the exports. (The current user column is the display name so not a stable reference to the user)

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [x] I have ~added~ updated phpunit tests.


## Release Changelog

- New: The object id and user id are now included on the exports.
