### PR TITLE
fix(users): guard false user in retrieve_password

### DIFF
--- a/connectors/class-connector-users.php
+++ b/connectors/class-connector-users.php
@@ -260,10 +260,14 @@ class Connector_Users extends Connector {
 	 * @param string $user_login  User login.
 	 */
 	public function callback_retrieve_password( $user_login ) {
-		if ( wp_stream_filter_var( $user_login, FILTER_VALIDATE_EMAIL ) ) {
+		// Core passes user_login; try login first so email-shaped logins resolve.
+		$user = get_user_by( 'login', $user_login );
+		if ( ! $user && is_email( $user_login ) ) {
 			$user = get_user_by( 'email', $user_login );
-		} else {
-			$user = get_user_by( 'login', $user_login );
+		}
+
+		if ( ! is_a( $user, 'WP_User' ) ) {
+			return;
 		}
 
 		$this->log(

--- a/tests/phpunit/connectors/test-class-connector-users.php
+++ b/tests/phpunit/connectors/test-class-connector-users.php
@@ -133,6 +133,49 @@ class Test_WP_Stream_Connector_Users extends WP_StreamTestCase {
 		$this->assertFalse( 0 === did_action( $this->action_prefix . 'callback_retrieve_password' ) );
 	}
 
+	/**
+	 * Email-shaped login that is not the user_email must still log.
+	 *
+	 * Core passes user_login to retrieve_password. Looking up by email first
+	 * returns false when login looks like an email but differs from user_email.
+	 */
+	public function test_callback_retrieve_password_with_email_shaped_login() {
+		$user_id = self::factory()->user->create(
+			array(
+				'user_login'   => 'john@example.com',
+				'user_email'   => 'different@example.com',
+				'display_name' => 'EmailLoginGuy',
+			)
+		);
+		$user    = get_user_by( 'id', $user_id );
+
+		$this->mock->expects( $this->once() )
+			->method( 'log' )
+			->with(
+				$this->equalTo( __( '%s\'s password was requested to be reset', 'stream' ) ),
+				$this->equalTo( array( 'display_name' => 'EmailLoginGuy' ) ),
+				$this->equalTo( $user_id ),
+				$this->equalTo( 'sessions' ),
+				$this->equalTo( 'forgot-password' ),
+				$this->equalTo( $user_id )
+			);
+
+		do_action( 'retrieve_password', $user->user_login );
+
+		$this->assertFalse( 0 === did_action( $this->action_prefix . 'callback_retrieve_password' ) );
+	}
+
+	/**
+	 * Unknown login must not call log or trigger property-on-bool warnings.
+	 */
+	public function test_callback_retrieve_password_with_unknown_user() {
+		$this->mock->expects( $this->never() )->method( 'log' );
+
+		do_action( 'retrieve_password', 'nonexistent-user-xyz' );
+
+		$this->assertFalse( 0 === did_action( $this->action_prefix . 'callback_retrieve_password' ) );
+	}
+
 	public function test_callback_set_logged_in_cookie() {
 		// Create user.
 		$user_id = self::factory()->user->create( array( 'display_name' => 'TestGuy' ) );


### PR DESCRIPTION
## Summary

`Connector_Users::callback_retrieve_password()` looked up the user by email whenever the submitted string looked like an email. WordPress core always passes `user_login` (not email) to the `retrieve_password` action, so an email-shaped login that did not match `user_email` returned `false` and triggered a PHP 8 warning for reading property on bool.

Look up by `login` first, fall back to `email` only for valid email strings, and return early if no `WP_User` is found.

Fixes #1838

## Changes

### `connectors/class-connector-users.php`
**Before:**
```php
public function callback_retrieve_password( $user_login ) {
    if ( wp_stream_filter_var( $user_login, FILTER_VALIDATE_EMAIL ) ) {
        $user = get_user_by( 'email', $user_login );
    } else {
        $user = get_user_by( 'login', $user_login );
    }

    $this->log(
        /* translators: %s: a user display name (e.g. "Jane Doe") */
        __( '%s\'s password was requested to be reset', 'stream' ),
        array(
            'display_name' => $user->display_name,
        ),
        $user->ID,
        'sessions',
        'forgot-password',
        $user->ID
    );
}
```

**After:**
```php
public function callback_retrieve_password( $user_login ) {
    // Core passes user_login; try login first so email-shaped logins resolve.
    $user = get_user_by( 'login', $user_login );
    if ( ! $user && is_email( $user_login ) ) {
        $user = get_user_by( 'email', $user_login );
    }

    if ( ! is_a( $user, 'WP_User' ) ) {
        return;
    }

    $this->log(
        /* translators: %s: a user display name (e.g. "Jane Doe") */
        __( '%s\'s password was requested to be reset', 'stream' ),
        array(
            'display_name' => $user->display_name,
        ),
        $user->ID,
        'sessions',
        'forgot-password',
        $user->ID
    );
}
```

**Why:** Login-first matches what core passes to the action and what `class-connector-two-factor.php` does for the same hook. The `is_a( $user, 'WP_User' )` guard matches the pattern already used in `get_role_labels()` and `class-connector-blogs.php`, and stops the property-on-bool warning for unknown logins or plugin/direct callers that pass a value that resolves to no user.

### `tests/phpunit/connectors/test-class-connector-users.php`
Added two cases:
- `test_callback_retrieve_password_with_email_shaped_login`: user_login is `john@example.com` but user_email is different. Asserts `log` is called once with the right `display_name`. This is the exact regression.
- `test_callback_retrieve_password_with_unknown_user`: asserts `log` is never called when the login does not resolve.

## Testing

**Automated (PHPUnit, single + multisite):**
- `Test_WP_Stream_Connector_Users::test_callback_retrieve_password_and_profile_update` (existing happy path): green
- `test_callback_retrieve_password_with_email_shaped_login` (new): green
- `test_callback_retrieve_password_with_unknown_user` (new): green
- All other Users connector tests: green

Run:
```
composer test-one -- --filter Test_WP_Stream_Connector_Users
```

**Manual (WordPress 6.9 / PHP 8.2):**
1. Create a user with login `john@example.com` and email `different@example.com`. Trigger lost-password for that user. Result: no warning, Stream logs a "Lost Password" entry.
2. Trigger lost-password for a normal login. Result: no warning, Stream logs.
3. Trigger lost-password for a non-existent login. Result: no warning, no Stream entry.

## Notes
- Scope kept to the reported method. Other unguarded `get_user_by` calls in this class are the same class of bug but are out of scope for this ticket.
- No new dependencies, no settings/DB changes, no public API changes.