### PR TITLE
Fix absint Warning

### DIFF
--- a/classes/class-list-table.php
+++ b/classes/class-list-table.php
@@ -571,8 +571,8 @@ class List_Table extends \WP_List_Table {
 			}
 
 			$users = array_map(
-				function ( $user_id ) {
-					return new Author( $user_id );
+				function ( $user ) {
+					return new Author( $user->ID );
 				},
 				get_users(
 					array(


### PR DESCRIPTION
Fixes a PHP warning when trying to instantiate `Author` with an `stdClass` object instead of a user ID:

```
Warning: Object of class stdClass could not be converted to int in /wordpress/core/6.7.1/wp-includes/load.php on line 1440
```

Confusingly, `get_users()` works different to `get_posts()`, where asking for only IDs still returns an object with only an ID property instead of an array of IDs.


Describe your approach and how it fixes the issue.

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: Describe a bug fix included in this release.
- New: Describe a new feature in this release.


## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).


Change `[ ]` to `[x]` to mark the items as done.
