### PR TITLE
Fix BuddyPress Action links

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     "wp-coding-standards/wpcs": "^3.1",
     "wp-phpunit/wp-phpunit": "^6.6",
     "wpackagist-plugin/advanced-custom-fields": "6.3.4",
+    "wpackagist-plugin/buddypress": "14.0.0",
     "wpackagist-plugin/classic-editor": "1.6.4",
     "wpackagist-plugin/easy-digital-downloads": "3.3.1",
     "wpackagist-plugin/jetpack": "13.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "10410efd54bb48d70f99c5e81ba94947",
+    "content-hash": "8238a49e6491e7a1369be939e9e43b83",
     "packages": [
         {
             "name": "composer/installers",
@@ -8467,6 +8467,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/advanced-custom-fields/"
+        },
+        {
+            "name": "wpackagist-plugin/buddypress",
+            "version": "14.0.0",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/buddypress/",
+                "reference": "tags/14.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/buddypress.14.0.0.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/buddypress/"
         },
         {
             "name": "wpackagist-plugin/classic-editor",

--- a/connectors/class-connector-buddypress.php
+++ b/connectors/class-connector-buddypress.php
@@ -173,6 +173,13 @@ class Connector_BuddyPress extends Connector {
 	 * @return array Action links
 	 */
 	public function action_links( $links, $record ) {
+
+		// Check we have access to BuddyPress on this blog and that the user will have access to the links.
+		if ( ! $this->is_dependency_satisfied() || ! bp_current_user_can_moderate() ) {
+			return;
+		}
+
+		// In the links, we also need to check the functions themselves as they're dependent on the BuddyPress module being enabled.
 		if ( in_array( $record->context, array( 'components' ), true ) ) {
 			$option_key = $record->get_meta( 'option_key', true );
 
@@ -181,7 +188,7 @@ class Connector_BuddyPress extends Connector {
 					array(
 						'page' => 'bp-components',
 					),
-					admin_url( 'admin.php' )
+					get_admin_url( $record->blog_id, 'admin.php' )
 				);
 			} elseif ( 'bp-pages' === $option_key ) {
 				$page_id = $record->get_meta( 'page_id', true );
@@ -190,7 +197,7 @@ class Connector_BuddyPress extends Connector {
 					array(
 						'page' => 'bp-page-settings',
 					),
-					admin_url( 'admin.php' )
+					get_admin_url( $record->blog_id, 'admin.php' )
 				);
 
 				if ( $page_id ) {
@@ -203,7 +210,7 @@ class Connector_BuddyPress extends Connector {
 				array(
 					'page' => $record->get_meta( 'page', true ),
 				),
-				admin_url( 'admin.php' )
+				get_admin_url( $record->blog_id, 'admin.php' )
 			);
 		} elseif ( in_array( $record->context, array( 'groups' ), true ) && function_exists( 'groups_get_group' ) ) {
 			$group_id = $record->get_meta( 'id', true );
@@ -218,7 +225,7 @@ class Connector_BuddyPress extends Connector {
 				$base_url   = \bp_get_admin_url( 'admin.php?page=bp-groups&amp;gid=' . $group_id );
 				$delete_url = wp_nonce_url( $base_url . '&amp;action=delete', 'bp-groups-delete' );
 				$edit_url   = $base_url . '&amp;action=edit';
-				$visit_url  = \bp_get_group_permalink( $group );
+				$visit_url  = function_exists( 'bp_get_group_url' ) ? \bp_get_group_url( $group ) : \bp_get_group_permalink( $group );
 
 				$links[ esc_html__( 'Edit group', 'stream' ) ]   = $edit_url;
 				$links[ esc_html__( 'View group', 'stream' ) ]   = $visit_url;


### PR DESCRIPTION
Fixes #1520 

This updates the action links to be blog specific and does not show them if the user can't view the linked page or if BuddyPress is not active on the site. This means that if BuddyPress is not network active and is enabled on a site other than the main site, the action links will not show up in the network admin Stream log table.

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.

