### PR TITLE
Harden live update preference authorization

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -120,6 +120,14 @@ jobs:
       - name: Install Composer dependencies
         run: composer install
 
+      - name: Refresh apt metadata
+        # `shivammathur/setup-php` adds the ondrej/php PPA, which recently
+        # changed its repository `Label`. `apt-get update` (invoked by
+        # Playwright's `--with-deps`) aborts with exit code 100 on such
+        # changes unless `--allow-releaseinfo-change` is passed. Refresh the
+        # metadata here so the subsequent Playwright dependency install works.
+        run: sudo apt-get update --allow-releaseinfo-change
+
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 

--- a/classes/class-list-table.php
+++ b/classes/class-list-table.php
@@ -1155,9 +1155,6 @@ class List_Table extends \WP_List_Table {
 			<div>
 				<input type="hidden" name="stream_live_update_nonce" id="stream_live_update_nonce" value="<?php echo esc_attr( $nonce ); ?>"/>
 			</div>
-			<div>
-				<input type="hidden" name="enable_live_update_user" id="enable_live_update_user" value="<?php echo absint( $user_id ); ?>"/>
-			</div>
 			<div class="metabox-prefs stream-live-update-checkbox">
 				<label for="enable_live_update">
 					<input type="checkbox" value="on" name="enable_live_update" id="enable_live_update" data-heartbeat="<?php echo esc_attr( $heartbeat ); ?>" <?php checked( $option, 'on' ); ?> />

--- a/classes/class-live-update.php
+++ b/classes/class-live-update.php
@@ -55,23 +55,15 @@ class Live_Update {
 	public function enable_live_update() {
 		check_ajax_referer( $this->user_meta_key . '_nonce', 'nonce' );
 
-		$input = array(
-			'checked'   => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
-			'user'      => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
-			'heartbeat' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
-		);
-
-		$input = filter_input_array( INPUT_POST, $input );
-
-		if ( false === $input ) {
-			wp_send_json_error( 'Error in live update checkbox' );
+		if ( ! current_user_can( $this->plugin->admin->view_cap ) ) {
+			wp_send_json_error( esc_html__( 'You do not have permission to do this.', 'stream' ) );
 		}
 
-		$checked = ( 'checked' === $input['checked'] ) ? 'on' : 'off';
+		$checked = ( 'checked' === wp_stream_filter_input( INPUT_POST, 'checked' ) ) ? 'on' : 'off';
 
-		$user = (int) $input['user'];
+		$user = get_current_user_id();
 
-		if ( 'false' === $input['heartbeat'] ) {
+		if ( 'false' === wp_stream_filter_input( INPUT_POST, 'heartbeat' ) ) {
 			update_user_meta( $user, $this->user_meta_key, 'off' );
 
 			wp_send_json_error( esc_html__( "Live updates could not be enabled because Heartbeat is not loaded.\n\nYour hosting provider or another plugin may have disabled it for performance reasons.", 'stream' ) );

--- a/src/js/admin.js
+++ b/src/js/admin.js
@@ -222,7 +222,6 @@ $( document ).ready(
 		$( '#enable_live_update' ).click(
 			function() {
 				const nonce = $( '#stream_live_update_nonce' ).val();
-				const user = $( '#enable_live_update_user' ).val();
 				let checked = 'unchecked';
 				let heartbeat = 'true';
 
@@ -239,7 +238,6 @@ $( document ).ready(
 						data: {
 							action: 'stream_enable_live_update',
 							nonce,
-							user,
 							checked,
 							heartbeat,
 						},

--- a/tests/phpunit/test-class-live-update.php
+++ b/tests/phpunit/test-class-live-update.php
@@ -1,0 +1,80 @@
+<?php
+namespace WP_Stream;
+
+/**
+ * Class Test_Live_Update
+ *
+ * @package WP_Stream
+ */
+class Test_Live_Update extends WP_StreamTestCase {
+	/**
+	 * Live update instance under test.
+	 *
+	 * @var Live_Update
+	 */
+	protected $live_update;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->live_update = new Live_Update( $this->plugin );
+	}
+
+	public function tearDown(): void {
+		unset( $_POST['action'], $_POST['nonce'], $_POST['checked'], $_POST['heartbeat'], $_POST['user'] );
+
+		parent::tearDown();
+	}
+
+	public function test_enable_live_update_only_updates_current_user() {
+		$attacker_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		$victim_id   = $this->factory->user->create( array( 'role' => 'administrator' ) );
+
+		$this->plugin->settings->options['general_role_access'] = array( 'subscriber' );
+		wp_set_current_user( $attacker_id );
+
+		$this->assertTrue( current_user_can( $this->plugin->admin->view_cap ) );
+
+		update_user_meta( $attacker_id, $this->live_update->user_meta_key, 'off' );
+		update_user_meta( $victim_id, $this->live_update->user_meta_key, 'off' );
+
+		$_POST['action']    = 'stream_enable_live_update';
+		$_POST['nonce']     = wp_create_nonce( $this->live_update->user_meta_key . '_nonce' );
+		$_POST['checked']   = 'checked';
+		$_POST['heartbeat'] = 'true';
+		$_POST['user']      = (string) $victim_id;
+
+		try {
+			$this->_handleAjax( 'stream_enable_live_update' );
+		} catch ( \WPAjaxDieContinueException $e ) {
+			// Expected: wp_send_json_success() terminates the AJAX request.
+		}
+
+		$this->assertSame( 'on', get_user_meta( $attacker_id, $this->live_update->user_meta_key, true ) );
+		$this->assertSame( 'off', get_user_meta( $victim_id, $this->live_update->user_meta_key, true ) );
+	}
+
+	public function test_enable_live_update_denies_users_without_view_cap() {
+		$user_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+
+		$this->plugin->settings->options['general_role_access'] = array( 'administrator' );
+		wp_set_current_user( $user_id );
+
+		$this->assertFalse( current_user_can( $this->plugin->admin->view_cap ) );
+
+		update_user_meta( $user_id, $this->live_update->user_meta_key, 'off' );
+
+		$_POST['action']    = 'stream_enable_live_update';
+		$_POST['nonce']     = wp_create_nonce( $this->live_update->user_meta_key . '_nonce' );
+		$_POST['checked']   = 'checked';
+		$_POST['heartbeat'] = 'true';
+
+		try {
+			$this->_handleAjax( 'stream_enable_live_update' );
+		} catch ( \WPAjaxDieContinueException $e ) {
+			// Expected: wp_send_json_error() terminates the AJAX request.
+		}
+
+		$this->assertSame( 'off', get_user_meta( $user_id, $this->live_update->user_meta_key, true ) );
+	}
+}

--- a/tests/phpunit/test-class-live-update.php
+++ b/tests/phpunit/test-class-live-update.php
@@ -50,6 +50,9 @@ class Test_Live_Update extends WP_StreamTestCase {
 			// Expected: wp_send_json_success() terminates the AJAX request.
 		}
 
+		$response = json_decode( $this->_last_response );
+		$this->assertTrue( $response->success );
+
 		$this->assertSame( 'on', get_user_meta( $attacker_id, $this->live_update->user_meta_key, true ) );
 		$this->assertSame( 'off', get_user_meta( $victim_id, $this->live_update->user_meta_key, true ) );
 	}
@@ -74,6 +77,9 @@ class Test_Live_Update extends WP_StreamTestCase {
 		} catch ( \WPAjaxDieContinueException $e ) {
 			// Expected: wp_send_json_error() terminates the AJAX request.
 		}
+
+		$response = json_decode( $this->_last_response );
+		$this->assertFalse( $response->success );
 
 		$this->assertSame( 'off', get_user_meta( $user_id, $this->live_update->user_meta_key, true ) );
 	}


### PR DESCRIPTION
## Summary

Security hardening for the `stream_enable_live_update` AJAX handler that toggles the per-user "Live updates" screen option.

- Enforce the Stream view capability (`view_cap`) before processing the request.
- Always target `get_current_user_id()` instead of a client-supplied `user` value, so a user can only ever change their own live update preference.
- Remove the now-unused user field from the screen-option markup (`classes/class-list-table.php`) and the AJAX payload (`src/js/admin.js`).
- Switch the handler to `wp_stream_filter_input()` for the `checked`/`heartbeat` params for consistent request handling.

## Tests

Adds `tests/phpunit/test-class-live-update.php`:

- `test_enable_live_update_only_updates_current_user()` — a user with view access cannot modify another user's preference by supplying a forged `user` id.
- `test_enable_live_update_denies_users_without_view_cap()` — a user without view access is denied.

## Notes

- No behavior change for legitimate use: an authorized user still toggles their own preference from the Screen Options panel exactly as before.
- `build/admin.js` is gitignored and regenerated at build time; only `src/js/admin.js` is committed.

Made with [Cursor](https://cursor.com)