### PR TITLE
Fix local environment path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ tests/data/tmp/*
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+/playwright/.auth/

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -258,7 +258,7 @@ class Plugin {
 		$dir_url         = trailingslashit( plugins_url( '', __DIR__ ) );
 		$dir_path        = plugin_dir_path( __DIR__ );
 		$dir_basename    = basename( $dir_path );
-		$plugin_basename = trailingslashit( $dir_basename ) . $dir_basename . '.php';
+		$plugin_basename = trailingslashit( $dir_basename ) . 'stream.php';
 
 		return compact( 'dir_url', 'dir_path', 'dir_basename', 'plugin_basename' );
 	}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -33,12 +33,16 @@ module.exports = defineConfig( {
 		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
 		trace: 'on-first-retry',
 	},
-
 	/* Configure projects for major browsers */
 	projects: [
+		{ name: 'setup', testMatch: /setup\.js/ },
 		{
 			name: 'chromium',
-			use: { ...devices[ 'Desktop Chrome' ] },
+			use: {
+				...devices[ 'Desktop Chrome' ],
+				storageState: 'playwright/.auth/user.json',
+			},
+			dependencies: [ 'setup' ],
 		},
 	],
 } );

--- a/tests/e2e/editor-new-post.spec.js
+++ b/tests/e2e/editor-new-post.spec.js
@@ -21,10 +21,7 @@ test.describe( 'Editor: saving a new post', () => {
 		console.log( `New post ${ postTitle }` );
 
 		// Even though we're using WP's npm package, it's more straightforward to do it this way, at least for me in this environment.
-		await page.goto( 'http://stream.wpenv.net/wp-login.php?redirect_to=http://stream.wpenv.net/wp-admin/post-new.php%2F&reauth=1' );
-		await page.getByLabel( 'Username or Email Address' ).fill( 'admin' );
-		await page.getByLabel( 'Password', { exact: true } ).fill( 'password' );
-		await page.getByRole( 'button', { name: 'Log In' } ).click();
+		await page.goto( 'http://stream.wpenv.net/wp-admin/post-new.php' );
 		await page.getByLabel( 'Add title' ).click();
 		await page.getByLabel( 'Add title' ).fill( postTitle );
 		await page.getByLabel( 'Add title' ).press( 'Tab' );

--- a/tests/e2e/network-activated.spec.js
+++ b/tests/e2e/network-activated.spec.js
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+let page;
+
+test.describe.configure( { mode: 'serial' } );
+
+test.beforeAll( async ( { browser } ) => {
+	page = await browser.newPage();
+} );
+
+test.afterAll( async () => {
+	await page.goto( 'http://stream.wpenv.net/wp-admin/network/plugins.php' );
+	const isActive = await page
+		.getByLabel( 'Network Deactivate Stream' )
+		.isVisible();
+
+	if ( isActive ) {
+		// eslint-disable-next-line no-console
+		console.log( 'Deactivating Stream after Network tests.' );
+		await page.getByLabel( 'Network Deactivate Stream' ).click();
+	}
+} );
+
+test.describe( 'Network: shows network activated states', () => {
+	// Do we have a published row?
+	test( 'does not show stream in network admin when deactivated', async () => {
+		await page.goto( 'http://stream.wpenv.net/wp-admin/network/index.php' );
+		// Expects Stream log to not have the Network Settings.
+		await expect(
+			page.locator( '[href*="admin.php?page=wp_stream"]' ),
+		).not.toBeVisible();
+	} );
+
+	// We should not have an updated row. This times out which makes it fail.
+	test( 'does not have updated row', async () => {
+		await page.goto( 'http://stream.wpenv.net/wp-admin/network/plugins.php' );
+		const isActive = await page
+			.getByLabel( 'Network Activate Stream' )
+			.isVisible();
+
+		if ( isActive ) {
+			// eslint-disable-next-line no-console
+			console.log( 'Activating Stream for next tests.' );
+			await page.getByLabel( 'Network Activate Stream' ).click();
+		}
+
+		await page.goto( 'http://stream.wpenv.net/wp-admin/network/index.php' );
+		// Expects Stream log to not have the Network Settings.
+		await expect(
+			page.locator( '[href*="admin.php?page=wp_stream_network_settings"]' ),
+		).toBeVisible();
+	} );
+} );

--- a/tests/e2e/network-activated.spec.js
+++ b/tests/e2e/network-activated.spec.js
@@ -37,7 +37,7 @@ test.describe( 'Network: shows network activated states', () => {
 	// We should not have an updated row. This times out which makes it fail.
 	test( 'does not have updated row', async () => {
 		await page.goto( 'http://stream.wpenv.net/wp-admin/network/plugins.php' );
-		const isActive = await page
+		const isInactive = await page
 			.getByLabel( 'Network Activate Stream' )
 			.isVisible();
 

--- a/tests/e2e/network-activated.spec.js
+++ b/tests/e2e/network-activated.spec.js
@@ -41,7 +41,7 @@ test.describe( 'Network: shows network activated states', () => {
 			.getByLabel( 'Network Activate Stream' )
 			.isVisible();
 
-		if ( isActive ) {
+		if ( isInactive ) {
 			// eslint-disable-next-line no-console
 			console.log( 'Activating Stream for next tests.' );
 			await page.getByLabel( 'Network Activate Stream' ).click();

--- a/tests/e2e/setup/setup.js
+++ b/tests/e2e/setup/setup.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { test as setup } from '@playwright/test';
+
+const authFile = 'playwright/.auth/user.json';
+
+/**
+ * Log in before all the tests.
+ * @see https://playwright.dev/docs/auth
+ */
+setup( 'authenticate', async ( { page } ) => {
+	// Log in.
+	await page.goto( 'http://stream.wpenv.net/wp-login.php' );
+	await page.getByLabel( 'Username or Email Address' ).fill( 'admin' );
+	await page.getByLabel( 'Password', { exact: true } ).fill( 'password' );
+	await page.getByRole( 'button', { name: 'Log In' } ).click();
+	// Wait until the page receives the cookies.
+
+	// Sometimes login flow sets cookies in the process of several redirects.
+	// Wait for the final URL to ensure that the cookies are actually set.
+	await page.waitForURL( 'http://stream.wpenv.net/wp-admin/' );
+
+	await page.goto( 'http://stream.wpenv.net/wp-admin/network/plugins.php' );
+	const isActive = await page.getByLabel( 'Network Deactivate Stream' ).isVisible();
+
+	// eslint-disable-next-line no-console
+	console.log( `Stream is currently active: ${ isActive }` );
+
+	if ( isActive ) {
+		// eslint-disable-next-line no-console
+		console.log( 'Deactivating Stream before tests.' );
+		await page.getByLabel( 'Network Deactivate Stream' ).click();
+	}
+
+	// End of authentication steps.
+	await page.context().storageState( { path: authFile } );
+
+	// eslint-disable-next-line no-console
+	console.log( 'Done with network setup.' );
+} );


### PR DESCRIPTION
Fixes #1545 

Fixes the path to the plugin file and adds e2e tests which show the network admin UI in the network activated and deactivated states.

It also introduces a setup step for the e2e tests which logs a user in as admin and deactivates the plugin so we know which state we're in when starting the tests.

To run all of the e2e tests, use `npm run tests-e2e`

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: `$this->plugin->is_network_activated()` works correctly now on local environments.