### PR TITLE
Fix saving inline alerts

### DIFF
--- a/classes/class-alerts-list.php
+++ b/classes/class-alerts-list.php
@@ -374,8 +374,8 @@ class Alerts_List {
 		$trigger_author                      = wp_stream_filter_input( INPUT_POST, 'wp_stream_trigger_author' );
 		$trigger_connector_and_context       = wp_stream_filter_input( INPUT_POST, 'wp_stream_trigger_connector_or_context' );
 		$trigger_connector_and_context_split = explode( '-', $trigger_connector_and_context );
-		$trigger_connector                   = $trigger_connector_and_context_split[0];
-		$trigger_context                     = $trigger_connector_and_context_split[1];
+		$trigger_connector                   = array_shift( $trigger_connector_and_context_split ) ?? '';
+		$trigger_context                     = array_shift( $trigger_connector_and_context_split ) ?? '';
 
 		$trigger_action      = wp_stream_filter_input( INPUT_POST, 'wp_stream_trigger_action' );
 		$alert_type          = wp_stream_filter_input( INPUT_POST, 'wp_stream_alert_type' );

--- a/classes/class-alerts.php
+++ b/classes/class-alerts.php
@@ -610,6 +610,24 @@ class Alerts {
 		echo '<label>' . esc_html__( 'Alert me when', 'stream' ) . '</label>';
 		$form->render_fields();
 		wp_nonce_field( 'save_alert', 'wp_stream_alerts_nonce' );
+
+		if ( $post instanceof \WP_Post ) :
+			/**
+			 * These fields are required for the post to be saved, as the Admin AJAX inline_save action is fired.
+			 *
+			 * @see get_inline_data()
+			 * @see wp_ajax_inline_save()
+			 */
+			?>
+			<input type="hidden" name="_status" value="<?php echo esc_attr( get_post_status( $post->ID ) ); ?>" />
+			<input type="hidden" name="jj" value="<?php echo esc_attr( mysql2date( 'd', $post->post_date, false ) ); ?>" />
+			<input type="hidden" name="mm" value="<?php echo esc_attr( mysql2date( 'm', $post->post_date, false ) ); ?>" />
+			<input type="hidden" name="aa" value="<?php echo esc_attr( mysql2date( 'Y', $post->post_date, false ) ); ?>" />
+			<input type="hidden" name="hh" value="<?php echo esc_attr( mysql2date( 'H', $post->post_date, false ) ); ?>" />
+			<input type="hidden" name="mn" value="<?php echo esc_attr( mysql2date( 'i', $post->post_date, false ) ); ?>" />
+			<input type="hidden" name="ss" value="<?php echo esc_attr( mysql2date( 's', $post->post_date, false ) ); ?>" />
+			<?php
+		endif;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1527.

The issue has 2 parts.

1. Saving inline the Alert will fire the Admin AJAX `inline_save` action. In its internals, it expected information about the date and time of the post to be available as POST arguments. We are adding this information as hidden fields;
2. There are cases where we are not saving a context or a connector. We should ensure a fallback;

# Checklist

- [x] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [x] I have added phpunit tests.


## Release Changelog

- Fix: Ensure that WordPress's core inline_save action has all the information it needs to save the Stream Alert post type.
- Fix: Handle partial data for Connector or Context
