### PR TITLE
Fix Two Factor connector issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "wpackagist-plugin/classic-editor": "1.6.4",
     "wpackagist-plugin/easy-digital-downloads": "3.3.1",
     "wpackagist-plugin/jetpack": "13.6",
-    "wpackagist-plugin/two-factor": "^0.11.0",
+    "wpackagist-plugin/two-factor": "0.11.0",
     "wpackagist-plugin/user-switching": "1.8.0",
     "wpackagist-plugin/wordpress-seo": "23.6",
     "wpackagist-plugin/wp-crontrol": "1.17.0",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "wpackagist-plugin/classic-editor": "1.6.4",
     "wpackagist-plugin/easy-digital-downloads": "3.3.1",
     "wpackagist-plugin/jetpack": "13.6",
-    "wpackagist-plugin/two-factor": "0.9.1",
+    "wpackagist-plugin/two-factor": "^0.11.0",
     "wpackagist-plugin/user-switching": "1.8.0",
     "wpackagist-plugin/wordpress-seo": "23.6",
     "wpackagist-plugin/wp-crontrol": "1.17.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d897bc67bba8444fa3fd9f59e2af5d82",
+    "content-hash": "d5066c2f3d585f28724b2fb997511669",
     "packages": [
         {
             "name": "composer/installers",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9a10988b81293e7489563a563653d1e7",
+    "content-hash": "d897bc67bba8444fa3fd9f59e2af5d82",
     "packages": [
         {
             "name": "composer/installers",
@@ -8542,15 +8542,15 @@
         },
         {
             "name": "wpackagist-plugin/two-factor",
-            "version": "0.9.1",
+            "version": "0.11.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/two-factor/",
-                "reference": "tags/0.9.1"
+                "reference": "tags/0.11.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/two-factor.0.9.1.zip"
+                "url": "https://downloads.wordpress.org/plugin/two-factor.0.11.0.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -8742,5 +8742,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/connectors/class-connector-two-factor.php
+++ b/connectors/class-connector-two-factor.php
@@ -291,9 +291,9 @@ class Connector_Two_Factor extends Connector {
 	 * Callback to watch for 2FA authenticated actions.
 	 *
 	 * @param \WP_User $user     Authenticated user.
-	 * @param object   $provider The 2FA Provider used.
+	 * @param ?object  $provider The 2FA Provider used, null if unknown (this might happen if using older Two Factor plugin version).
 	 */
-	public function callback_two_factor_user_authenticated( $user, $provider ) {
+	public function callback_two_factor_user_authenticated( $user, $provider = null ) {
 
 		/* Translators: %s is the Two Factor provider. */
 		$message = __(
@@ -301,10 +301,15 @@ class Connector_Two_Factor extends Connector {
 			'stream'
 		);
 
+		// Get the provider key.
+		$provider_key = null === $provider
+			? __( 'unknown Two Factor method', 'stream' )
+			: $provider->get_key();
+
 		$this->log(
 			$message,
 			array(
-				'provider' => $provider->get_key(),
+				'provider' => $provider_key,
 			),
 			$user->ID,
 			'auth',


### PR DESCRIPTION
Fixes https://github.com/xwp/stream/issues/1689

Fix fatal error caused by missing data in older versions of the Two Factor plugin.

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: Fatal error caused by missing data in older versions of the Two Factor plugin.