### PR TITLE
Fix PHP 8.4 Deprecations

### DIFF
--- a/classes/class-cli.php
+++ b/classes/class-cli.php
@@ -211,7 +211,7 @@ class CLI extends \WP_CLI_Command {
 		$output = fopen( 'php://output', 'w' ); // @codingStandardsIgnoreLine Clever output for WP CLI using php://output
 
 		foreach ( $records as $line ) {
-			fputcsv( $output, $line );
+            fputcsv( $output, $line, ',', '"', '\\' );
 		}
 
 		fclose( $output ); // @codingStandardsIgnoreLine

--- a/classes/class-cli.php
+++ b/classes/class-cli.php
@@ -211,7 +211,7 @@ class CLI extends \WP_CLI_Command {
 		$output = fopen( 'php://output', 'w' ); // @codingStandardsIgnoreLine Clever output for WP CLI using php://output
 
 		foreach ( $records as $line ) {
-            fputcsv( $output, $line, ',', '"', '\\' );
+			fputcsv( $output, $line, ',', '"', '\\' );
 		}
 
 		fclose( $output ); // @codingStandardsIgnoreLine

--- a/exporters/class-exporter-csv.php
+++ b/exporters/class-exporter-csv.php
@@ -41,10 +41,10 @@ class Exporter_CSV extends Exporter {
 		ob_start();
 
 		$csv = fopen( 'php://output', 'w' );
-        fputcsv( $csv, array_values( $columns ), ',', '"', '\\' );
+		fputcsv( $csv, array_values( $columns ), ',', '"', '\\' );
 
 		foreach ( $data as $row ) {
-            fputcsv( $csv, $row, ',', '"', '\\' );
+			fputcsv( $csv, $row, ',', '"', '\\' );
 		}
 		fclose( $csv ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 

--- a/exporters/class-exporter-csv.php
+++ b/exporters/class-exporter-csv.php
@@ -41,10 +41,10 @@ class Exporter_CSV extends Exporter {
 		ob_start();
 
 		$csv = fopen( 'php://output', 'w' );
-		fputcsv( $csv, array_values( $columns ) );
+        fputcsv( $csv, array_values( $columns ), ',', '"', '\\' );
 
 		foreach ( $data as $row ) {
-			fputcsv( $csv, $row );
+            fputcsv( $csv, $row, ',', '"', '\\' );
 		}
 		fclose( $csv ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
 


### PR DESCRIPTION
## Summary

This PR fixes PHP 8.4 deprecation warnings related to `fputcsv()`.

Starting with PHP 8.4, calling `fputcsv()` without explicitly passing the `$escape` parameter triggers the following deprecation warning:

> The `$escape` parameter must be passed when calling `fputcsv()` as its default value will change in a future PHP version.

## Changes

* Updated both occurrences of `fputcsv()` where the `$escape` parameter was omitted.
* Explicitly passed the current default escape character (`'\\'`) to preserve the existing behavior and eliminate the deprecation warning.

Example:

```php
fputcsv( $csv, $row, ',', '"', '\\' );
```

## Impact

This change is fully backward compatible and prepares the codebase for PHP 8.4 by removing the deprecation warnings without changing the existing CSV output behavior.
