### PR TITLE
Release 4.2.1

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -10,6 +10,7 @@ composer.lock
 docker-compose.build.yml
 docker-compose.yml
 Gruntfile.js
+connectors.md
 package.json
 package-lock.json
 phpcs.xml.dist

--- a/.github/workflows/deploy-to-stream-dist.yml
+++ b/.github/workflows/deploy-to-stream-dist.yml
@@ -64,9 +64,20 @@ jobs:
           WORKING_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
           SRC_DIR="$ROOT_DIR/source"
           DIST_DIR="$ROOT_DIR/dist"
-          DIST_BRANCH="${GITHUB_REF#refs/heads/}"
-          DIST_TAG="${GITHUB_REF#refs/tags/}"
           COMMIT_MESSAGE="$(git log -1 --oneline)"
+
+          if [ "${{ github.event_name }}" = "release" ]; then
+            # On a release event, GITHUB_REF is refs/tags/<tag>. Push the dist
+            # commit to the branch the release targets (e.g. master) and create
+            # the tag on top of it.
+            DIST_BRANCH="${{ github.event.release.target_commitish }}"
+            DIST_TAG="${GITHUB_REF#refs/tags/}"
+          else
+            # On a push event, GITHUB_REF is refs/heads/<branch>. Mirror the
+            # branch to dist without tagging.
+            DIST_BRANCH="${GITHUB_REF#refs/heads/}"
+            DIST_TAG=""
+          fi
 
           echo "ROOT_DIR=$ROOT_DIR" >> $GITHUB_ENV
           echo "WORKING_BRANCH=$WORKING_BRANCH" >> $GITHUB_ENV
@@ -121,7 +132,7 @@ jobs:
           if [ "${{ github.event_name }}" = "release" ]; then
             echo "Tagging a release: $DIST_TAG"
             git tag --force "$DIST_TAG"
-            git push --force --tags origin "$DIST_BRANCH"
+            git push --force origin "$DIST_BRANCH" "refs/tags/$DIST_TAG"
           else
             git push --force origin "$DIST_BRANCH"
           fi

--- a/alerts/class-alert-type-highlight.php
+++ b/alerts/class-alert-type-highlight.php
@@ -281,6 +281,10 @@ class Alert_Type_Highlight extends Alert_Type {
 	public function ajax_remove_highlight() {
 		check_ajax_referer( self::REMOVE_ACTION_NONCE, 'security' );
 
+		if ( ! current_user_can( $this->plugin->admin->view_cap ) ) {
+			wp_send_json_error( __( 'You do not have permission to do this.', 'stream' ) );
+		}
+
 		$failure_message = __( 'Removing Highlight Failed', 'stream' );
 
 		if ( empty( $_POST['recordId'] ) ) {

--- a/alerts/class-alert-type-ifttt.php
+++ b/alerts/class-alert-type-ifttt.php
@@ -209,7 +209,7 @@ class Alert_Type_IFTTT extends Alert_Type {
 			$recordarr,
 			array(
 				/* translators: %s: the Event Name of the Alert (e.g. "Update a post") */
-				'summary' => sprintf( __( 'The event %s was triggered' ), $alert->alert_meta['event_name'] ),
+				'summary' => sprintf( __( 'The event %s was triggered', 'stream' ), $alert->alert_meta['event_name'] ),
 				'user_id' => get_current_user_id(),
 				'created' => current_time( 'Y-m-d H:i:s' ),
 				// Blog's local time.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,19 @@
 # Stream Changelog
 
+## 4.2.1 - July 2, 2026
+
+### Bug Fixes
+
+- Fix authorization checks for Stream activity access and harden related AJAX, export, and query paths ([#1915](https://github.com/xwp/stream/pull/1915)).
+- Fix inverted `isset()` check silently ignoring user search input in `get_users()` ([#1897](https://github.com/xwp/stream/pull/1897)).
+- Create missing database tables when resetting the database ([#1285](https://github.com/xwp/stream/pull/1285)).
+- Avoid generating rewrite rules for the alerts post type ([#1380](https://github.com/xwp/stream/pull/1380)).
+- Correct release event branch handling for `stream-dist` deployments ([#1894](https://github.com/xwp/stream/pull/1894)).
+
+### Development
+
+- Update Node.js, Playwright, and related JavaScript/PHP development dependencies ([#1887](https://github.com/xwp/stream/pull/1887), [#1892](https://github.com/xwp/stream/pull/1892), [#1895](https://github.com/xwp/stream/pull/1895), [#1898](https://github.com/xwp/stream/pull/1898), [#1899](https://github.com/xwp/stream/pull/1899), [#1901](https://github.com/xwp/stream/pull/1901), [#1903](https://github.com/xwp/stream/pull/1903), [#1904](https://github.com/xwp/stream/pull/1904), [#1908](https://github.com/xwp/stream/pull/1908), [#1910](https://github.com/xwp/stream/pull/1910), [#1912](https://github.com/xwp/stream/pull/1912), [#1913](https://github.com/xwp/stream/pull/1913)).
+
 ## 4.2.0 - May 28, 2026
 
 ### New Features

--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -504,6 +504,9 @@ class Admin {
 				'admin-exclude',
 				array(
 					$this->plugin->with_select2(),
+				),
+				array(
+					'getActionsNonce' => wp_create_nonce( 'stream_get_actions' ),
 				)
 			);
 

--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -660,6 +660,12 @@ class Admin {
 			);
 		}
 
+		// Ensure the database tables exist before attempting to clear records.
+		// Install::check() short-circuits on DOING_AJAX, so call install()
+		// directly. dbDelta is idempotent and safe to run when tables already
+		// exist.
+		$this->plugin->install->install( $this->plugin->get_version() );
+
 		$this->erase_stream_records();
 
 		if ( defined( 'WP_STREAM_TESTS' ) && WP_STREAM_TESTS ) {

--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -510,17 +510,21 @@ class Admin {
 				)
 			);
 
+			$current_order = isset( $_GET['order'] ) ? sanitize_key( wp_unslash( $_GET['order'] ) ) : 'desc'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			if ( ! in_array( $current_order, array( 'asc', 'desc' ), true ) ) {
+				$current_order = 'desc';
+			}
+			$current_query = map_deep( wp_unslash( $_GET ), 'sanitize_text_field' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
 			$this->plugin->enqueue_asset(
 				'live-updates',
 				array( 'heartbeat' ),
 				array(
 					'current_screen'      => $hook,
 					'current_page'        => isset( $_GET['paged'] ) ? absint( wp_unslash( $_GET['paged'] ) ) : '1', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-					'current_order'       => isset( $_GET['order'] ) && in_array( strtolower( $_GET['order'] ), array( 'asc', 'desc' ), true ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-						? esc_js( $_GET['order'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-						: 'desc',
-					'current_query'       => wp_json_encode( $_GET ), // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-					'current_query_count' => count( $_GET ), // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+					'current_order'       => $current_order,
+					'current_query'       => wp_json_encode( $current_query ),
+					'current_query_count' => count( $current_query ),
 				)
 			);
 		}
@@ -1388,7 +1392,7 @@ class Admin {
 			);
 		}
 
-		$links[] = sprintf( '<a href="%s">%s</a>', esc_url( $admin_page_url ), esc_html__( 'Settings', 'default' ) );
+		$links[] = sprintf( '<a href="%s">%s</a>', esc_url( $admin_page_url ), esc_html__( 'Settings', 'stream' ) );
 
 		return $links;
 	}

--- a/classes/class-alerts-list.php
+++ b/classes/class-alerts-list.php
@@ -284,7 +284,7 @@ class Alerts_List {
 			$nonce_url = wp_nonce_url( $bare_url, 'trash-post_' . $post_id );
 			?>
 			<div class="row-actions">
-				<span class="inline hide-if-no-js"><a href="#" class="editinline" aria-label="Quick edit “Hello world!” inline"><?php esc_html_e( 'Edit' ); ?></a>&nbsp;|&nbsp;</span>
+				<span class="inline hide-if-no-js"><a href="#" class="editinline" aria-label="Quick edit “Hello world!” inline"><?php esc_html_e( 'Edit', 'stream' ); ?></a>&nbsp;|&nbsp;</span>
 				<span class="trash">
 					<a href="<?php echo esc_url( $nonce_url ); ?>" class="submitdelete"><?php esc_html_e( 'Trash', 'stream' ); ?></a>
 				</span>

--- a/classes/class-alerts.php
+++ b/classes/class-alerts.php
@@ -358,6 +358,7 @@ class Alerts {
 			'description'         => __( 'Alerts for Stream.', 'stream' ),
 			'public'              => false,
 			'publicly_queryable'  => false,
+			'rewrite'             => false,
 			'exclude_from_search' => true,
 			'show_ui'             => true,
 			'show_in_menu'        => false, // @see modify_admin_menu

--- a/classes/class-alerts.php
+++ b/classes/class-alerts.php
@@ -723,7 +723,7 @@ class Alerts {
 				</div>
 				<div id="publishing-action">
 					<span class="spinner"></span>
-					<?php submit_button( __( 'Save' ), 'primary button-large', 'publish', false ); ?>
+					<?php submit_button( __( 'Save', 'stream' ), 'primary button-large', 'publish', false ); ?>
 				</div>
 				<div class="clear"></div>
 			</div>

--- a/classes/class-alerts.php
+++ b/classes/class-alerts.php
@@ -327,8 +327,9 @@ class Alerts {
 				'inline-edit-post',
 			),
 			array(
-				'any'        => __( 'Any', 'stream' ),
-				'anyContext' => __( 'Any Context', 'stream' ),
+				'any'             => __( 'Any', 'stream' ),
+				'anyContext'      => __( 'Any Context', 'stream' ),
+				'getActionsNonce' => wp_create_nonce( 'stream_get_actions' ),
 			)
 		);
 	}
@@ -781,6 +782,8 @@ class Alerts {
 				)
 			);
 		}
+
+		check_ajax_referer( 'stream_get_actions', 'nonce' );
 
 		$connector_name    = wp_stream_filter_input( INPUT_POST, 'connector' );
 		$stream_connectors = wp_stream_get_instance()->connectors;

--- a/classes/class-alerts.php
+++ b/classes/class-alerts.php
@@ -774,6 +774,14 @@ class Alerts {
 	 * Update actions dropdown options based on the connector selected.
 	 */
 	public function get_actions() {
+		if ( ! current_user_can( self::CAPABILITY ) ) {
+			wp_send_json_error(
+				array(
+					'message' => 'You do not have permission to do this.',
+				)
+			);
+		}
+
 		$connector_name    = wp_stream_filter_input( INPUT_POST, 'connector' );
 		$stream_connectors = wp_stream_get_instance()->connectors;
 		if ( ! empty( $connector_name ) ) {

--- a/classes/class-cli.php
+++ b/classes/class-cli.php
@@ -124,7 +124,9 @@ class CLI extends \WP_CLI_Command {
 			$query_args[ $key ] = $value;
 		}
 
-		$query_args['fields'] = implode( ',', $fields );
+		// Pass fields as an array so the query builder can validate each
+		// column against its allowlist (column names cannot be prepared).
+		$query_args['fields'] = $fields;
 
 		$records = wp_stream_get_instance()->db->query( $query_args );
 

--- a/classes/class-db-driver-wpdb.php
+++ b/classes/class-db-driver-wpdb.php
@@ -138,6 +138,10 @@ class DB_Driver_WPDB implements DB_Driver {
 	 */
 	public function get_column_values( $column ) {
 		global $wpdb;
+		if ( ! in_array( $column, Query::ALLOWED_FIELDS, true ) ) {
+			return array();
+		}
+
 		return (array) $wpdb->get_results(
 			"SELECT DISTINCT $column FROM $wpdb->stream", // @codingStandardsIgnoreLine can't prepare column name
 			'ARRAY_A'

--- a/classes/class-export.php
+++ b/classes/class-export.php
@@ -46,6 +46,12 @@ class Export {
 	 * @return void
 	 */
 	public function render_download() {
+		// Records are only viewable by users with the Stream view capability;
+		// don't rely on the nonce alone for authorization.
+		if ( ! current_user_can( $this->plugin->admin->view_cap ) ) {
+			return;
+		}
+
 		$nonce = wp_stream_filter_input( INPUT_GET, 'stream_record_actions_nonce' );
 		if ( ! wp_verify_nonce( $nonce, 'stream_record_actions_nonce' ) ) {
 			return;

--- a/classes/class-install.php
+++ b/classes/class-install.php
@@ -102,8 +102,12 @@ class Install {
 		}
 
 		$update = null;
-		if ( isset( $_REQUEST['wp_stream_update'] ) && wp_verify_nonce( 'wp_stream_update_db' ) ) {
-			$update = esc_attr( $_REQUEST['wp_stream_update'] );
+		if (
+			isset( $_REQUEST['wp_stream_update'], $_REQUEST['_wpnonce'] )
+			&&
+			wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['_wpnonce'] ) ), 'wp_stream_update_db' )
+		) {
+			$update = sanitize_key( wp_unslash( $_REQUEST['wp_stream_update'] ) );
 		}
 
 		if ( ! $update ) {
@@ -221,8 +225,12 @@ class Install {
 		}
 
 		$update = null;
-		if ( isset( $_REQUEST['wp_stream_update'] ) && wp_verify_nonce( 'wp_stream_update_db' ) ) {
-			$update = esc_attr( $_REQUEST['wp_stream_update'] );
+		if (
+			isset( $_REQUEST['wp_stream_update'], $_REQUEST['_wpnonce'] )
+			&&
+			wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['_wpnonce'] ) ), 'wp_stream_update_db' )
+		) {
+			$update = sanitize_key( wp_unslash( $_REQUEST['wp_stream_update'] ) );
 		}
 
 		if ( ! $update ) {

--- a/classes/class-list-table.php
+++ b/classes/class-list-table.php
@@ -776,7 +776,8 @@ class List_Table extends \WP_List_Table {
 		$query_vars = array();
 
 		if ( isset( $_SERVER['QUERY_STRING'] ) ) {
-			parse_str( urldecode( $_SERVER['QUERY_STRING'] ), $query_vars );
+			parse_str( wp_unslash( $_SERVER['QUERY_STRING'] ), $query_vars );
+			$query_vars = map_deep( $query_vars, 'sanitize_text_field' );
 		}
 
 		// Ignore certain query vars and query vars that are empty.
@@ -911,7 +912,7 @@ class List_Table extends \WP_List_Table {
 				<input type="submit" name="" id="search-submit" class="button" value="%3$s" />
 			</p>',
 			esc_html__( 'Search Records', 'stream' ),
-			esc_attr( ! empty( $_GET['search'] ) ? $_GET['search'] : '' ), // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			esc_attr( ! empty( $_GET['search'] ) ? sanitize_text_field( wp_unslash( $_GET['search'] ) ) : '' ), // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			esc_attr__( 'Search Records', 'stream' )
 		);
 	}

--- a/classes/class-live-update.php
+++ b/classes/class-live-update.php
@@ -183,7 +183,13 @@ class Live_Update {
 			return $response;
 		}
 
-		$enable_stream_update = ( 'off' !== get_user_meta( get_current_user_id(), $this->user_meta_key ) );
+		// Ensure the current user is allowed to view Stream records before
+		// exposing any activity data through the Heartbeat API.
+		if ( ! current_user_can( $this->plugin->admin->view_cap ) ) {
+			return $response;
+		}
+
+		$enable_stream_update = ( 'off' !== get_user_meta( get_current_user_id(), $this->user_meta_key, true ) );
 
 		// Register list table.
 		$this->list_table = new List_Table(

--- a/classes/class-live-update.php
+++ b/classes/class-live-update.php
@@ -206,7 +206,7 @@ class Live_Update {
 		if ( isset( $data['wp-stream-heartbeat'] ) && isset( $total_items ) ) {
 			$response['total_items'] = $total_items;
 			/* translators: %d: number of items (e.g. "42") */
-			$response['total_items_i18n'] = sprintf( _n( '%d item', '%d items', $total_items ), number_format_i18n( $total_items ) );
+			$response['total_items_i18n'] = sprintf( _n( '%d item', '%d items', $total_items, 'stream' ), number_format_i18n( $total_items ) );
 		}
 
 		if ( isset( $data['wp-stream-heartbeat'] ) && 'live-update' === $data['wp-stream-heartbeat'] && $enable_stream_update ) {

--- a/classes/class-log.php
+++ b/classes/class-log.php
@@ -303,7 +303,7 @@ class Log {
 	 */
 	public function debug_backtrace( $recordarr ) {
 		if ( version_compare( PHP_VERSION, '5.3.6', '<' ) ) {
-			return __( 'Debug backtrace requires at least PHP 5.3.6', 'wp_stream' );
+			return __( 'Debug backtrace requires at least PHP 5.3.6', 'stream' );
 		}
 
 		// Record details.

--- a/classes/class-network.php
+++ b/classes/class-network.php
@@ -84,12 +84,14 @@ class Network {
 	 * @see https://core.trac.wordpress.org/ticket/22589
 	 */
 	public function ajax_network_admin() {
+		$http_referer = isset( $_SERVER['HTTP_REFERER'] ) ? esc_url_raw( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '';
+
 		if (
 			defined( 'DOING_AJAX' )
 			&&
 			DOING_AJAX
 			&&
-			preg_match( '#^' . network_admin_url() . '#i', $_SERVER['HTTP_REFERER'] )
+			0 === stripos( $http_referer, network_admin_url() )
 		) {
 			define( 'WP_NETWORK_ADMIN', true );
 			return WP_NETWORK_ADMIN;
@@ -348,7 +350,11 @@ class Network {
 	public function network_options_action() {
 
 		// Check the nonce.
-		if ( empty( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], sprintf( '%s-options', $this->network_settings_option ) ) ) {
+		if (
+			empty( $_POST['_wpnonce'] )
+			||
+			! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ), sprintf( '%s-options', $this->network_settings_option ) )
+		) {
 			return;
 		}
 
@@ -358,23 +364,25 @@ class Network {
 		}
 
 		// Check the action.
-		if ( ! isset( $_GET['action'] ) || $this->network_settings_page_slug !== $_GET['action'] ) {
+		$action = isset( $_GET['action'] ) ? sanitize_key( wp_unslash( $_GET['action'] ) ) : '';
+		if ( $this->network_settings_page_slug !== $action ) {
 			return;
 		}
 
-		$option = ! empty( $_POST['option_page'] ) ? $_POST['option_page'] : false;
+		$option = ! empty( $_POST['option_page'] ) ? sanitize_key( wp_unslash( $_POST['option_page'] ) ) : false;
 
 		if ( $option && $this->network_settings_option === $option ) {
 
-			$value    = array();
-			$sections = $this->plugin->settings->get_fields();
+			$value          = array();
+			$posted_options = isset( $_POST[ $option ] ) && is_array( $_POST[ $option ] ) ? wp_unslash( $_POST[ $option ] ) : array();
+			$sections       = $this->plugin->settings->get_fields();
 
 			foreach ( $sections as $section_name => $section ) {
 				foreach ( $section['fields'] as $field_idx => $field ) {
 					$option_key = $section_name . '_' . $field['name'];
 
-					if ( isset( $_POST[ $option ][ $option_key ] ) ) {
-						$value[ $option_key ] = $this->plugin->settings->sanitize_setting_by_field_type( $_POST[ $option ][ $option_key ], $field['type'] );
+					if ( isset( $posted_options[ $option_key ] ) ) {
+						$value[ $option_key ] = $this->plugin->settings->sanitize_setting_by_field_type( $posted_options[ $option_key ], $field['type'] );
 					} else {
 						$value[ $option_key ] = false;
 					}

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -20,7 +20,7 @@ class Plugin {
 	 *
 	 * @const string
 	 */
-	const VERSION = '4.2.0';
+	const VERSION = '4.2.1';
 
 	/**
 	 * WP-CLI command

--- a/classes/class-query.php
+++ b/classes/class-query.php
@@ -206,6 +206,11 @@ class Query {
 		$fields  = (array) $args['fields'];
 		$selects = array();
 
+		// Column names cannot be passed through $wpdb->prepare(), so restrict
+		// the selectable fields to a known allowlist to prevent SQL injection
+		// via the `fields` argument.
+		$selectable_fields = array( 'ID', 'site_id', 'blog_id', 'object_id', 'user_id', 'user_role', 'created', 'summary', 'connector', 'context', 'action', 'ip' );
+
 		if ( ! empty( $fields ) ) {
 			foreach ( $fields as $field ) {
 				// We'll query the meta table later.
@@ -213,9 +218,15 @@ class Query {
 					continue;
 				}
 
+				if ( ! in_array( $field, $selectable_fields, true ) ) {
+					continue;
+				}
+
 				$selects[] = sprintf( "$wpdb->stream.%s", $field );
 			}
-		} else {
+		}
+
+		if ( empty( $selects ) ) {
 			$selects[] = "$wpdb->stream.*";
 		}
 

--- a/classes/class-query.php
+++ b/classes/class-query.php
@@ -11,6 +11,8 @@ namespace WP_Stream;
  * Class - Query
  */
 class Query {
+	const ALLOWED_FIELDS = array( 'ID', 'site_id', 'blog_id', 'object_id', 'user_id', 'user_role', 'created', 'summary', 'connector', 'context', 'action', 'ip' );
+
 	/**
 	 * Hold the number of records found
 	 *
@@ -58,8 +60,7 @@ class Query {
 			$field = ! empty( $args['search_field'] ) ? $args['search_field'] : 'summary';
 
 			// Sanitize field.
-			$allowed_fields = array( 'ID', 'site_id', 'blog_id', 'object_id', 'user_id', 'user_role', 'created', 'summary', 'connector', 'context', 'action', 'ip' );
-			if ( in_array( $field, $allowed_fields, true ) ) {
+			if ( in_array( $field, self::ALLOWED_FIELDS, true ) ) {
 				$where .= $wpdb->prepare( " AND $wpdb->stream.{$field} LIKE %s", "%{$args['search']}%" ); // @codingStandardsIgnoreLine can't prepare column name
 			}
 		}
@@ -209,8 +210,6 @@ class Query {
 		// Column names cannot be passed through $wpdb->prepare(), so restrict
 		// the selectable fields to a known allowlist to prevent SQL injection
 		// via the `fields` argument.
-		$selectable_fields = array( 'ID', 'site_id', 'blog_id', 'object_id', 'user_id', 'user_role', 'created', 'summary', 'connector', 'context', 'action', 'ip' );
-
 		if ( ! empty( $fields ) ) {
 			foreach ( $fields as $field ) {
 				// We'll query the meta table later.
@@ -218,7 +217,7 @@ class Query {
 					continue;
 				}
 
-				if ( ! in_array( $field, $selectable_fields, true ) ) {
+				if ( ! in_array( $field, self::ALLOWED_FIELDS, true ) ) {
 					continue;
 				}
 

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -112,7 +112,7 @@ class Settings {
 		$search = '';
 		$input  = wp_stream_filter_input( INPUT_POST, 'find' );
 
-		if ( ! isset( $input['term'] ) ) {
+		if ( isset( $input['term'] ) ) {
 			$search = wp_unslash( trim( $input['term'] ) );
 		}
 

--- a/composer.lock
+++ b/composer.lock
@@ -6322,16 +6322,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.4.40",
+            "version": "v5.4.53",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "81cad0ceab3d61fe14fe941ff18a230ac9c80f83"
+                "reference": "ae0bbb46f77ff56591d0a0259c7f458f4b3e1f77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/81cad0ceab3d61fe14fe941ff18a230ac9c80f83",
-                "reference": "81cad0ceab3d61fe14fe941ff18a230ac9c80f83",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/ae0bbb46f77ff56591d0a0259c7f458f4b3e1f77",
+                "reference": "ae0bbb46f77ff56591d0a0259c7f458f4b3e1f77",
                 "shasum": ""
             },
             "require": {
@@ -6377,7 +6377,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.4.40"
+                "source": "https://github.com/symfony/yaml/tree/v5.4.53"
             },
             "funding": [
                 {
@@ -6389,11 +6389,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:33:22+00:00"
+            "time": "2026-05-20T17:13:41+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/connectors/class-connector-blogs.php
+++ b/connectors/class-connector-blogs.php
@@ -54,7 +54,7 @@ class Connector_Blogs extends Connector {
 	 * @return string
 	 */
 	public function get_label() {
-		return esc_html__( 'Sites' );
+		return esc_html__( 'Sites', 'stream' );
 	}
 
 	/**
@@ -103,13 +103,13 @@ class Connector_Blogs extends Connector {
 	 * @return array
 	 */
 	public function action_links( $links, $record ) {
-		$links [ esc_html__( 'Site Admin' ) ] = get_admin_url( $record->object_id );
+		$links [ esc_html__( 'Site Admin', 'stream' ) ] = get_admin_url( $record->object_id );
 
 		if ( $record->object_id ) {
 			$site_admin_link = get_admin_url( $record->object_id );
 
 			if ( $site_admin_link ) {
-				$links [ esc_html__( 'Site Admin' ) ] = $site_admin_link;
+				$links [ esc_html__( 'Site Admin', 'stream' ) ] = $site_admin_link;
 			}
 
 			$site_settings_link = add_query_arg(

--- a/connectors/class-connector-edd.php
+++ b/connectors/class-connector-edd.php
@@ -161,7 +161,8 @@ class Connector_EDD extends Connector {
 			$posts_connector = new Connector_Posts();
 			$links           = $posts_connector->action_links( $links, $record );
 		} elseif ( in_array( $record->context, array( 'discounts' ), true ) ) {
-			$post_type_label = get_post_type_labels( get_post_type_object( 'edd_discount' ) )->singular_name;
+			$post_type       = get_post_type_object( 'edd_discount' );
+			$post_type_label = $post_type ? $post_type->labels->singular_name : esc_html__( 'Discount', 'stream' );
 			$base            = admin_url( 'edit.php?post_type=download&page=edd-discounts' );
 
 			/* translators: %s: a post type (e.g. "Post") */

--- a/connectors/class-connector-mercator.php
+++ b/connectors/class-connector-mercator.php
@@ -43,7 +43,7 @@ class Connector_Mercator extends Connector {
 	 * @return string
 	 */
 	public function get_label() {
-		return esc_html__( 'Mercator' );
+		return esc_html__( 'Mercator', 'stream' );
 	}
 
 	/**
@@ -92,13 +92,13 @@ class Connector_Mercator extends Connector {
 	 * @return array
 	 */
 	public function action_links( $links, $record ) {
-		$links [ esc_html__( 'Site Admin' ) ] = get_admin_url( $record->object_id );
+		$links [ esc_html__( 'Site Admin', 'stream' ) ] = get_admin_url( $record->object_id );
 
 		if ( $record->object_id ) {
 			$site_admin_link = get_admin_url( $record->object_id );
 
 			if ( $site_admin_link ) {
-				$links [ esc_html__( 'Site Admin' ) ] = $site_admin_link;
+				$links [ esc_html__( 'Site Admin', 'stream' ) ] = $site_admin_link;
 			}
 
 			$site_settings_link = add_query_arg(

--- a/connectors/class-connector-two-factor.php
+++ b/connectors/class-connector-two-factor.php
@@ -325,7 +325,7 @@ class Connector_Two_Factor extends Connector {
 	 * @param \WP_Error $error WP_Error object.
 	 */
 	public function callback_wp_login_failed( $user_login, $error ) {
-		if ( ! str_starts_with( $error->get_error_code(), 'two_factor_' ) ) {
+		if ( 0 !== strpos( $error->get_error_code(), 'two_factor_' ) ) {
 			return;
 		}
 

--- a/includes/db-updates.php
+++ b/includes/db-updates.php
@@ -4,6 +4,7 @@
  *
  * @package WP_Stream
  */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/includes/db-updates.php
+++ b/includes/db-updates.php
@@ -4,6 +4,9 @@
  *
  * @package WP_Stream
  */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 /**
  * Version 3.0.8

--- a/includes/feeds/atom.php
+++ b/includes/feeds/atom.php
@@ -4,6 +4,7 @@
  *
  * @package WP_Stream
  */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/includes/feeds/atom.php
+++ b/includes/feeds/atom.php
@@ -4,6 +4,9 @@
  *
  * @package WP_Stream
  */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 header( 'Content-Type: ' . feed_content_type( 'atom' ) . '; charset=' . get_option( 'blog_charset' ), true );
 printf( '<?xml version="1.0" encoding="%s"?>', esc_attr( get_option( 'blog_charset' ) ) );

--- a/includes/feeds/json.php
+++ b/includes/feeds/json.php
@@ -6,6 +6,9 @@
  *
  * @var $records
  */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 header( 'Content-type: application/json; charset=' . get_option( 'blog_charset' ), true );
 echo wp_json_encode( $records, JSON_PRETTY_PRINT );

--- a/includes/feeds/json.php
+++ b/includes/feeds/json.php
@@ -6,6 +6,7 @@
  *
  * @var $records
  */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/includes/feeds/rss-2.0.php
+++ b/includes/feeds/rss-2.0.php
@@ -4,6 +4,7 @@
  *
  * @package WP_Stream
  */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/includes/feeds/rss-2.0.php
+++ b/includes/feeds/rss-2.0.php
@@ -4,6 +4,9 @@
  *
  * @package WP_Stream
  */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 header( 'Content-Type: ' . feed_content_type( 'rss-http' ) . '; charset=' . get_option( 'blog_charset' ), true );
 printf( '<?xml version="1.0" encoding="%s"?>', esc_attr( get_option( 'blog_charset' ) ) );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4,6 +4,7 @@
  *
  * @package WP_Stream
  */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4,6 +4,9 @@
  *
  * @package WP_Stream
  */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 /**
  * Gets a specific external variable by name and optionally filters it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.60.0",
-        "@types/node": "^24.12.4",
+        "@types/node": "^24.13.0",
         "@wordpress/e2e-test-utils-playwright": "^1.46.0",
         "@wordpress/eslint-plugin": "^25.2.0",
         "@wordpress/scripts": "^32.2.0",
@@ -5427,13 +5427,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.12.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
-      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "version": "24.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.0.tgz",
+      "integrity": "sha512-5vtOqGQr4NJKeEzV441FcOi2MeG9UTWq9LqVLGneDdu4vlX17H8kQ2PA2UmNwCUGPVDj4oBjNhS7ReVEIWJJrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/node-forge": {
@@ -21364,9 +21364,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "npm-run-all2": "^9.0.2"
       },
       "engines": {
-        "node": "^24.16.0"
+        "node": "^24.17.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@wordpress/scripts": "^32.2.0",
         "copy-webpack-plugin": "^14.0.0",
         "eslint-plugin-react-hooks": "^7.1.1",
-        "globals": "^17.6.0",
+        "globals": "^17.7.0",
         "jquery": "4.0.0",
         "npm-run-all2": "^9.0.2"
       },
@@ -12131,9 +12131,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
-      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "timeago": "^1.6.7"
       },
       "devDependencies": {
-        "@playwright/test": "^1.60.0",
+        "@playwright/test": "^1.61.0",
         "@types/node": "^24.13.2",
         "@wordpress/e2e-test-utils-playwright": "^1.46.0",
         "@wordpress/eslint-plugin": "^25.2.0",
@@ -4466,13 +4466,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
-      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.60.0"
+        "playwright": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -16948,13 +16948,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0"
+        "playwright-core": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -16967,9 +16967,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "npm-run-all2": "^9.0.2"
       },
       "engines": {
-        "node": "^24.17.0"
+        "node": "^24.18.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.60.0",
-        "@types/node": "^24.13.0",
+        "@types/node": "^24.13.1",
         "@wordpress/e2e-test-utils-playwright": "^1.46.0",
         "@wordpress/eslint-plugin": "^25.2.0",
         "@wordpress/scripts": "^32.2.0",
@@ -5427,9 +5427,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.13.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.0.tgz",
-      "integrity": "sha512-5vtOqGQr4NJKeEzV441FcOi2MeG9UTWq9LqVLGneDdu4vlX17H8kQ2PA2UmNwCUGPVDj4oBjNhS7ReVEIWJJrg==",
+      "version": "24.13.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.1.tgz",
+      "integrity": "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.60.0",
-        "@types/node": "^24.13.1",
+        "@types/node": "^24.13.2",
         "@wordpress/e2e-test-utils-playwright": "^1.46.0",
         "@wordpress/eslint-plugin": "^25.2.0",
         "@wordpress/scripts": "^32.2.0",
@@ -5427,9 +5427,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.13.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.1.tgz",
-      "integrity": "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "timeago": "^1.6.7"
       },
       "devDependencies": {
-        "@playwright/test": "^1.61.0",
+        "@playwright/test": "^1.61.1",
         "@types/node": "^24.13.2",
         "@wordpress/e2e-test-utils-playwright": "^1.46.0",
         "@wordpress/eslint-plugin": "^25.2.0",
@@ -4466,13 +4466,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
-      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.0"
+        "playwright": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -16948,13 +16948,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
-      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.0"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -16967,9 +16967,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
-      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18023,9 +18023,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "globals": "^17.6.0",
         "jquery": "4.0.0",
-        "npm-run-all2": "^9.0.1"
+        "npm-run-all2": "^9.0.2"
       },
       "engines": {
         "node": "^24.16.0"
@@ -16087,9 +16087,9 @@
       }
     },
     "node_modules/npm-run-all2": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-all2/-/npm-run-all2-9.0.1.tgz",
-      "integrity": "sha512-ZtK8WXZBUA9x0XD6nxYdFLe86FxpkCTq2LiQxzX0LeXQY/vyAigQZXjjj/xfTwgV4Yqe/vYNIq2W09lrHKTcuQ==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-all2/-/npm-run-all2-9.0.2.tgz",
+      "integrity": "sha512-+dd4SO2jAlLE06OzmJKzIe6QvvjXezcbmobnh8usR0a8BzQCABTdqTXqVPji0ICOhSQpIIrkGd7IzNl5iDaRSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16097,9 +16097,9 @@
         "cross-spawn": "^7.0.6",
         "memorystream": "^0.3.1",
         "picomatch": "^4.0.2",
-        "pidtree": "^0.6.0",
+        "pidtree": "^1.0.0",
         "read-package-json-fast": "^6.0.0",
-        "shell-quote": "^1.7.3",
+        "shell-quote": "^1.8.4",
         "which": "^7.0.0"
       },
       "bin": {
@@ -16811,16 +16811,16 @@
       }
     },
     "node_modules/pidtree": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
-      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-1.0.0.tgz",
+      "integrity": "sha512-avfAvjB9Dd0wdj3rjJX//yS+G79OO0KrS5pJHFJENjYGX6N4SMgEDBBI/yFy0lloOYSaC6XQxzpOAMPfSYFV/Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "pidtree": "bin/pidtree.js"
       },
       "engines": {
-        "node": ">=0.10"
+        "node": ">=18"
       }
     },
     "node_modules/pify": {
@@ -19303,9 +19303,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "globals": "^17.6.0",
     "jquery": "4.0.0",
-    "npm-run-all2": "^9.0.1"
+    "npm-run-all2": "^9.0.2"
   },
   "scripts": {
     "build": "wp-scripts build",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "track"
   ],
   "devDependencies": {
-    "@playwright/test": "^1.60.0",
+    "@playwright/test": "^1.61.0",
     "@types/node": "^24.13.2",
     "@wordpress/e2e-test-utils-playwright": "^1.46.0",
     "@wordpress/eslint-plugin": "^25.2.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "devDependencies": {
     "@playwright/test": "^1.60.0",
-    "@types/node": "^24.13.0",
+    "@types/node": "^24.13.1",
     "@wordpress/e2e-test-utils-playwright": "^1.46.0",
     "@wordpress/eslint-plugin": "^25.2.0",
     "@wordpress/scripts": "^32.2.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@wordpress/scripts": "^32.2.0",
     "copy-webpack-plugin": "^14.0.0",
     "eslint-plugin-react-hooks": "^7.1.1",
-    "globals": "^17.6.0",
+    "globals": "^17.7.0",
     "jquery": "4.0.0",
     "npm-run-all2": "^9.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "devDependencies": {
     "@playwright/test": "^1.60.0",
-    "@types/node": "^24.12.4",
+    "@types/node": "^24.13.0",
     "@wordpress/e2e-test-utils-playwright": "^1.46.0",
     "@wordpress/eslint-plugin": "^25.2.0",
     "@wordpress/scripts": "^32.2.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "devDependencies": {
     "@playwright/test": "^1.60.0",
-    "@types/node": "^24.13.1",
+    "@types/node": "^24.13.2",
     "@wordpress/e2e-test-utils-playwright": "^1.46.0",
     "@wordpress/eslint-plugin": "^25.2.0",
     "@wordpress/scripts": "^32.2.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "XWP",
   "license": "GPLv2+",
   "engines": {
-    "node": "^24.17.0"
+    "node": "^24.18.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "XWP",
   "license": "GPLv2+",
   "engines": {
-    "node": "^24.16.0"
+    "node": "^24.17.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "track"
   ],
   "devDependencies": {
-    "@playwright/test": "^1.61.0",
+    "@playwright/test": "^1.61.1",
     "@types/node": "^24.13.2",
     "@wordpress/e2e-test-utils-playwright": "^1.46.0",
     "@wordpress/eslint-plugin": "^25.2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: xwp
 Tags: wp stream, stream, activity, logs, track
 Requires at least: 4.6
 Tested up to: 7.0
-Stable tag: 4.2.0
+Stable tag: 4.2.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -133,6 +133,10 @@ Use only `$_SERVER['REMOTE_ADDR']` as the client IP address for event logs witho
 
 
 == Changelog ==
+
+= 4.2.1 - July 2, 2026 =
+
+See: [https://github.com/xwp/stream/blob/develop/changelog.md#421---july-2-2026](https://github.com/xwp/stream/blob/develop/changelog.md#421---july-2-2026)
 
 = 4.2.0 - May 28, 2026 =
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,15 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    "monorepo:wordpress"
   ],
   "enabledManagers": [
     "npm"
   ],
   "rangeStrategy": "bump",
+  "postUpdateOptions": [
+    "npmDedupe"
+  ],
   "packageRules": [
     {
       "updateTypes": [

--- a/src/js/admin-exclude.js
+++ b/src/js/admin-exclude.js
@@ -407,6 +407,7 @@ function getActions( row, connector ) {
 	const data = {
 		action: 'get_actions',
 		connector,
+		nonce: window[ 'wp-stream-admin-exclude' ].getActionsNonce,
 	};
 
 	$.post(

--- a/src/js/alerts.js
+++ b/src/js/alerts.js
@@ -140,6 +140,7 @@ function getActions( connector ) {
 	const data = {
 		action: 'get_actions',
 		connector,
+		nonce: window[ 'wp-stream-alerts' ].getActionsNonce,
 	};
 
 	$.post(

--- a/stream.php
+++ b/stream.php
@@ -3,7 +3,7 @@
  * Plugin Name: Stream
  * Plugin URI: https://xwp.co/work/stream/
  * Description: Stream tracks logged-in user activity so you can monitor every change made on your WordPress site in beautifully organized detail. All activity is organized by context, action and IP address for easy filtering. Developers can extend Stream with custom connectors to log any kind of action.
- * Version: 4.2.0
+ * Version: 4.2.1
  * Author: XWP
  * Author URI: https://xwp.co
  * License: GPLv2+

--- a/stream.php
+++ b/stream.php
@@ -34,6 +34,10 @@
 /**
  * Configuration Constants
  */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 if ( ! defined( 'WP_STREAM_SETTINGS_CAPABILITY' ) ) {
 	define( 'WP_STREAM_SETTINGS_CAPABILITY', 'manage_options' );
 }

--- a/tests/phpunit/test-class-alerts.php
+++ b/tests/phpunit/test-class-alerts.php
@@ -368,6 +368,7 @@ class Test_Alerts extends WP_StreamTestCase {
 		$alerts = new Alerts( $this->plugin );
 		try {
 			$_POST['connector'] = '';
+			$_POST['nonce']     = wp_create_nonce( 'stream_get_actions' );
 			$this->_handleAjax( 'get_actions' );
 		} catch ( \WPAjaxDieContinueException $e ) {
 			$exception = $e;

--- a/tests/phpunit/test-class-alerts.php
+++ b/tests/phpunit/test-class-alerts.php
@@ -362,6 +362,9 @@ class Test_Alerts extends WP_StreamTestCase {
 	}
 
 	public function test_get_actions() {
+		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
 		$alerts = new Alerts( $this->plugin );
 		try {
 			$_POST['connector'] = '';

--- a/tests/phpunit/test-class-export.php
+++ b/tests/phpunit/test-class-export.php
@@ -14,6 +14,9 @@ class Test_Export extends WP_StreamTestCase {
 	 */
 	public function setUp(): void {
 		parent::setUp();
+		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
 		$_GET['page'] = 'wp_stream';
 		$this->export = new Export( $this->plugin );
 		$this->assertNotEmpty( $this->export );

--- a/tests/phpunit/test-class-export.php
+++ b/tests/phpunit/test-class-export.php
@@ -16,6 +16,7 @@ class Test_Export extends WP_StreamTestCase {
 		parent::setUp();
 		$user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );
+		$this->plugin->settings->options['general_role_access'] = array( 'administrator' );
 
 		$_GET['page'] = 'wp_stream';
 		$this->export = new Export( $this->plugin );


### PR DESCRIPTION
Release 4.2.1. Merge `release/v4.2.1` into `master` so the version tag and WP.org deploy can target `master`.

## Release Changelog

See [changelog.md -> 4.2.1](https://github.com/xwp/stream/blob/release/v4.2.1/changelog.md#421---july-2-2026) for the full list. Highlights:

- **Fix:** Harden authorization checks for Stream activity access and related AJAX/export/query paths (#1915).
- **Fix:** Restore user search input handling in `get_users()` (#1897).
- **Fix:** Create missing database tables when resetting the database (#1285).
- **Fix:** Avoid generating rewrite rules for the alerts post type (#1380).
- **Fix:** Correct release event branch handling for `stream-dist` deployments (#1894).
- **Dev:** Update Node.js, Playwright, and related development dependencies.

## Release Checklist

- [x] This pull request is to the `master` branch.
- [x] Release version follows [semantic versioning](https://semver.org). No breaking changes.
- [x] Update changelog in `readme.txt`.
- [x] Bump version in `stream.php` (4.2.1).
- [x] Bump `Stable tag` in `readme.txt` (4.2.1).
- [x] Bump version in `classes/class-plugin.php` (4.2.1).
- [ ] Cut `v4.2.1-rc.1` as a GitHub pre-release targeting `release/v4.2.1` and verify WP.org dry-run + ZIP asset.
- [ ] Smoke-test the RC ZIP on a clean WP install.
- [ ] Draft the stable `v4.2.1` release on GitHub after this PR merges.

## Verification

- [x] `npm install`
- [x] `composer install`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test`
- [x] `CI=1 npm run test-e2e`


Made with [Cursor](https://cursor.com)