### PR TITLE
Use Woo built in method to get tax label

### DIFF
--- a/connectors/class-connector-woocommerce.php
+++ b/connectors/class-connector-woocommerce.php
@@ -619,14 +619,16 @@ class Connector_Woocommerce extends Connector {
 	 * @param array $tax_rate     Tax Rate data.
 	 */
 	public function callback_woocommerce_tax_rate_updated( $tax_rate_id, $tax_rate ) {
+		$tax_rate_label = \WC_Tax::get_rate_label( $tax_rate_id );
+
 		$this->log(
-			/* translators: %4$s: a tax rate name (e.g. "GST") */
+			/* translators: %s: a tax rate name (e.g. "GST") */
 			_x(
-				'"%4$s" tax rate updated',
+				'"%s" tax rate updated',
 				'Tax rate name',
 				'stream'
 			),
-			$tax_rate,
+			array( $tax_rate_label ),
 			$tax_rate_id,
 			'tax',
 			'updated'


### PR DESCRIPTION
Fixes https://github.com/xwp/stream/issues/1649.

Instead of relaying on the `$tax_rate` array, which seems not to work anymore, we're using built in method from the `WC_Tax` `\WC_Tax::get_rate_label()` class to get the edited tax label.

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: Use Woo built in method `\WC_Tax::get_rate_label()` to get the tax label