### PR TITLE
Sync master (4.2.1) back into develop

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -10,6 +10,7 @@ composer.lock
 docker-compose.build.yml
 docker-compose.yml
 Gruntfile.js
+connectors.md
 package.json
 package-lock.json
 phpcs.xml.dist

--- a/alerts/class-alert-type-ifttt.php
+++ b/alerts/class-alert-type-ifttt.php
@@ -209,7 +209,7 @@ class Alert_Type_IFTTT extends Alert_Type {
 			$recordarr,
 			array(
 				/* translators: %s: the Event Name of the Alert (e.g. "Update a post") */
-				'summary' => sprintf( __( 'The event %s was triggered' ), $alert->alert_meta['event_name'] ),
+				'summary' => sprintf( __( 'The event %s was triggered', 'stream' ), $alert->alert_meta['event_name'] ),
 				'user_id' => get_current_user_id(),
 				'created' => current_time( 'Y-m-d H:i:s' ),
 				// Blog's local time.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,19 @@
 # Stream Changelog
 
+## 4.2.1 - July 2, 2026
+
+### Bug Fixes
+
+- Fix authorization checks for Stream activity access and harden related AJAX, export, and query paths ([#1915](https://github.com/xwp/stream/pull/1915)).
+- Fix inverted `isset()` check silently ignoring user search input in `get_users()` ([#1897](https://github.com/xwp/stream/pull/1897)).
+- Create missing database tables when resetting the database ([#1285](https://github.com/xwp/stream/pull/1285)).
+- Avoid generating rewrite rules for the alerts post type ([#1380](https://github.com/xwp/stream/pull/1380)).
+- Correct release event branch handling for `stream-dist` deployments ([#1894](https://github.com/xwp/stream/pull/1894)).
+
+### Development
+
+- Update Node.js, Playwright, and related JavaScript/PHP development dependencies ([#1887](https://github.com/xwp/stream/pull/1887), [#1892](https://github.com/xwp/stream/pull/1892), [#1895](https://github.com/xwp/stream/pull/1895), [#1898](https://github.com/xwp/stream/pull/1898), [#1899](https://github.com/xwp/stream/pull/1899), [#1901](https://github.com/xwp/stream/pull/1901), [#1903](https://github.com/xwp/stream/pull/1903), [#1904](https://github.com/xwp/stream/pull/1904), [#1908](https://github.com/xwp/stream/pull/1908), [#1910](https://github.com/xwp/stream/pull/1910), [#1912](https://github.com/xwp/stream/pull/1912), [#1913](https://github.com/xwp/stream/pull/1913)).
+
 ## 4.2.0 - May 28, 2026
 
 ### New Features

--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -510,17 +510,21 @@ class Admin {
 				)
 			);
 
+			$current_order = isset( $_GET['order'] ) ? sanitize_key( wp_unslash( $_GET['order'] ) ) : 'desc'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			if ( ! in_array( $current_order, array( 'asc', 'desc' ), true ) ) {
+				$current_order = 'desc';
+			}
+			$current_query = map_deep( wp_unslash( $_GET ), 'sanitize_text_field' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
 			$this->plugin->enqueue_asset(
 				'live-updates',
 				array( 'heartbeat' ),
 				array(
 					'current_screen'      => $hook,
 					'current_page'        => isset( $_GET['paged'] ) ? absint( wp_unslash( $_GET['paged'] ) ) : '1', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-					'current_order'       => isset( $_GET['order'] ) && in_array( strtolower( $_GET['order'] ), array( 'asc', 'desc' ), true ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-						? esc_js( $_GET['order'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-						: 'desc',
-					'current_query'       => wp_json_encode( $_GET ), // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-					'current_query_count' => count( $_GET ), // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+					'current_order'       => $current_order,
+					'current_query'       => wp_json_encode( $current_query ),
+					'current_query_count' => count( $current_query ),
 				)
 			);
 		}
@@ -1388,7 +1392,7 @@ class Admin {
 			);
 		}
 
-		$links[] = sprintf( '<a href="%s">%s</a>', esc_url( $admin_page_url ), esc_html__( 'Settings', 'default' ) );
+		$links[] = sprintf( '<a href="%s">%s</a>', esc_url( $admin_page_url ), esc_html__( 'Settings', 'stream' ) );
 
 		return $links;
 	}

--- a/classes/class-alerts-list.php
+++ b/classes/class-alerts-list.php
@@ -284,7 +284,7 @@ class Alerts_List {
 			$nonce_url = wp_nonce_url( $bare_url, 'trash-post_' . $post_id );
 			?>
 			<div class="row-actions">
-				<span class="inline hide-if-no-js"><a href="#" class="editinline" aria-label="Quick edit “Hello world!” inline"><?php esc_html_e( 'Edit' ); ?></a>&nbsp;|&nbsp;</span>
+				<span class="inline hide-if-no-js"><a href="#" class="editinline" aria-label="Quick edit “Hello world!” inline"><?php esc_html_e( 'Edit', 'stream' ); ?></a>&nbsp;|&nbsp;</span>
 				<span class="trash">
 					<a href="<?php echo esc_url( $nonce_url ); ?>" class="submitdelete"><?php esc_html_e( 'Trash', 'stream' ); ?></a>
 				</span>

--- a/classes/class-alerts.php
+++ b/classes/class-alerts.php
@@ -723,7 +723,7 @@ class Alerts {
 				</div>
 				<div id="publishing-action">
 					<span class="spinner"></span>
-					<?php submit_button( __( 'Save' ), 'primary button-large', 'publish', false ); ?>
+					<?php submit_button( __( 'Save', 'stream' ), 'primary button-large', 'publish', false ); ?>
 				</div>
 				<div class="clear"></div>
 			</div>

--- a/classes/class-db-driver-wpdb.php
+++ b/classes/class-db-driver-wpdb.php
@@ -138,6 +138,10 @@ class DB_Driver_WPDB implements DB_Driver {
 	 */
 	public function get_column_values( $column ) {
 		global $wpdb;
+		if ( ! in_array( $column, Query::ALLOWED_FIELDS, true ) ) {
+			return array();
+		}
+
 		return (array) $wpdb->get_results(
 			"SELECT DISTINCT $column FROM $wpdb->stream", // @codingStandardsIgnoreLine can't prepare column name
 			'ARRAY_A'

--- a/classes/class-install.php
+++ b/classes/class-install.php
@@ -102,8 +102,12 @@ class Install {
 		}
 
 		$update = null;
-		if ( isset( $_REQUEST['wp_stream_update'] ) && wp_verify_nonce( 'wp_stream_update_db' ) ) {
-			$update = esc_attr( $_REQUEST['wp_stream_update'] );
+		if (
+			isset( $_REQUEST['wp_stream_update'], $_REQUEST['_wpnonce'] )
+			&&
+			wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['_wpnonce'] ) ), 'wp_stream_update_db' )
+		) {
+			$update = sanitize_key( wp_unslash( $_REQUEST['wp_stream_update'] ) );
 		}
 
 		if ( ! $update ) {
@@ -221,8 +225,12 @@ class Install {
 		}
 
 		$update = null;
-		if ( isset( $_REQUEST['wp_stream_update'] ) && wp_verify_nonce( 'wp_stream_update_db' ) ) {
-			$update = esc_attr( $_REQUEST['wp_stream_update'] );
+		if (
+			isset( $_REQUEST['wp_stream_update'], $_REQUEST['_wpnonce'] )
+			&&
+			wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['_wpnonce'] ) ), 'wp_stream_update_db' )
+		) {
+			$update = sanitize_key( wp_unslash( $_REQUEST['wp_stream_update'] ) );
 		}
 
 		if ( ! $update ) {

--- a/classes/class-list-table.php
+++ b/classes/class-list-table.php
@@ -776,7 +776,8 @@ class List_Table extends \WP_List_Table {
 		$query_vars = array();
 
 		if ( isset( $_SERVER['QUERY_STRING'] ) ) {
-			parse_str( urldecode( $_SERVER['QUERY_STRING'] ), $query_vars );
+			parse_str( wp_unslash( $_SERVER['QUERY_STRING'] ), $query_vars );
+			$query_vars = map_deep( $query_vars, 'sanitize_text_field' );
 		}
 
 		// Ignore certain query vars and query vars that are empty.
@@ -911,7 +912,7 @@ class List_Table extends \WP_List_Table {
 				<input type="submit" name="" id="search-submit" class="button" value="%3$s" />
 			</p>',
 			esc_html__( 'Search Records', 'stream' ),
-			esc_attr( ! empty( $_GET['search'] ) ? $_GET['search'] : '' ), // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			esc_attr( ! empty( $_GET['search'] ) ? sanitize_text_field( wp_unslash( $_GET['search'] ) ) : '' ), // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			esc_attr__( 'Search Records', 'stream' )
 		);
 	}

--- a/classes/class-live-update.php
+++ b/classes/class-live-update.php
@@ -206,7 +206,7 @@ class Live_Update {
 		if ( isset( $data['wp-stream-heartbeat'] ) && isset( $total_items ) ) {
 			$response['total_items'] = $total_items;
 			/* translators: %d: number of items (e.g. "42") */
-			$response['total_items_i18n'] = sprintf( _n( '%d item', '%d items', $total_items ), number_format_i18n( $total_items ) );
+			$response['total_items_i18n'] = sprintf( _n( '%d item', '%d items', $total_items, 'stream' ), number_format_i18n( $total_items ) );
 		}
 
 		if ( isset( $data['wp-stream-heartbeat'] ) && 'live-update' === $data['wp-stream-heartbeat'] && $enable_stream_update ) {

--- a/classes/class-log.php
+++ b/classes/class-log.php
@@ -303,7 +303,7 @@ class Log {
 	 */
 	public function debug_backtrace( $recordarr ) {
 		if ( version_compare( PHP_VERSION, '5.3.6', '<' ) ) {
-			return __( 'Debug backtrace requires at least PHP 5.3.6', 'wp_stream' );
+			return __( 'Debug backtrace requires at least PHP 5.3.6', 'stream' );
 		}
 
 		// Record details.

--- a/classes/class-network.php
+++ b/classes/class-network.php
@@ -84,12 +84,14 @@ class Network {
 	 * @see https://core.trac.wordpress.org/ticket/22589
 	 */
 	public function ajax_network_admin() {
+		$http_referer = isset( $_SERVER['HTTP_REFERER'] ) ? esc_url_raw( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) : '';
+
 		if (
 			defined( 'DOING_AJAX' )
 			&&
 			DOING_AJAX
 			&&
-			preg_match( '#^' . network_admin_url() . '#i', $_SERVER['HTTP_REFERER'] )
+			0 === stripos( $http_referer, network_admin_url() )
 		) {
 			define( 'WP_NETWORK_ADMIN', true );
 			return WP_NETWORK_ADMIN;
@@ -348,7 +350,11 @@ class Network {
 	public function network_options_action() {
 
 		// Check the nonce.
-		if ( empty( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], sprintf( '%s-options', $this->network_settings_option ) ) ) {
+		if (
+			empty( $_POST['_wpnonce'] )
+			||
+			! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ), sprintf( '%s-options', $this->network_settings_option ) )
+		) {
 			return;
 		}
 
@@ -358,23 +364,25 @@ class Network {
 		}
 
 		// Check the action.
-		if ( ! isset( $_GET['action'] ) || $this->network_settings_page_slug !== $_GET['action'] ) {
+		$action = isset( $_GET['action'] ) ? sanitize_key( wp_unslash( $_GET['action'] ) ) : '';
+		if ( $this->network_settings_page_slug !== $action ) {
 			return;
 		}
 
-		$option = ! empty( $_POST['option_page'] ) ? $_POST['option_page'] : false;
+		$option = ! empty( $_POST['option_page'] ) ? sanitize_key( wp_unslash( $_POST['option_page'] ) ) : false;
 
 		if ( $option && $this->network_settings_option === $option ) {
 
-			$value    = array();
-			$sections = $this->plugin->settings->get_fields();
+			$value          = array();
+			$posted_options = isset( $_POST[ $option ] ) && is_array( $_POST[ $option ] ) ? wp_unslash( $_POST[ $option ] ) : array();
+			$sections       = $this->plugin->settings->get_fields();
 
 			foreach ( $sections as $section_name => $section ) {
 				foreach ( $section['fields'] as $field_idx => $field ) {
 					$option_key = $section_name . '_' . $field['name'];
 
-					if ( isset( $_POST[ $option ][ $option_key ] ) ) {
-						$value[ $option_key ] = $this->plugin->settings->sanitize_setting_by_field_type( $_POST[ $option ][ $option_key ], $field['type'] );
+					if ( isset( $posted_options[ $option_key ] ) ) {
+						$value[ $option_key ] = $this->plugin->settings->sanitize_setting_by_field_type( $posted_options[ $option_key ], $field['type'] );
 					} else {
 						$value[ $option_key ] = false;
 					}

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -20,7 +20,7 @@ class Plugin {
 	 *
 	 * @const string
 	 */
-	const VERSION = '4.2.0';
+	const VERSION = '4.2.1';
 
 	/**
 	 * WP-CLI command

--- a/connectors/class-connector-blogs.php
+++ b/connectors/class-connector-blogs.php
@@ -54,7 +54,7 @@ class Connector_Blogs extends Connector {
 	 * @return string
 	 */
 	public function get_label() {
-		return esc_html__( 'Sites' );
+		return esc_html__( 'Sites', 'stream' );
 	}
 
 	/**
@@ -103,13 +103,13 @@ class Connector_Blogs extends Connector {
 	 * @return array
 	 */
 	public function action_links( $links, $record ) {
-		$links [ esc_html__( 'Site Admin' ) ] = get_admin_url( $record->object_id );
+		$links [ esc_html__( 'Site Admin', 'stream' ) ] = get_admin_url( $record->object_id );
 
 		if ( $record->object_id ) {
 			$site_admin_link = get_admin_url( $record->object_id );
 
 			if ( $site_admin_link ) {
-				$links [ esc_html__( 'Site Admin' ) ] = $site_admin_link;
+				$links [ esc_html__( 'Site Admin', 'stream' ) ] = $site_admin_link;
 			}
 
 			$site_settings_link = add_query_arg(

--- a/connectors/class-connector-edd.php
+++ b/connectors/class-connector-edd.php
@@ -161,7 +161,8 @@ class Connector_EDD extends Connector {
 			$posts_connector = new Connector_Posts();
 			$links           = $posts_connector->action_links( $links, $record );
 		} elseif ( in_array( $record->context, array( 'discounts' ), true ) ) {
-			$post_type_label = get_post_type_labels( get_post_type_object( 'edd_discount' ) )->singular_name;
+			$post_type       = get_post_type_object( 'edd_discount' );
+			$post_type_label = $post_type ? $post_type->labels->singular_name : esc_html__( 'Discount', 'stream' );
 			$base            = admin_url( 'edit.php?post_type=download&page=edd-discounts' );
 
 			/* translators: %s: a post type (e.g. "Post") */

--- a/connectors/class-connector-mercator.php
+++ b/connectors/class-connector-mercator.php
@@ -43,7 +43,7 @@ class Connector_Mercator extends Connector {
 	 * @return string
 	 */
 	public function get_label() {
-		return esc_html__( 'Mercator' );
+		return esc_html__( 'Mercator', 'stream' );
 	}
 
 	/**
@@ -92,13 +92,13 @@ class Connector_Mercator extends Connector {
 	 * @return array
 	 */
 	public function action_links( $links, $record ) {
-		$links [ esc_html__( 'Site Admin' ) ] = get_admin_url( $record->object_id );
+		$links [ esc_html__( 'Site Admin', 'stream' ) ] = get_admin_url( $record->object_id );
 
 		if ( $record->object_id ) {
 			$site_admin_link = get_admin_url( $record->object_id );
 
 			if ( $site_admin_link ) {
-				$links [ esc_html__( 'Site Admin' ) ] = $site_admin_link;
+				$links [ esc_html__( 'Site Admin', 'stream' ) ] = $site_admin_link;
 			}
 
 			$site_settings_link = add_query_arg(

--- a/connectors/class-connector-two-factor.php
+++ b/connectors/class-connector-two-factor.php
@@ -325,7 +325,7 @@ class Connector_Two_Factor extends Connector {
 	 * @param \WP_Error $error WP_Error object.
 	 */
 	public function callback_wp_login_failed( $user_login, $error ) {
-		if ( ! str_starts_with( $error->get_error_code(), 'two_factor_' ) ) {
+		if ( 0 !== strpos( $error->get_error_code(), 'two_factor_' ) ) {
 			return;
 		}
 

--- a/includes/db-updates.php
+++ b/includes/db-updates.php
@@ -4,6 +4,7 @@
  *
  * @package WP_Stream
  */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/includes/db-updates.php
+++ b/includes/db-updates.php
@@ -4,6 +4,9 @@
  *
  * @package WP_Stream
  */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 /**
  * Version 3.0.8

--- a/includes/feeds/atom.php
+++ b/includes/feeds/atom.php
@@ -4,6 +4,7 @@
  *
  * @package WP_Stream
  */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/includes/feeds/atom.php
+++ b/includes/feeds/atom.php
@@ -4,6 +4,9 @@
  *
  * @package WP_Stream
  */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 header( 'Content-Type: ' . feed_content_type( 'atom' ) . '; charset=' . get_option( 'blog_charset' ), true );
 printf( '<?xml version="1.0" encoding="%s"?>', esc_attr( get_option( 'blog_charset' ) ) );

--- a/includes/feeds/json.php
+++ b/includes/feeds/json.php
@@ -6,6 +6,9 @@
  *
  * @var $records
  */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 header( 'Content-type: application/json; charset=' . get_option( 'blog_charset' ), true );
 echo wp_json_encode( $records, JSON_PRETTY_PRINT );

--- a/includes/feeds/json.php
+++ b/includes/feeds/json.php
@@ -6,6 +6,7 @@
  *
  * @var $records
  */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/includes/feeds/rss-2.0.php
+++ b/includes/feeds/rss-2.0.php
@@ -4,6 +4,7 @@
  *
  * @package WP_Stream
  */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/includes/feeds/rss-2.0.php
+++ b/includes/feeds/rss-2.0.php
@@ -4,6 +4,9 @@
  *
  * @package WP_Stream
  */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 header( 'Content-Type: ' . feed_content_type( 'rss-http' ) . '; charset=' . get_option( 'blog_charset' ), true );
 printf( '<?xml version="1.0" encoding="%s"?>', esc_attr( get_option( 'blog_charset' ) ) );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4,6 +4,7 @@
  *
  * @package WP_Stream
  */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -4,6 +4,9 @@
  *
  * @package WP_Stream
  */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 /**
  * Gets a specific external variable by name and optionally filters it.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: xwp
 Tags: wp stream, stream, activity, logs, track
 Requires at least: 4.6
 Tested up to: 7.0
-Stable tag: 4.2.0
+Stable tag: 4.2.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -133,6 +133,10 @@ Use only `$_SERVER['REMOTE_ADDR']` as the client IP address for event logs witho
 
 
 == Changelog ==
+
+= 4.2.1 - July 2, 2026 =
+
+See: [https://github.com/xwp/stream/blob/develop/changelog.md#421---july-2-2026](https://github.com/xwp/stream/blob/develop/changelog.md#421---july-2-2026)
 
 = 4.2.0 - May 28, 2026 =
 

--- a/stream.php
+++ b/stream.php
@@ -3,7 +3,7 @@
  * Plugin Name: Stream
  * Plugin URI: https://xwp.co/work/stream/
  * Description: Stream tracks logged-in user activity so you can monitor every change made on your WordPress site in beautifully organized detail. All activity is organized by context, action and IP address for easy filtering. Developers can extend Stream with custom connectors to log any kind of action.
- * Version: 4.2.0
+ * Version: 4.2.1
  * Author: XWP
  * Author URI: https://xwp.co
  * License: GPLv2+

--- a/stream.php
+++ b/stream.php
@@ -34,6 +34,10 @@
 /**
  * Configuration Constants
  */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 if ( ! defined( 'WP_STREAM_SETTINGS_CAPABILITY' ) ) {
 	define( 'WP_STREAM_SETTINGS_CAPABILITY', 'manage_options' );
 }


### PR DESCRIPTION
## Summary

Reconciles `develop` with the `4.2.1` release that shipped from `master` but was never merged back (the "merge master into develop" step of the release cycle was missed after 4.2.1).

This brings `develop` up to date so the next release can be cut cleanly without regressing 4.2.1:

- **Version bump** to `4.2.1` in `stream.php`, `readme.txt` (Stable tag), and `classes/class-plugin.php` (`VERSION`).
- **Changelog** now includes the `4.2.1` entry.
- **Plugin Check hardening** from the 4.2.1 release: `ABSPATH` guards in feed/include entry points, output escaping in connectors, and related fixes across ~24 files.

Develop's newer work is preserved, including the live update authorization fix (#1918) and its PHPUnit coverage.

## Merge details

- Merged `origin/master` into `develop` with no conflicts (auto-merge resolved `classes/class-list-table.php` and `classes/class-live-update.php`, the two files touched on both sides).
- Verified post-merge: version reads `4.2.1` everywhere, the security fix (`current_user_can` / `get_current_user_id`) and `tests/phpunit/test-class-live-update.php` are intact, and the Plugin Check guards are present.

## Notes

- This is a prerequisite for cutting `4.2.2`.

Made with [Cursor](https://cursor.com)