### PR TITLE
Use Yoast deprecated method conditionally

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "wpackagist-plugin/jetpack": "13.6",
     "wpackagist-plugin/two-factor": "0.9.1",
     "wpackagist-plugin/user-switching": "1.8.0",
-    "wpackagist-plugin/wordpress-seo": "23.1",
+    "wpackagist-plugin/wordpress-seo": "23.6",
     "wpackagist-plugin/wp-crontrol": "1.17.0",
     "wpackagist-theme/twentytwentythree": "^1.0",
     "xwp/wait-for": "^0.0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "81ba0f890407d548fa7dcf88b79a1d3f",
+    "content-hash": "da3052af4e98a524473b832a82ec0ce4",
     "packages": [
         {
             "name": "composer/installers",
@@ -8560,15 +8560,15 @@
         },
         {
             "name": "wpackagist-plugin/wordpress-seo",
-            "version": "23.1",
+            "version": "23.6",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wordpress-seo/",
-                "reference": "tags/23.1"
+                "reference": "tags/23.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wordpress-seo.23.1.zip"
+                "url": "https://downloads.wordpress.org/plugin/wordpress-seo.23.6.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "81ba0f890407d548fa7dcf88b79a1d3f",
+    "content-hash": "5aab1f8048c3967f358b9a5e2621f976",
     "packages": [
         {
             "name": "composer/installers",
@@ -8539,6 +8539,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/jetpack/"
+        },
+        {
+            "name": "wpackagist-plugin/two-factor",
+            "version": "0.9.1",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/two-factor/",
+                "reference": "tags/0.9.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/two-factor.0.9.1.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/two-factor/"
         },
         {
             "name": "wpackagist-plugin/user-switching",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5aab1f8048c3967f358b9a5e2621f976",
+    "content-hash": "81ba0f890407d548fa7dcf88b79a1d3f",
     "packages": [
         {
             "name": "composer/installers",
@@ -8539,24 +8539,6 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/jetpack/"
-        },
-        {
-            "name": "wpackagist-plugin/two-factor",
-            "version": "0.9.1",
-            "source": {
-                "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/two-factor/",
-                "reference": "tags/0.9.1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/two-factor.0.9.1.zip"
-            },
-            "require": {
-                "composer/installers": "^1.0 || ^2.0"
-            },
-            "type": "wordpress-plugin",
-            "homepage": "https://wordpress.org/plugins/two-factor/"
         },
         {
             "name": "wpackagist-plugin/user-switching",

--- a/connectors/class-connector-wordpress-seo.php
+++ b/connectors/class-connector-wordpress-seo.php
@@ -385,7 +385,9 @@ class Connector_WordPress_SEO extends Connector {
 	private function meta( $object_id, $meta_key, $meta_value ) {
 		$prefix = \WPSEO_Meta::$meta_prefix;
 
-		\WPSEO_Metabox::translate_meta_boxes();
+		if ( defined( 'WPSEO_VERSION' ) && version_compare( WPSEO_VERSION, '23.5', '<' ) ) {
+			\WPSEO_Metabox::translate_meta_boxes();
+		}
 
 		if ( 0 !== strpos( $meta_key, $prefix ) ) {
 			return;


### PR DESCRIPTION
Fixes #1594


# Checklist

- [x] I have tested the changes in the local development environment (see `contributing.md`).

## Release Changelog

- Fix: Use `\WPSEO_Metabox::translate_meta_boxes()` conditionally to prevent logging warnings.
