### PR TITLE
Improve connector registration logic

### DIFF
--- a/classes/class-connectors.php
+++ b/classes/class-connectors.php
@@ -109,8 +109,8 @@ class Connectors {
 			// Set fully qualified class name.
 			$class_name = sprintf( '\WP_Stream\Connector_%s', str_replace( '-', '_', $connector ) );
 
-			// Bail if no class loaded or it does not extend WP_Stream\Connector.
-			if ( ! class_exists( $class_name ) || ! is_subclass_of( $class_name, 'WP_Stream\Connector' ) ) {
+			// Bail if no class loaded.
+			if ( ! class_exists( $class_name ) ) {
 				continue;
 			}
 

--- a/classes/class-connectors.php
+++ b/classes/class-connectors.php
@@ -98,6 +98,9 @@ class Connectors {
 			'wordpress-seo',
 		);
 
+		// Get excluded connectors.
+		$excluded_connectors = array();
+
 		$classes = array();
 		foreach ( $connectors as $connector ) {
 			// Load connector class file.
@@ -106,33 +109,14 @@ class Connectors {
 			// Set fully qualified class name.
 			$class_name = sprintf( '\WP_Stream\Connector_%s', str_replace( '-', '_', $connector ) );
 
-			// Bail if no class loaded.
-			if ( ! class_exists( $class_name ) ) {
+			// Bail if no class loaded or it does not extend WP_Stream\Connector.
+			if ( ! class_exists( $class_name ) || ! is_subclass_of( $class_name, 'WP_Stream\Connector' ) ) {
 				continue;
 			}
 
 			// Initialize connector.
-			$class = new $class_name( $this->plugin->log );
-
-			// Check if the connector class extends WP_Stream\Connector.
-			if ( ! is_subclass_of( $class, 'WP_Stream\Connector' ) ) {
-				continue;
-			}
-
-			// Check if the connector events are allowed to be registered in the WP Admin.
-			if ( is_admin() && ! $class->register_admin ) {
-				continue;
-			}
-
-			// Check if the connector events are allowed to be registered in the WP Frontend.
-			if ( ! is_admin() && ! $class->register_frontend ) {
-				continue;
-			}
-
-			// Run any final validations the connector may have before used.
-			if ( $class->is_dependency_satisfied() ) {
-				$classes[ $class->name ] = $class;
-			}
+			$class = new $class_name();
+			$classes[ $class->name ] = $class;
 		}
 
 		/**
@@ -140,23 +124,28 @@ class Connectors {
 		 *
 		 * @param array $classes An array of Connector objects.
 		 */
-		$this->connectors = apply_filters( 'wp_stream_connectors', $classes );
+		$connector_classes = apply_filters( 'wp_stream_connectors', $classes );
 
-		if ( empty( $this->connectors ) ) {
-			return;
-		}
-
-		foreach ( $this->connectors as $connector ) {
-			if ( ! method_exists( $connector, 'get_label' ) ) {
+		foreach ( $connector_classes as $connector ) {
+			// Check if the connector class extends WP_Stream\Connector.
+			if ( ! is_subclass_of( $connector, 'WP_Stream\Connector' ) ) {
 				continue;
 			}
-			$this->term_labels['stream_connector'][ $connector->name ] = $connector->get_label();
-		}
 
-		// Get excluded connectors.
-		$excluded_connectors = array();
+			// Check if the connector events are allowed to be registered in the WP Admin.
+			if ( is_admin() && ! $connector->register_admin ) {
+				continue;
+			}
 
-		foreach ( $this->connectors as $connector ) {
+			// Check if the connector events are allowed to be registered in the WP Frontend.
+			if ( ! is_admin() && ! $connector->register_frontend ) {
+				continue;
+			}
+
+			// Run any final validations the connector may have before used.
+			if ( ! $connector->is_dependency_satisfied() ) {
+				continue;
+			}
 
 			// Register error for invalid any connector class.
 			if ( ! method_exists( $connector, 'get_label' ) ) {
@@ -180,21 +169,6 @@ class Connectors {
 				continue;
 			}
 
-			// Check if the connectors extends the Connector class, if not skip it.
-			if ( ! is_subclass_of( $connector, '\WP_Stream\Connector' ) ) {
-				/* translators: %s: connector class name, intended to provide help to developers (e.g. "Connector_BuddyPress") */
-				$this->plugin->admin->notice( sprintf( __( '%1$s class wasn\'t loaded because it doesn\'t extends the %2$s class.', 'stream' ), $connector->name, 'Connector' ), true );
-				continue;
-			}
-
-			// Store connector label.
-			if ( ! in_array( $connector->name, $this->term_labels['stream_connector'], true ) ) {
-				$this->term_labels['stream_connector'][ $connector->name ] = $connector->get_label();
-			}
-
-			$connector_name = $connector->name;
-			$is_excluded    = in_array( $connector_name, $excluded_connectors, true );
-
 			/**
 			 * Allows excluded connectors to be overridden and registered.
 			 *
@@ -202,16 +176,28 @@ class Connectors {
 			 * @param string $connector           The current connector's slug.
 			 * @param array  $excluded_connectors An array of all excluded connector slugs.
 			 */
-			$is_excluded_connector = apply_filters( 'wp_stream_check_connector_is_excluded', $is_excluded, $connector_name, $excluded_connectors );
+			$is_excluded_connector = apply_filters(
+				'wp_stream_check_connector_is_excluded',
+				in_array( $connector->name, $excluded_connectors, true ),
+				$connector->name,
+				$excluded_connectors
+			);
 
 			if ( $is_excluded_connector ) {
 				continue;
 			}
 
+			// Add connector to the registry.
+			$this->connectors[ $connector->name ] = $connector;
+
+			// Register the connector.
 			$connector->register();
 
 			// Link context labels to their connector.
 			$this->contexts[ $connector->name ] = $connector->get_context_labels();
+
+			// Store connector label.
+			$this->term_labels['stream_connector'][ $connector->name ] = $connector->get_label();
 
 			// Add new terms to our label lookup array.
 			$this->term_labels['stream_action']  = array_merge(
@@ -229,8 +215,8 @@ class Connectors {
 		/**
 		 * Fires after all connectors have been registered.
 		 *
-		 * @param array      $labels     All register connectors labels array
-		 * @param Connectors $connectors The Connectors object
+		 * @param array      $labels            All register connectors labels array
+		 * @param Connectors $connector_classes The Connectors object
 		 */
 		do_action( 'wp_stream_after_connectors_registration', $labels, $this );
 	}


### PR DESCRIPTION
Fixes #1500.

Connector classes can be validated in a single loop pass and only registered if they pass all the checks. The checks should involve validating that all connector dependencies are satisfied. We should not rely on a third-party to do that for us.

## Sample Connector

***Note: The following is intended to replace the connector example presented in https://github.com/xwp/stream/wiki/Creating-a-Custom-Connector***

A custom connector can be really simple. There are just a few tasks it must do:
- Register the connector class in Stream.
- Define action or actions (WordPress hooks) along with a callback function which should be triggered whenever an action is called. The callback function is responsible for creating the actual log record.
- Define labels used on the admin screens.

Below, you'll find an example of a connector plugin. It's a Stream Observer which logs visits to the Stream Settings and Alerts admin screens. While it would not be useful in a real-life scenario, it can show basic concepts behind Stream connectors really well.

The plugin consists of only 2 files. In the first one, the main file containing the necessary WordPress plugin header, the connector class is registered in Stream via the `wp_stream_connectors` filter:

```php
<?php
/**
 * Plugin Name: Stream Observer Connector
 *
 * @package Stream_Observer
 */

namespace Stream_Observer;

/**
 * Register the Stream Observer connector.
 *
 * @param array $classes Array of connector class names.
 *
 * @return array
 */
add_filter(
	'wp_stream_connectors',
	function ( $classes ) {
		require plugin_dir_path( __FILE__ ) . '/classes/class-connector.php';

		$classes[] = new Connector();

		return $classes;
	}
);
```

The second file contains the connector class definition:

```php
<?php
/**
 * Stream Observer - a connector to log Stream admin screens visits.
 *
 * @package Stream_Observer
 */

namespace Stream_Observer;

class Connector extends \WP_Stream\Connector {
	/**
	 * "Visited" action slug.
	 */
	const ACTION_VISITED = 'visited';

	/**
	 * "Admin" context slug.
	 */
	const CONTEXT_ADMIN = 'admin';

	/**
	 * Connector slug.
	 *
	 * @var string
	 */
	public $name = 'stream_observer';

	/**
	 * Actions registered for this connector.
	 *
	 * These are actions (WordPress hooks) that the Stream_Observer connector
	 * will listen to. Whenever an action from this list is triggered, Stream
	 * will run a callback function defined in the connector class.
	 *
	 * The callback function names follow the format: `callback_{action_name}`.
	 *
	 * @var array
	 */
	public $actions = array(
		'current_screen',
	);

	/**
	 * Return translated connector label.
	 *
	 * @return string
	 */
	public function get_label() {
		return __( 'Stream Observer', 'stream-observer' );
	}

	/**
	 * Return translated context labels.
	 *
	 * @return array
	 */
	public function get_context_labels() {
		return array(
			self::CONTEXT_ADMIN => __( 'Admin', 'stream-observer' ),
		);
	}

	/**
	 * Return translated action labels.
	 *
	 * @return array
	 */
	public function get_action_labels() {
		return array(
			self::ACTION_VISITED => __( 'Visited', 'stream-observer' ),
		);
	}

	/**
	 * Track `current_screen` action and log Stream screens visits.
	 *
	 * @param \WP_Screen $current_screen Current `WP_Screen` object.
	 *
	 * @return void
	 */
	public function callback_current_screen( $current_screen ) {
		if ( ! ( $current_screen instanceof \WP_Screen ) ) {
			return;
		}

		// We want to log visits to the Alerts or Settings screens.
		$tracked_screens = array(
			'edit-wp_stream_alerts'          => __( 'Alerts', 'stream-observer' ),
			'stream_page_wp_stream_settings' => __( 'Settings', 'stream-observer' ),
		);

		if ( ! isset( $tracked_screens[ $current_screen->id ] ) ) {
			return;
		}

		$this->log(
			/* translators: %1$s: Stream admin screen title, e.g. "Alerts".. */
			__( 'Stream "%1$s" screen visited', 'stream-observer' ),
			// This array will be compacted and saved as Stream meta.
			array(
				'title' => $tracked_screens[ $current_screen->id ],
				'id'    => $current_screen->id,
			),
			// Stream admin screens don't use numeric IDs so we set object ID to 0.
			0,
			self::CONTEXT_ADMIN,
			self::ACTION_VISITED,
		);
	}
}
```

Here you'll find the list of actions the connector should listen to:

```php
public $actions = array(
	'current_screen',
);
```

Along with a callback function which calls `$this->log( ... )` to store the record:

```php
public function callback_current_screen( $current_screen )
```

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [ ] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: Do not rely on third-parties in checking if a custom connector dependencies are satisfied