### PR TITLE
Add filter to allow more records in exports with tests

### DIFF
--- a/classes/class-connectors.php
+++ b/classes/class-connectors.php
@@ -115,7 +115,7 @@ class Connectors {
 			}
 
 			// Initialize connector.
-			$class = new $class_name();
+			$class                   = new $class_name();
 			$classes[ $class->name ] = $class;
 		}
 

--- a/classes/class-export.php
+++ b/classes/class-export.php
@@ -162,7 +162,14 @@ class Export {
 	 * @return int
 	 */
 	public function disable_paginate() {
-		return 10000;
+
+		/**
+		 * Filter to change how many records are exported.
+		 * Increasing this too much could cause your export to time out.
+		 *
+		 * @return int The number of records to export.
+		 */
+		return apply_filters( 'wp_stream_export_limit', 10000 );
 	}
 
 	/**

--- a/tests/phpunit/test-class-export.php
+++ b/tests/phpunit/test-class-export.php
@@ -89,6 +89,23 @@ class Test_Export extends WP_StreamTestCase {
 	}
 
 	/**
+	 * Test pagination limit filter
+	 */
+	public function test_export_limit_filter() {
+		add_filter(
+			'wp_stream_export_limit',
+			static function () {
+				return 5;
+			}
+		);
+
+		$filtered_limit = $this->export->disable_paginate();
+		$this->assertEquals( $filtered_limit, 5 );
+
+		remove_all_filters( 'wp_stream_export_limit' );
+	}
+
+	/**
 	 * Test for present columns returning
 	 */
 	public function test_expand_columns() {


### PR DESCRIPTION
Also fixes a whitespace linting issue in an unrelated file.

Fixes #1476.

This adds a filter to set how many records are exported.

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
  This needs to be done in the wiki when it's released.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [x] I have added phpunit tests.
