### PR TITLE
Fix: Allow only safe URLs for Slack alerts.

### DIFF
--- a/alerts/class-alert-type-slack.php
+++ b/alerts/class-alert-type-slack.php
@@ -171,7 +171,7 @@ class Alert_Type_Slack extends Alert_Type {
 				$data['icon_url'] = $options['icon'];
 			}
 		}
-		wp_remote_post(
+		wp_safe_remote_post(
 			$options['webhook'],
 			array(
 				'body'    => wp_json_encode( $data ),


### PR DESCRIPTION
Fixes #000.

Hardening fix reported by one of users.

# Checklist

- [x] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: Allow only safe URLs for Slack alerts.