### PR TITLE
fix(log): trim whitespace in comma-separated IP exclude rules

### DIFF
--- a/classes/class-log.php
+++ b/classes/class-log.php
@@ -242,9 +242,23 @@ class Log {
 			}
 
 			if ( 'ip_address' === $exclude_key ) {
-				$ip_addresses = explode( ',', $exclude_value );
+				// Stored value shape varies: the admin form posts one
+				// comma-joined string per row, while a direct API or test
+				// caller can hand us an array of IPs. Normalize first, then
+				// trim and drop empties so a stored "1.1.1.1, 8.8.8.8" or
+				// ["1.1.1.1", " 8.8.8.8"] both match a real client IP.
+				$ip_addresses = is_array( $exclude_value )
+					? $exclude_value
+					: explode( ',', (string) $exclude_value );
 
-				if ( in_array( $record['ip_address'], $ip_addresses, true ) ) {
+				$ip_addresses = array_filter(
+					array_map( 'trim', $ip_addresses ),
+					function ( $value ) {
+						return '' !== $value;
+					}
+				);
+
+				if ( ! empty( $record['ip_address'] ) && in_array( $record['ip_address'], $ip_addresses, true ) ) {
 					++$matches_found;
 				}
 			} elseif ( $record[ $exclude_key ] === $exclude_value ) {

--- a/classes/class-log.php
+++ b/classes/class-log.php
@@ -242,18 +242,11 @@ class Log {
 			}
 
 			if ( 'ip_address' === $exclude_key ) {
-				// Stored value shape varies: the admin form posts one
-				// comma-joined string per row, while a direct API or test
-				// caller can hand us an array of IPs. Normalize first, then
-				// trim and drop empties so a stored "1.1.1.1, 8.8.8.8" or
-				// ["1.1.1.1", " 8.8.8.8"] both match a real client IP.
-				$ip_addresses = is_array( $exclude_value )
-					? $exclude_value
-					: explode( ',', (string) $exclude_value );
+				// Admin form joins multi-IP values with a comma; trim each
+				// one so "1.1.1.1, 8.8.8.8" still matches a real client IP.
+				$ip_addresses = array_filter( array_map( 'trim', explode( ',', (string) $exclude_value ) ) );
 
-				$ip_addresses = array_filter( array_map( 'trim', $ip_addresses ) );
-
-				if ( ! empty( $record['ip_address'] ) && in_array( $record['ip_address'], $ip_addresses, true ) ) {
+				if ( in_array( $record['ip_address'], $ip_addresses, true ) ) {
 					++$matches_found;
 				}
 			} elseif ( $record[ $exclude_key ] === $exclude_value ) {

--- a/classes/class-log.php
+++ b/classes/class-log.php
@@ -251,12 +251,7 @@ class Log {
 					? $exclude_value
 					: explode( ',', (string) $exclude_value );
 
-				$ip_addresses = array_filter(
-					array_map( 'trim', $ip_addresses ),
-					function ( $value ) {
-						return '' !== $value;
-					}
-				);
+				$ip_addresses = array_filter( array_map( 'trim', $ip_addresses ) );
 
 				if ( ! empty( $record['ip_address'] ) && in_array( $record['ip_address'], $ip_addresses, true ) ) {
 					++$matches_found;

--- a/tests/phpunit/test-class-log.php
+++ b/tests/phpunit/test-class-log.php
@@ -181,4 +181,136 @@ class Test_Log extends WP_StreamTestCase {
 			)
 		);
 	}
+
+	public function test_ip_address_rule_matches_with_whitespace() {
+		// Whitespace around commas (admin form join + user paste) must not
+		// silently fail the IP match. See issue #1824.
+		$this->assertTrue(
+			$this->plugin->log->record_matches_rules(
+				array(
+					'ip_address' => '8.8.8.8',
+				),
+				array(
+					'ip_address' => '1.1.1.1, 8.8.8.8',
+				),
+				'Trailing space after comma does not break the match'
+			)
+		);
+
+		$this->assertTrue(
+			$this->plugin->log->record_matches_rules(
+				array(
+					'ip_address' => '8.8.8.8',
+				),
+				array(
+					'ip_address' => '8.8.8.8 ',
+				),
+				'Trailing space on a single-IP rule still matches'
+			)
+		);
+
+		$this->assertFalse(
+			$this->plugin->log->record_matches_rules(
+				array(
+					'ip_address' => '',
+				),
+				array(
+					'ip_address' => '1.1.1.1',
+				),
+				'Empty record IP never matches an IP-only rule'
+			)
+		);
+
+		// Empty tokens between commas (e.g. user-pasted "1.1.1.1, ,") must be
+		// dropped, not treated as a valid match against the empty record IP.
+		$this->assertTrue(
+			$this->plugin->log->record_matches_rules(
+				array(
+					'ip_address' => '1.1.1.1',
+				),
+				array(
+					'ip_address' => '1.1.1.1, ,',
+				),
+				'Empty comma-separated tokens are dropped before matching'
+			)
+		);
+
+		// Stored value may already be an array (direct API callers, tests).
+		// Both shapes must match.
+		$this->assertTrue(
+			$this->plugin->log->record_matches_rules(
+				array(
+					'ip_address' => '8.8.8.8',
+				),
+				array(
+					'ip_address' => array( '127.0.0.1', '8.8.8.8' ),
+				),
+				'Array-shaped IP rule matches the second entry'
+			)
+		);
+
+		$this->assertTrue(
+			$this->plugin->log->record_matches_rules(
+				array(
+					'ip_address' => '8.8.8.8',
+				),
+				array(
+					'ip_address' => array( ' 8.8.8.8 ' ),
+				),
+				'Array-shaped IP rule trims whitespace per entry'
+			)
+		);
+	}
+
+	public function test_ip_only_exclude_rule_excludes_record() {
+		// End-to-end coverage for the bug in #1824. Shape mirrors the
+		// parallel-array rule format produced by both the wp-admin Exclude
+		// list and the stream/create-exclusion-rule ability.
+		$this->plugin->settings->options['exclude_rules'] = array(
+			'exclude_row'    => array( 0 => '' ),
+			'author_or_role' => array( 0 => '' ),
+			'connector'      => array( 0 => '' ),
+			'context'        => array( 0 => '' ),
+			'action'         => array( 0 => '' ),
+			'ip_address'     => array( 0 => '127.0.0.1' ),
+		);
+
+		$user = $this->factory->user->create_and_get();
+		$user->add_role( 'administrator' );
+
+		$this->assertTrue(
+			$this->plugin->log->is_record_excluded(
+				'users',
+				'profile',
+				'updated',
+				$user,
+				'127.0.0.1'
+			),
+			'IP-only rule excludes a record from the matching IP'
+		);
+
+		$this->assertFalse(
+			$this->plugin->log->is_record_excluded(
+				'users',
+				'profile',
+				'updated',
+				$user,
+				'8.8.8.8'
+			),
+			'IP-only rule does not exclude a record from a different IP'
+		);
+
+		// Whitespace in the stored IP value must still match.
+		$this->plugin->settings->options['exclude_rules']['ip_address'][0] = '127.0.0.1, 8.8.8.8';
+		$this->assertTrue(
+			$this->plugin->log->is_record_excluded(
+				'users',
+				'profile',
+				'updated',
+				$user,
+				'8.8.8.8'
+			),
+			'Comma-joined IP list with whitespace matches the second entry'
+		);
+	}
 }

--- a/tests/phpunit/test-class-log.php
+++ b/tests/phpunit/test-class-log.php
@@ -182,9 +182,9 @@ class Test_Log extends WP_StreamTestCase {
 		);
 	}
 
-	public function test_ip_address_rule_matches_with_whitespace() {
+	public function test_ip_address_rule_trims_whitespace_around_commas() {
 		// Whitespace around commas (admin form join + user paste) must not
-		// silently fail the IP match. See issue #1824.
+		// silently fail the IP match.
 		$this->assertTrue(
 			$this->plugin->log->record_matches_rules(
 				array(
@@ -192,9 +192,9 @@ class Test_Log extends WP_StreamTestCase {
 				),
 				array(
 					'ip_address' => '1.1.1.1, 8.8.8.8',
-				),
-				'Trailing space after comma does not break the match'
-			)
+				)
+			),
+			'Trailing space after comma does not break the match'
 		);
 
 		$this->assertTrue(
@@ -204,11 +204,13 @@ class Test_Log extends WP_StreamTestCase {
 				),
 				array(
 					'ip_address' => '8.8.8.8 ',
-				),
-				'Trailing space on a single-IP rule still matches'
-			)
+				)
+			),
+			'Trailing space on a single-IP rule still matches'
 		);
+	}
 
+	public function test_ip_address_rule_does_not_match_empty_record_ip() {
 		$this->assertFalse(
 			$this->plugin->log->record_matches_rules(
 				array(
@@ -216,11 +218,13 @@ class Test_Log extends WP_StreamTestCase {
 				),
 				array(
 					'ip_address' => '1.1.1.1',
-				),
-				'Empty record IP never matches an IP-only rule'
-			)
+				)
+			),
+			'Empty record IP never matches an IP-only rule'
 		);
+	}
 
+	public function test_ip_address_rule_drops_empty_comma_tokens() {
 		// Empty tokens between commas (e.g. user-pasted "1.1.1.1, ,") must be
 		// dropped, not treated as a valid match against the empty record IP.
 		$this->assertTrue(
@@ -230,42 +234,17 @@ class Test_Log extends WP_StreamTestCase {
 				),
 				array(
 					'ip_address' => '1.1.1.1, ,',
-				),
-				'Empty comma-separated tokens are dropped before matching'
-			)
-		);
-
-		// Stored value may already be an array (direct API callers, tests).
-		// Both shapes must match.
-		$this->assertTrue(
-			$this->plugin->log->record_matches_rules(
-				array(
-					'ip_address' => '8.8.8.8',
-				),
-				array(
-					'ip_address' => array( '127.0.0.1', '8.8.8.8' ),
-				),
-				'Array-shaped IP rule matches the second entry'
-			)
-		);
-
-		$this->assertTrue(
-			$this->plugin->log->record_matches_rules(
-				array(
-					'ip_address' => '8.8.8.8',
-				),
-				array(
-					'ip_address' => array( ' 8.8.8.8 ' ),
-				),
-				'Array-shaped IP rule trims whitespace per entry'
-			)
+				)
+			),
+			'Empty comma-separated tokens are dropped before matching'
 		);
 	}
 
 	public function test_ip_only_exclude_rule_excludes_record() {
-		// End-to-end coverage for the bug in #1824. Shape mirrors the
-		// parallel-array rule format produced by both the wp-admin Exclude
-		// list and the stream/create-exclusion-rule ability.
+		// End-to-end coverage for the comma/whitespace exclude-rule fix.
+		// Shape mirrors the parallel-array rule format produced by both the
+		// wp-admin Exclude list and the stream/create-exclusion-rule ability.
+		// Does not cover the separate IPv6/proxy-chain cause of issue #1824.
 		$this->plugin->settings->options['exclude_rules'] = array(
 			'exclude_row'    => array( 0 => '' ),
 			'author_or_role' => array( 0 => '' ),


### PR DESCRIPTION
Relates to #1824 (does not resolve it — see Summary and review discussion below: the report's actual repro has no comma/whitespace in the IP value, so a different root cause — likely IPv6 `::1` vs `127.0.0.1`, or `REMOTE_ADDR` parsing — remains open in that issue).

## Summary

Exclude rules with a comma-separated multi-IP address value (and all other fields set to Any) did not honor whitespace around the commas. `Log::record_matches_rules()` only split the value with `explode( ',', ... )` and used a strict `in_array()` against it, so a stored `"127.0.0.1, 8.8.8.8"` never matched a real `8.8.8.8` request.

**Note:** this does not address issue #1824 — see the review discussion below for why. This PR only fixes the comma/whitespace handling described here.

## Changes

### `classes/class-log.php`

**Before:**
```php
if ( 'ip_address' === $exclude_key ) {
	$ip_addresses = explode( ',', $exclude_value );

	if ( in_array( $record['ip_address'], $ip_addresses, true ) ) {
		++$matches_found;
	}
}
```

**After:**
```php
if ( 'ip_address' === $exclude_key ) {
	// Admin form joins multi-IP values with a comma; trim each
	// one so "1.1.1.1, 8.8.8.8" still matches a real client IP.
	$ip_addresses = array_filter( array_map( 'trim', explode( ',', (string) $exclude_value ) ) );

	if ( in_array( $record['ip_address'], $ip_addresses, true ) ) {
		++$matches_found;
	}
}
```

**Why:** the admin Exclude form joins multi-IP values with a comma (`src/js/admin-exclude.js`), so the stored value is a single string. Without trimming, `"127.0.0.1, 8.8.8.8"` becomes `['127.0.0.1', ' 8.8.8.8']` after `explode()` and the strict `in_array()` never matches.

## Repro before the fix

```php
$log->record_matches_rules(
	array( 'ip_address' => '8.8.8.8' ),
	array( 'ip_address' => '127.0.0.1, 8.8.8.8' )
);
// false (expected: true)
```

## Testing

**Multi-IP rule with whitespace**
1. In wp-admin, open Stream -> Settings -> Exclude.
2. Add a rule: leave Author or Role, Context, and Action as Any. Set IP Address to `127.0.0.1, 8.8.8.8` (with or without a space after the comma). Save.
3. Make a request from `8.8.8.8`.

Result: the request is excluded (with the fix). Without the fix, it is still logged.

**Automated tests run:**
- `composer test-one -- --filter='Test_Log::test_ip_address_rule_trims_whitespace_around_commas'` (single + multisite, green)
- `composer test-one -- --filter='Test_Log::test_ip_address_rule_does_not_match_empty_record_ip'` (single + multisite, green)
- `composer test-one -- --filter='Test_Log::test_ip_address_rule_drops_empty_comma_tokens'` (single + multisite, green)
- `composer test-one -- --filter='Test_Log::test_ip_only_exclude_rule_excludes_record'` (single + multisite, green)
- `composer lint-php` and `composer lint-tests` (green)
- CodeRabbit review: 0 findings

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [x] I have added phpunit tests.


## Release Changelog

- Fix: Exclude rules with a comma-separated multi-IP address value now match correctly when the stored value has whitespace around the commas.

## Release Checklist

_N/A — this PR targets `develop`, not `master`; these apply once the fix ships in a release branch._

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).