### PR TITLE
Update the `Test_WP_Stream_Connector_Editor::test_log_changes` test case to reflect the recent changes

### DIFF
--- a/connectors/class-connector-editor.php
+++ b/connectors/class-connector-editor.php
@@ -213,7 +213,7 @@ class Connector_Editor extends Connector {
 			return;
 		}
 
-		$location   = null;
+		$location = null;
 
 		if ( $theme_slug ) {
 			$location          = 'theme-editor.php';

--- a/tests/phpunit/connectors/test-class-connector-editor.php
+++ b/tests/phpunit/connectors/test-class-connector-editor.php
@@ -1,7 +1,15 @@
 <?php
 namespace WP_Stream;
 
+use WP_UnitTestCase_Base;
+
 class Test_WP_Stream_Connector_Editor extends WP_StreamTestCase {
+	/**
+	 * Admin user ID
+	 *
+	 * @var int
+	 */
+	private int $admin_user_id;
 
 	/**
 	 * The original contents of the file.
@@ -15,6 +23,15 @@ class Test_WP_Stream_Connector_Editor extends WP_StreamTestCase {
 
 		$this->plugin->connectors->unload_connectors();
 		$this->original_contents = file_get_contents( WP_PLUGIN_DIR . '/hello.php' );
+
+		// Add admin user to test caps.
+		$this->admin_user_id = WP_UnitTestCase_Base::factory()->user->create(
+			array(
+				'role'       => 'administrator',
+				'user_login' => 'test_admin',
+				'email'      => 'test@land.com',
+			)
+		);
 
 		$this->mock = $this->getMockBuilder( Connector_Editor::class )
 			->setMethods( array( 'log' ) )
@@ -30,6 +47,8 @@ class Test_WP_Stream_Connector_Editor extends WP_StreamTestCase {
 	public function test_log_changes() {
 		$theme  = wp_get_theme( 'twentytwentythree' );
 		$plugin = get_plugins()['hello.php'];
+
+		wp_set_current_user( $this->admin_user_id );
 
 		$this->mock->expects( $this->exactly( 2 ) )
 			->method( 'log' )
@@ -76,22 +95,35 @@ class Test_WP_Stream_Connector_Editor extends WP_StreamTestCase {
 				)
 			);
 
-		// Update theme file.
+		// Update the request method.
 		$_SERVER['REQUEST_METHOD'] = 'POST';
-		$_POST['action']           = 'update';
-		$_POST['theme']            = 'twentytwentythree';
-		do_action( 'load-theme-editor.php' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 
-		\file_put_contents( $theme->get_files( 'css' )['style.css'], "\r\n", FILE_APPEND ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-		apply_filters( 'wp_redirect', 'theme-editor.php' );
+		// Generate the nonce and send a theme code update request.
+		$nonce             = wp_create_nonce( 'edit-theme_twentytwentythree_style.css' );
+		$_REQUEST['nonce'] = $nonce;
+		$_POST             = array(
+			'nonce'            => $nonce,
+			'_wp_http_referer' => '/wp-admin/network/theme-editor.php',
+			'newcontent'       => '# hello!',
+			'action'           => 'edit-theme-plugin-file',
+			'file'             => 'style.css',
+			'theme'            => 'twentytwentythree',
+		);
 
-		// Update plugin file
-		$_POST['plugin'] = 'hello.php';
-		$_POST['file']   = 'hello.php';
-		unset( $_POST['theme'] );
-		do_action( 'load-plugin-editor.php' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+		do_action( 'wp_ajax_edit-theme-plugin-file' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 
-		\file_put_contents( WP_PLUGIN_DIR . '/hello.php', "\r\n", FILE_APPEND ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-		apply_filters( 'wp_redirect', 'plugin-editor.php' );
+		// Generate the nonce and send a plugin update request.
+		$nonce             = wp_create_nonce( 'edit-plugin_hello.php' );
+		$_REQUEST['nonce'] = $nonce;
+		$_POST             = array(
+			'nonce'            => $nonce,
+			'_wp_http_referer' => '/wp-admin/network/plugin-editor.php?plugin=hello.php&Submit=Select',
+			'newcontent'       => "<?php\n/**\n * Plugin Name: Hello Dolly!\n * Description: A plugin used for PHP unit tests\n */\n",
+			'action'           => 'edit-theme-plugin-file',
+			'file'             => 'hello.php',
+			'plugin'           => 'hello.php',
+		);
+
+		do_action( 'wp_ajax_edit-theme-plugin-file' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 	}
 }


### PR DESCRIPTION
In the https://github.com/xwp/stream/pull/1658 PR changes to the connector for theme and plugin files editor has been introduced. This PR updates the `Test_WP_Stream_Connector_Editor::test_log_changes` unit test case to reflect the recently implemented changes.

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [x] I have added phpunit tests.


## Release Changelog

- Fix: Failing PHPUnit tests related to theme and plugin file edits connector

