### PR TITLE
Include timezone in logs for clarity

### DIFF
--- a/classes/class-export.php
+++ b/classes/class-export.php
@@ -111,7 +111,7 @@ class Export {
 			switch ( $column_name ) {
 				case 'date':
 					$created                 = gmdate( 'Y-m-d H:i:s', strtotime( $record->created ) );
-					$row_out[ $column_name ] = get_date_from_gmt( $created, 'Y/m/d h:i:s A' );
+					$row_out[ $column_name ] = get_date_from_gmt( $created, 'Y/m/d h:i:s A T' );
 					break;
 
 				case 'summary':

--- a/classes/class-list-table.php
+++ b/classes/class-list-table.php
@@ -313,7 +313,7 @@ class List_Table extends \WP_List_Table {
 				);
 				$out         = $this->column_link( $date_string, 'date', get_date_from_gmt( $created, 'Y/m/d' ) );
 				$out        .= '<br />';
-				$out        .= get_date_from_gmt( $created, 'h:i:s A' );
+				$out        .= get_date_from_gmt( $created, 'h:i:s A T' );
 				break;
 
 			case 'summary':

--- a/ui/css/admin.css
+++ b/ui/css/admin.css
@@ -87,14 +87,11 @@
 
 .toplevel_page_wp_stream .column-date {
 	width: 120px;
-	white-space: nowrap;
 }
 
 .toplevel_page_wp_stream .column-date .timeago {
 	display: inline-block;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	max-width: 100%;
+	padding-bottom: 2px;
 }
 
 .toplevel_page_wp_stream .column-user_id {


### PR DESCRIPTION
Fixes #1414, #917.

---

**#1414**

Stream logs, both those displayed in WP admin and those exported to CSV or JSON, were lacking information about the timezone in which dates are represented. This PR adds the timezone information to the Stream logs.

<img width="963" alt="Screenshot 2024-07-31 at 15 20 51" src="https://github.com/user-attachments/assets/d8f9731b-278f-459e-8e14-5b5fa16b4ba0">

---

**#917**

Sometimes the "timeago" string did not fit into a single line, causing undesired text overflow issues. This PR allows the text in the date cell to break into multiple lines.

<img width="937" alt="Screenshot 2024-07-31 at 15 25 42" src="https://github.com/user-attachments/assets/e64103c3-3b40-40dc-9a21-2589b8b4417f">


# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Enhancement: Add timezone designator to the Stream records.
- Fix: Allow text in the date cell to break into multiple lines.
