### PR TITLE
Display feature request notice on Settings screen

### DIFF
--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -158,6 +158,9 @@ class Admin {
 		add_action( 'admin_notices', array( $this, 'prepare_admin_notices' ) );
 		add_action( 'shutdown', array( $this, 'admin_notices' ) );
 
+		// Feature request notice.
+		add_action( 'admin_notices', array( $this, 'display_feature_request_notice' ) );
+
 		// Add admin body class.
 		add_filter( 'admin_body_class', array( $this, 'admin_body_class' ) );
 
@@ -300,6 +303,26 @@ class Admin {
 
 			echo wp_kses( $html_message, $allowed_html );
 		}
+	}
+
+	/**
+	 * Display a feature request notice.
+	 *
+	 * @return void
+	 */
+	public function display_feature_request_notice() {
+		$screen = get_current_screen();
+
+		// Display the notice only on the Stream settings page.
+		if ( empty( $this->screen_id['settings'] ) || $this->screen_id['settings'] !== $screen->id ) {
+			return;
+		}
+
+		printf(
+			'<div class="notice notice-info notice-stream-feature-request"><p>%1$s <a href="https://github.com/xwp/stream/issues/new/choose" target="_blank">%2$s <span class="dashicons dashicons-external"></span></a></p></div>',
+			esc_html__( 'Have suggestions or found a bug?', 'stream' ),
+			esc_html__( 'Click here to let us know!', 'stream' )
+		);
 	}
 
 	/**

--- a/ui/css/admin.css
+++ b/ui/css/admin.css
@@ -272,6 +272,11 @@ more custom columns squeezes the summary column to a narrow strip.
 
 /* Settings */
 
+.notice-stream-feature-request .dashicons {
+	font-size: 17px;
+	text-decoration: none;
+}
+
 .wp_stream_settings .select2.select2-container,
 .wp_stream_network_settings .select2.select2-container,
 .wp_stream_default_settings .select2.select2-container {


### PR DESCRIPTION
Fixes #1539

This PR adds a feature request notice on the Stream Settings screen like this:

<img width="1118" alt="Screenshot 2024-08-05 at 14 20 18" src="https://github.com/user-attachments/assets/ed7665ea-15c4-4204-b6dc-a1089d86375a">

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [ ] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- New: Display a feature request notice on the Settings screen
