### PR TITLE
fix(wc): pass order ID, not `WC_Order` object, to Stream log()

### DIFF
--- a/connectors/class-connector-woocommerce.php
+++ b/connectors/class-connector-woocommerce.php
@@ -495,7 +495,7 @@ class Connector_Woocommerce extends Connector {
 			'stream'
 		);
 
-		$order_id        = \WC_Order_Factory::get_order( $order_id );
+		$order_id        = \WC_Order_Factory::get_order_id( $order_id );
 		$order_title     = esc_html__( 'Order number', 'stream' ) . ' ' . esc_html( $order_id );
 		$order_type_name = esc_html__( 'order', 'stream' );
 


### PR DESCRIPTION
Fixes #1928.

`Connector_Woocommerce::callback_woocommerce_order_status_changed()` fetched a `WC_Order` object via `WC_Order_Factory::get_order()`, then passed it where an order ID (int) was expected — into `Log::log()`'s `$object_id` parameter. This triggers a PHP warning on every order status change: `Object of class Automattic\WooCommerce\Admin\Overrides\Order could not be converted to int`.

The fix swaps `get_order()` for `get_order_id()`, matching `callback_transition_post_status()` and `callback_deleted_post()` in the same file, which already fetch the ID correctly. No other behaviour changes.