### PR TITLE
Sync master (4.2.2) back into develop

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Stream Changelog
 
+## 4.2.2 - July 6, 2026
+
+### Security
+
+- Harden authorization for the live update preference: enforce the Stream view capability and always target the current user in the `stream_enable_live_update` AJAX handler so a user can only change their own live update preference ([#1918](https://github.com/xwp/stream/pull/1918)).
+
 ## 4.2.1 - July 2, 2026
 
 ### Bug Fixes

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -20,7 +20,7 @@ class Plugin {
 	 *
 	 * @const string
 	 */
-	const VERSION = '4.2.1';
+	const VERSION = '4.2.2';
 
 	/**
 	 * WP-CLI command

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: xwp
 Tags: wp stream, stream, activity, logs, track
 Requires at least: 4.6
 Tested up to: 7.0
-Stable tag: 4.2.1
+Stable tag: 4.2.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -133,6 +133,10 @@ Use only `$_SERVER['REMOTE_ADDR']` as the client IP address for event logs witho
 
 
 == Changelog ==
+
+= 4.2.2 - July 6, 2026 =
+
+See: [https://github.com/xwp/stream/blob/develop/changelog.md#422---july-6-2026](https://github.com/xwp/stream/blob/develop/changelog.md#422---july-6-2026)
 
 = 4.2.1 - July 2, 2026 =
 

--- a/stream.php
+++ b/stream.php
@@ -3,7 +3,7 @@
  * Plugin Name: Stream
  * Plugin URI: https://xwp.co/work/stream/
  * Description: Stream tracks logged-in user activity so you can monitor every change made on your WordPress site in beautifully organized detail. All activity is organized by context, action and IP address for easy filtering. Developers can extend Stream with custom connectors to log any kind of action.
- * Version: 4.2.1
+ * Version: 4.2.2
  * Author: XWP
  * Author URI: https://xwp.co
  * License: GPLv2+


### PR DESCRIPTION
## Summary

Post-release sync: merges `master` into `develop` after the 4.2.2 release so the branches stay in sync (Step 6.2 of the release cycle).

- Brings the version bump to `4.2.2` (`stream.php`, `readme.txt` Stable tag, `classes/class-plugin.php` VERSION) into `develop`.
- Brings the `4.2.2` changelog entry into `develop`.

The security fix itself was already on `develop` (via #1918), so this diff is limited to the release metadata.

## Merge details

- Merged `origin/master` into `develop` with no conflicts.
- Verified post-merge: version reads `4.2.2` everywhere and the changelog top entry is `4.2.2`.

Made with [Cursor](https://cursor.com)