### PR TITLE
Feature: allow defining of settings capability for more granular access control

### DIFF
--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -110,11 +110,11 @@ class Admin {
 	public $view_cap = 'view_stream';
 
 	/**
-	 * Capability name for viewing settings
+	 * Capability name for managing settings
 	 *
 	 * @var string
 	 */
-	public $settings_cap = 'manage_options';
+	public $settings_cap = WP_STREAM_SETTINGS_CAPABILITY;
 
 	/**
 	 * Total amount of authors to pre-load

--- a/classes/class-alerts.php
+++ b/classes/class-alerts.php
@@ -27,7 +27,7 @@ class Alerts {
 	/**
 	 * Capability required to access alerts.
 	 */
-	const CAPABILITY = 'manage_options';
+	const CAPABILITY = WP_STREAM_SETTINGS_CAPABILITY;
 
 	/**
 	 * Holds Instance of plugin object

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,14 @@ View the [plugin description on WordPress.org](https://wordpress.org/plugins/str
 
 A list of the connectors is in [connectors.md](connectors.md).
 
+### Configuration
+
+To customize who can manage Stream settings, you can define the `WP_STREAM_SETTINGS_CAPABILITY` constant in your `wp-config.php` file. By default, capability will be set to `manage_options`.
+
+```php
+define('WP_STREAM_SETTINGS_CAPABILITY', 'wp_stream_manage_settings');
+```
+
 ## Known Issues
 
 - We have temporarily disabled the data removal feature through plugin uninstallation, starting with version 3.9.3. We identified a few edge cases that did not behave as expected and we decided that a temporary removal is preferable at this time for such an impactful and irreversible operation. Our team is actively working on refining this feature to ensure it performs optimally and securely. We plan to reintroduce it in a future update with enhanced safeguards.

--- a/stream.php
+++ b/stream.php
@@ -31,6 +31,13 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+/**
+ * Configuration Constants
+ */
+if ( ! defined( 'WP_STREAM_SETTINGS_CAPABILITY' ) ) {
+	define( 'WP_STREAM_SETTINGS_CAPABILITY', 'manage_options' );
+}
+
 const WP_STREAM_MIN_PHP_VERSION = '7.0';
 
 if ( version_compare( PHP_VERSION, WP_STREAM_MIN_PHP_VERSION, '<' ) ) {


### PR DESCRIPTION
### What
Introduces optional constant WP_STREAM_SETTINGS_CAPABILITY to allow site owners to set more granular control over who can manage Stream's settings. It defaults to the existing `manage_options` for backward compatibility. 

### Why
We run a large multisite and request the ability to have a custom capability name so we can filter access to Stream settings for our network and site admins based on user settings.

# Checklist

- [x] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
