### PR TITLE
Fix phpcs warnings in BuddyPress connector

### DIFF
--- a/connectors/class-connector-buddypress.php
+++ b/connectors/class-connector-buddypress.php
@@ -706,9 +706,9 @@ class Connector_BuddyPress extends Connector {
 			array(
 				'activity_action' => wp_strip_all_tags( $activity->action ),
 				'id'              => $activity->id,
-				'item_id' => $activity->item_id,
-				'type'    => $activity->type,
-				'author'  => $activity->user_id,
+				'item_id'         => $activity->item_id,
+				'type'            => $activity->type,
+				'author'          => $activity->user_id,
 			),
 			$activity->id,
 			'activity',


### PR DESCRIPTION
## Summary

Fixes 3 phpcs warnings in `connectors/class-connector-buddypress.php` (array double arrow alignment, lines 709-711).

## Changes

- Aligned array double arrows via `vendor/bin/phpcbf`.

No functional changes, formatting only. phpcs now passes clean on the file.