### PR TITLE
add files to generate and remove test data

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -60,6 +60,9 @@ We use npm as the canonical task runner for the project. The following commands 
 - `npm run test-xdebug` will run the PHPunit tests with Xdebug enabled.
 - `npm run switch-to:php7.4` and `npm run switch-to:php8.2` will switch you to either PHP 7.4 or PHP 8.2
 - `npm run document:connectors` generates [connectors.md](connectors.md). This runs via your local php.
+- `npm run large-log-tables:generate` inserts ~1.6M rows to `wp_stream` and ~8.4M rows to `wp_streammeta` for testing
+- `npm run large-log-tables:remove` removes the test data only
+- `npm run large-log-tables:show` shows how much test data is in the tables, this does not include non-test entries
 
 By default, tests have `WP_DEBUG` as false. You can override this if necessary by setting `WP_STREAM_TEST_DEBUG` to "yes".
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - .:/var/www/html/wp-content/plugins/stream-src # Working directory.
       - ./build:/var/www/html/wp-content/plugins/stream # Built version for testing.
       - ./local/public:/var/www/html # WP core files.
+      - ./local/scripts:/var/local/scripts # Let us access the scripts in the container.
     restart: always
     extra_hosts:
       - host.docker.internal:host-gateway

--- a/local/scripts/large-datasets/bulk-insert-logs.sample.sql
+++ b/local/scripts/large-datasets/bulk-insert-logs.sample.sql
@@ -1,0 +1,222 @@
+
+/* This is a fallback file for debugging purposes. :) */
+
+ DELIMITER / /
+
+
+ / / DROP PROCEDURE IF EXISTS generateStreamLogs
+
+ / / CREATE PROCEDURE generateStreamLogs(logdate DATETIME) BEGIN DECLARE i INT DEFAULT 0;
+
+ SELECT ( CONCAT( 'Generating data for ', logdate ) );
+
+ WHILE (i <= 100) DO
+ INSERT INTO
+	 wordpress.wp_stream (
+		 site_id,
+		 blog_id,
+		 object_id,
+		 user_id,
+		 user_role,
+		 summary,
+		 created,
+		 connector,
+		 context,
+		 `action`,
+		 ip
+	 )
+ VALUES
+	 (
+		1,
+		1,
+		i,
+		1,
+		'administrator',
+		'This is the summary',
+		logdate,
+		'posts',
+		'post',
+		'test',
+		'127.0.0.1'
+	),(
+		1,
+		1,
+		i,
+		1,
+		'administrator',
+		'This is the summary',
+		logdate,
+		'posts',
+		'post',
+		'test',
+		'127.0.0.1'
+	),(
+		1,
+		1,
+		i,
+		1,
+		'administrator',
+		'This is the summary',
+		logdate,
+		'posts',
+		'post',
+		'test',
+		'127.0.0.1'
+	),(
+		1,
+		1,
+		i,
+		1,
+		'administrator',
+		'This is the summary',
+		logdate,
+		'posts',
+		'post',
+		'test',
+		'127.0.0.1'
+	),(
+		1,
+		1,
+		i,
+		1,
+		'administrator',
+		'This is the summary',
+		logdate,
+		'posts',
+		'post',
+		'test',
+		'127.0.0.1'
+	),(
+		1,
+		1,
+		i,
+		1,
+		'administrator',
+		'This is the summary',
+		logdate,
+		'posts',
+		'post',
+		'test',
+		'127.0.0.1'
+	),(
+		1,
+		1,
+		i,
+		1,
+		'administrator',
+		'This is the summary',
+		logdate,
+		'posts',
+		'post',
+		'test',
+		'127.0.0.1'
+	),(
+		1,
+		1,
+		i,
+		1,
+		'administrator',
+		'This is the summary',
+		logdate,
+		'posts',
+		'post',
+		'test',
+		'127.0.0.1'
+	),(
+		1,
+		1,
+		i,
+		1,
+		'administrator',
+		'This is the summary',
+		logdate,
+		'posts',
+		'post',
+		'test',
+		'127.0.0.1'
+	),(
+		1,
+		1,
+		i,
+		1,
+		'administrator',
+		'This is the summary',
+		logdate,
+		'posts',
+		'post',
+		'test',
+		'127.0.0.1'
+	);
+
+ INSERT INTO
+	 wordpress.wp_stream_meta (record_id, meta_key, meta_value)
+ VALUES
+	(LAST_INSERT_ID() + 0, 'test_meta_key_1', 'meta_value_1'),
+	(LAST_INSERT_ID() + 0, 'test_meta_key_2', 'meta_value_2'),
+	(LAST_INSERT_ID() + 0, 'test_meta_key_3', 'meta_value_3'),
+	(LAST_INSERT_ID() + 0, 'test_meta_key_4', 'meta_value_4'),
+	(LAST_INSERT_ID() + 0, 'test_meta_key_5', 'meta_value_5'),(LAST_INSERT_ID() + 1, 'test_meta_key_1', 'meta_value_1'),
+	(LAST_INSERT_ID() + 1, 'test_meta_key_2', 'meta_value_2'),
+	(LAST_INSERT_ID() + 1, 'test_meta_key_3', 'meta_value_3'),
+	(LAST_INSERT_ID() + 1, 'test_meta_key_4', 'meta_value_4'),
+	(LAST_INSERT_ID() + 1, 'test_meta_key_5', 'meta_value_5'),(LAST_INSERT_ID() + 2, 'test_meta_key_1', 'meta_value_1'),
+	(LAST_INSERT_ID() + 2, 'test_meta_key_2', 'meta_value_2'),
+	(LAST_INSERT_ID() + 2, 'test_meta_key_3', 'meta_value_3'),
+	(LAST_INSERT_ID() + 2, 'test_meta_key_4', 'meta_value_4'),
+	(LAST_INSERT_ID() + 2, 'test_meta_key_5', 'meta_value_5'),(LAST_INSERT_ID() + 3, 'test_meta_key_1', 'meta_value_1'),
+	(LAST_INSERT_ID() + 3, 'test_meta_key_2', 'meta_value_2'),
+	(LAST_INSERT_ID() + 3, 'test_meta_key_3', 'meta_value_3'),
+	(LAST_INSERT_ID() + 3, 'test_meta_key_4', 'meta_value_4'),
+	(LAST_INSERT_ID() + 3, 'test_meta_key_5', 'meta_value_5'),(LAST_INSERT_ID() + 4, 'test_meta_key_1', 'meta_value_1'),
+	(LAST_INSERT_ID() + 4, 'test_meta_key_2', 'meta_value_2'),
+	(LAST_INSERT_ID() + 4, 'test_meta_key_3', 'meta_value_3'),
+	(LAST_INSERT_ID() + 4, 'test_meta_key_4', 'meta_value_4'),
+	(LAST_INSERT_ID() + 4, 'test_meta_key_5', 'meta_value_5'),(LAST_INSERT_ID() + 5, 'test_meta_key_1', 'meta_value_1'),
+	(LAST_INSERT_ID() + 5, 'test_meta_key_2', 'meta_value_2'),
+	(LAST_INSERT_ID() + 5, 'test_meta_key_3', 'meta_value_3'),
+	(LAST_INSERT_ID() + 5, 'test_meta_key_4', 'meta_value_4'),
+	(LAST_INSERT_ID() + 5, 'test_meta_key_5', 'meta_value_5'),(LAST_INSERT_ID() + 6, 'test_meta_key_1', 'meta_value_1'),
+	(LAST_INSERT_ID() + 6, 'test_meta_key_2', 'meta_value_2'),
+	(LAST_INSERT_ID() + 6, 'test_meta_key_3', 'meta_value_3'),
+	(LAST_INSERT_ID() + 6, 'test_meta_key_4', 'meta_value_4'),
+	(LAST_INSERT_ID() + 6, 'test_meta_key_5', 'meta_value_5'),(LAST_INSERT_ID() + 7, 'test_meta_key_1', 'meta_value_1'),
+	(LAST_INSERT_ID() + 7, 'test_meta_key_2', 'meta_value_2'),
+	(LAST_INSERT_ID() + 7, 'test_meta_key_3', 'meta_value_3'),
+	(LAST_INSERT_ID() + 7, 'test_meta_key_4', 'meta_value_4'),
+	(LAST_INSERT_ID() + 7, 'test_meta_key_5', 'meta_value_5'),(LAST_INSERT_ID() + 8, 'test_meta_key_1', 'meta_value_1'),
+	(LAST_INSERT_ID() + 8, 'test_meta_key_2', 'meta_value_2'),
+	(LAST_INSERT_ID() + 8, 'test_meta_key_3', 'meta_value_3'),
+	(LAST_INSERT_ID() + 8, 'test_meta_key_4', 'meta_value_4'),
+	(LAST_INSERT_ID() + 8, 'test_meta_key_5', 'meta_value_5'),(LAST_INSERT_ID() + 9, 'test_meta_key_1', 'meta_value_1'),
+	(LAST_INSERT_ID() + 9, 'test_meta_key_2', 'meta_value_2'),
+	(LAST_INSERT_ID() + 9, 'test_meta_key_3', 'meta_value_3'),
+	(LAST_INSERT_ID() + 9, 'test_meta_key_4', 'meta_value_4'),
+	(LAST_INSERT_ID() + 9, 'test_meta_key_5', 'meta_value_5');
+
+ SET
+	 i = i + 1;
+
+ END WHILE;
+
+ END;
+
+ / / DROP PROCEDURE IF EXISTS generateStreamLogsByDays
+
+ / / CREATE PROCEDURE generateStreamLogsByDays() BEGIN DECLARE j INT DEFAULT 0;
+
+ WHILE (j <= 1640) DO CALL generateStreamLogs(
+	 DATE_ADD(
+		 CAST('2018-07-02 00:00:00' as DATETIME),
+		 INTERVAL - j DAY
+	 )
+ );
+
+ SET
+	 j = j + 1;
+
+ END WHILE;
+
+ END;
+
+ / / CALL generateStreamLogsByDays();
+

--- a/local/scripts/large-datasets/bulk-insert-logs.sql
+++ b/local/scripts/large-datasets/bulk-insert-logs.sql
@@ -1,0 +1,223 @@
+
+/* This is a generated file. Run it via `php local/scripts/large-datasets/generate-bulk-insert.php` outside the Docker container. */
+
+ DELIMITER / /
+
+
+ / / DROP PROCEDURE IF EXISTS generateStreamLogs
+
+ / / CREATE PROCEDURE generateStreamLogs(logdate DATETIME) BEGIN DECLARE i INT DEFAULT 0;
+
+ SELECT ( CONCAT( 'Generating data for ', logdate ) );
+
+ WHILE (i <= 100) DO
+ INSERT INTO
+	 wordpress.wp_stream (
+		 site_id,
+		 blog_id,
+		 object_id,
+		 user_id,
+		 user_role,
+		 summary,
+		 created,
+		 connector,
+		 context,
+		 `action`,
+		 ip
+	 )
+ VALUES
+	 (
+		1,
+		1,
+		i,
+		1,
+		'administrator',
+		'This is the summary',
+		logdate,
+		'posts',
+		'post',
+		'test',
+		'127.0.0.1'
+	),(
+		1,
+		1,
+		i,
+		1,
+		'administrator',
+		'This is the summary',
+		logdate,
+		'posts',
+		'post',
+		'test',
+		'127.0.0.1'
+	),(
+		1,
+		1,
+		i,
+		1,
+		'administrator',
+		'This is the summary',
+		logdate,
+		'posts',
+		'post',
+		'test',
+		'127.0.0.1'
+	),(
+		1,
+		1,
+		i,
+		1,
+		'administrator',
+		'This is the summary',
+		logdate,
+		'posts',
+		'post',
+		'test',
+		'127.0.0.1'
+	),(
+		1,
+		1,
+		i,
+		1,
+		'administrator',
+		'This is the summary',
+		logdate,
+		'posts',
+		'post',
+		'test',
+		'127.0.0.1'
+	),(
+		1,
+		1,
+		i,
+		1,
+		'administrator',
+		'This is the summary',
+		logdate,
+		'posts',
+		'post',
+		'test',
+		'127.0.0.1'
+	),(
+		1,
+		1,
+		i,
+		1,
+		'administrator',
+		'This is the summary',
+		logdate,
+		'posts',
+		'post',
+		'test',
+		'127.0.0.1'
+	),(
+		1,
+		1,
+		i,
+		1,
+		'administrator',
+		'This is the summary',
+		logdate,
+		'posts',
+		'post',
+		'test',
+		'127.0.0.1'
+	),(
+		1,
+		1,
+		i,
+		1,
+		'administrator',
+		'This is the summary',
+		logdate,
+		'posts',
+		'post',
+		'test',
+		'127.0.0.1'
+	),(
+		1,
+		1,
+		i,
+		1,
+		'administrator',
+		'This is the summary',
+		logdate,
+		'posts',
+		'post',
+		'test',
+		'127.0.0.1'
+	);
+
+ INSERT INTO
+	 wordpress.wp_stream_meta (record_id, meta_key, meta_value)
+ VALUES
+	(LAST_INSERT_ID() + 0, 'test_meta_key_1', 'meta_value_1'),
+	(LAST_INSERT_ID() + 0, 'test_meta_key_2', 'meta_value_2'),
+	(LAST_INSERT_ID() + 0, 'test_meta_key_3', 'meta_value_3'),
+	(LAST_INSERT_ID() + 0, 'test_meta_key_4', 'meta_value_4'),
+	(LAST_INSERT_ID() + 0, 'test_meta_key_5', 'meta_value_5'),(LAST_INSERT_ID() + 1, 'test_meta_key_1', 'meta_value_1'),
+	(LAST_INSERT_ID() + 1, 'test_meta_key_2', 'meta_value_2'),
+	(LAST_INSERT_ID() + 1, 'test_meta_key_3', 'meta_value_3'),
+	(LAST_INSERT_ID() + 1, 'test_meta_key_4', 'meta_value_4'),
+	(LAST_INSERT_ID() + 1, 'test_meta_key_5', 'meta_value_5'),(LAST_INSERT_ID() + 2, 'test_meta_key_1', 'meta_value_1'),
+	(LAST_INSERT_ID() + 2, 'test_meta_key_2', 'meta_value_2'),
+	(LAST_INSERT_ID() + 2, 'test_meta_key_3', 'meta_value_3'),
+	(LAST_INSERT_ID() + 2, 'test_meta_key_4', 'meta_value_4'),
+	(LAST_INSERT_ID() + 2, 'test_meta_key_5', 'meta_value_5'),(LAST_INSERT_ID() + 3, 'test_meta_key_1', 'meta_value_1'),
+	(LAST_INSERT_ID() + 3, 'test_meta_key_2', 'meta_value_2'),
+	(LAST_INSERT_ID() + 3, 'test_meta_key_3', 'meta_value_3'),
+	(LAST_INSERT_ID() + 3, 'test_meta_key_4', 'meta_value_4'),
+	(LAST_INSERT_ID() + 3, 'test_meta_key_5', 'meta_value_5'),(LAST_INSERT_ID() + 4, 'test_meta_key_1', 'meta_value_1'),
+	(LAST_INSERT_ID() + 4, 'test_meta_key_2', 'meta_value_2'),
+	(LAST_INSERT_ID() + 4, 'test_meta_key_3', 'meta_value_3'),
+	(LAST_INSERT_ID() + 4, 'test_meta_key_4', 'meta_value_4'),
+	(LAST_INSERT_ID() + 4, 'test_meta_key_5', 'meta_value_5'),(LAST_INSERT_ID() + 5, 'test_meta_key_1', 'meta_value_1'),
+	(LAST_INSERT_ID() + 5, 'test_meta_key_2', 'meta_value_2'),
+	(LAST_INSERT_ID() + 5, 'test_meta_key_3', 'meta_value_3'),
+	(LAST_INSERT_ID() + 5, 'test_meta_key_4', 'meta_value_4'),
+	(LAST_INSERT_ID() + 5, 'test_meta_key_5', 'meta_value_5'),(LAST_INSERT_ID() + 6, 'test_meta_key_1', 'meta_value_1'),
+	(LAST_INSERT_ID() + 6, 'test_meta_key_2', 'meta_value_2'),
+	(LAST_INSERT_ID() + 6, 'test_meta_key_3', 'meta_value_3'),
+	(LAST_INSERT_ID() + 6, 'test_meta_key_4', 'meta_value_4'),
+	(LAST_INSERT_ID() + 6, 'test_meta_key_5', 'meta_value_5'),(LAST_INSERT_ID() + 7, 'test_meta_key_1', 'meta_value_1'),
+	(LAST_INSERT_ID() + 7, 'test_meta_key_2', 'meta_value_2'),
+	(LAST_INSERT_ID() + 7, 'test_meta_key_3', 'meta_value_3'),
+	(LAST_INSERT_ID() + 7, 'test_meta_key_4', 'meta_value_4'),
+	(LAST_INSERT_ID() + 7, 'test_meta_key_5', 'meta_value_5'),(LAST_INSERT_ID() + 8, 'test_meta_key_1', 'meta_value_1'),
+	(LAST_INSERT_ID() + 8, 'test_meta_key_2', 'meta_value_2'),
+	(LAST_INSERT_ID() + 8, 'test_meta_key_3', 'meta_value_3'),
+	(LAST_INSERT_ID() + 8, 'test_meta_key_4', 'meta_value_4'),
+	(LAST_INSERT_ID() + 8, 'test_meta_key_5', 'meta_value_5'),(LAST_INSERT_ID() + 9, 'test_meta_key_1', 'meta_value_1'),
+	(LAST_INSERT_ID() + 9, 'test_meta_key_2', 'meta_value_2'),
+	(LAST_INSERT_ID() + 9, 'test_meta_key_3', 'meta_value_3'),
+	(LAST_INSERT_ID() + 9, 'test_meta_key_4', 'meta_value_4'),
+	(LAST_INSERT_ID() + 9, 'test_meta_key_5', 'meta_value_5');
+
+ SET
+	 i = i + 1;
+
+ END WHILE;
+
+ END;
+
+ / / DROP PROCEDURE IF EXISTS generateStreamLogsByDays
+
+ / / CREATE PROCEDURE generateStreamLogsByDays() BEGIN DECLARE j INT DEFAULT 0;
+
+ WHILE (j <= 1640) DO CALL generateStreamLogs(
+	 DATE_ADD(
+		 CAST('2018-07-02 00:00:00' as DATETIME),
+		 INTERVAL - j DAY
+	 )
+ );
+
+ SET
+	 j = j + 1;
+
+ END WHILE;
+
+ END;
+
+ / / CALL generateStreamLogsByDays();
+
+ 

--- a/local/scripts/large-datasets/generate-bulk-insert.php
+++ b/local/scripts/large-datasets/generate-bulk-insert.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Helper script to generate bulk insert sql.
+ */
+
+ // The total number of stream records to insert per day will be:
+ // $number_of_values_to_insert_at_a_time * $number_of_inserts_per_day
+ // You can play with these numbers to see performance.
+$number_of_values_to_insert_at_a_time = 10;
+$number_of_inserts_per_day            = 100;
+
+// The number of days to insert data.
+$number_of_days                       = 1640;
+
+// The starting date for the insert. The days will run backwards from this.
+$starting_date = '2018-07-02 00:00:00';
+
+$stream_values      = [];
+$stream_meta_values = [];
+
+for ( $j=0; $j < $number_of_values_to_insert_at_a_time; $j++ ) {
+	$stream_values[] = "(
+		1,
+		1,
+		i,
+		1,
+		'administrator',
+		'This is the summary',
+		logdate,
+		'posts',
+		'post',
+		'test',
+		'127.0.0.1'
+	)";
+
+	$stream_meta_values[] = "(LAST_INSERT_ID() + {$j}, 'test_meta_key_1', 'meta_value_1'),
+	(LAST_INSERT_ID() + {$j}, 'test_meta_key_2', 'meta_value_2'),
+	(LAST_INSERT_ID() + {$j}, 'test_meta_key_3', 'meta_value_3'),
+	(LAST_INSERT_ID() + {$j}, 'test_meta_key_4', 'meta_value_4'),
+	(LAST_INSERT_ID() + {$j}, 'test_meta_key_5', 'meta_value_5')";
+}
+
+ob_start();
+?>
+
+/* This is a generated file. Run it via `php local/scripts/large-datasets/generate-bulk-insert.php` outside the Docker container. */
+
+ DELIMITER / /
+
+
+ / / DROP PROCEDURE IF EXISTS generateStreamLogs
+
+ / / CREATE PROCEDURE generateStreamLogs(logdate DATETIME) BEGIN DECLARE i INT DEFAULT 0;
+
+ SELECT ( CONCAT( 'Generating data for ', logdate ) );
+
+ WHILE (i <= <?php echo (int) $number_of_inserts_per_day; ?>) DO
+ INSERT INTO
+	 wordpress.wp_stream (
+		 site_id,
+		 blog_id,
+		 object_id,
+		 user_id,
+		 user_role,
+		 summary,
+		 created,
+		 connector,
+		 context,
+		 `action`,
+		 ip
+	 )
+ VALUES
+	 <?php echo implode( ',', $stream_values ); ?>;
+
+ INSERT INTO
+	 wordpress.wp_stream_meta (record_id, meta_key, meta_value)
+ VALUES
+	<?php echo implode( ',', $stream_meta_values ); ?>;
+
+ SET
+	 i = i + 1;
+
+ END WHILE;
+
+ END;
+
+ / / DROP PROCEDURE IF EXISTS generateStreamLogsByDays
+
+ / / CREATE PROCEDURE generateStreamLogsByDays() BEGIN DECLARE j INT DEFAULT 0;
+
+ WHILE (j <= <?php echo (int) $number_of_days; ?>) DO CALL generateStreamLogs(
+	 DATE_ADD(
+		 CAST('<?php echo $starting_date; ?>' as DATETIME),
+		 INTERVAL - j DAY
+	 )
+ );
+
+ SET
+	 j = j + 1;
+
+ END WHILE;
+
+ END;
+
+ / / CALL generateStreamLogsByDays();
+
+ <?php
+
+$sql = ob_get_clean();
+
+file_put_contents( __DIR__ . '/bulk-insert-logs.sql', $sql );

--- a/local/scripts/large-datasets/remove-test-logs.sql
+++ b/local/scripts/large-datasets/remove-test-logs.sql
@@ -1,0 +1,8 @@
+/* Delete the test data only */
+
+SELECT COUNT(ID) AS 'number of stream records being deleted:' FROM wordpress.wp_stream WHERE action='test';
+SELECT COUNT(meta_id) AS 'number of stream meta data rows being deleted:' FROM wordpress.wp_stream_meta WHERE meta_key LIKE 'test_meta_key_%';
+
+SELECT( 'Please be patient, this can take some time' );
+DELETE FROM wordpress.wp_stream_meta WHERE meta_key LIKE 'test_meta_key_%';
+DELETE FROM wordpress.wp_stream WHERE action='test';

--- a/local/scripts/large-datasets/show-stream-db-stats.sql
+++ b/local/scripts/large-datasets/show-stream-db-stats.sql
@@ -1,0 +1,4 @@
+/* Whatever can go here, it's just to see the state of things. */
+
+SELECT COUNT(ID) AS 'number of stream records:' FROM wordpress.wp_stream WHERE action='test';
+SELECT COUNT(meta_id) AS 'number of stream meta data rows:' FROM wordpress.wp_stream_meta WHERE meta_key LIKE 'test_meta_key_%';

--- a/package.json
+++ b/package.json
@@ -57,6 +57,9 @@
     "stop-all": "docker stop $(docker ps -a -q)",
     "logs": "docker compose logs --follow",
     "cli": "docker compose run --rm --user $(id -u) wordpress --",
+    "large-log-tables:remove": "npm run cli -- /bin/sh -c  'mysql mysql -hmysql -uroot -ppassword < /var/local/scripts/large-datasets/remove-test-logs.sql'",
+    "large-log-tables:generate": "npm run cli -- /bin/sh -c  'mysql mysql -hmysql -uroot -ppassword < /var/local/scripts/large-datasets/bulk-insert-logs.sql'",
+    "large-log-tables:show": "npm run cli -- /bin/sh -c  'mysql mysql -hmysql -uroot -ppassword < /var/local/scripts/large-datasets/show-stream-db-stats.sql'",
     "install-wordpress": "npm run cli wp core multisite-install"
   }
 }


### PR DESCRIPTION
This adds three npm scripts to generate large tables as well as a php script to generate the SQL file. 

You can tweak the generation script to generate different amounts of data. Currently it's "put it back when you're done" so revert your changes unless they're a better way of generating the data :) 

# Checklist

- [x] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Tooling: Add scripts to generate large Stream tables for testing
