### PR TITLE
fix(ci): replace archived upload-release-asset with gh CLI

### DIFF
--- a/.github/workflows/deploy-to-wp-org.yml
+++ b/.github/workflows/deploy-to-wp-org.yml
@@ -80,23 +80,15 @@ jobs:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
 
-      # After the deployment, we also want to create a zip and upload it to the release on GitHub.
+      # Attach the generated zip to the GitHub release (gh is preinstalled on runners).
       - name: Upload release asset
-        uses: actions/upload-release-asset@v1
         env:
-          # Note, this is an exception to action secrets: GITHUB_TOKEN is always available and provides access to
-          # the current repository this action runs in.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-        with:
-          # Get the URL for uploading assets to the current release.
-          upload_url: ${{ github.event.release.upload_url }}
-
-          # Provide the path to the file generated in the previous step using the output.
-          asset_path: ${{ steps.deploy.outputs.zip-path }}
-
-          # Provide what the file should be named when attached to the release (plugin-name.zip)
-          asset_name: ${{ github.event.repository.name }}.zip
-
-          # Provide the file type.
-          asset_content_type: application/zip
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          ZIP_PATH: ${{ steps.deploy.outputs.zip-path }}
+          ASSET_NAME: ${{ github.event.repository.name }}.zip
+        run: |
+          gh release upload \
+            "$RELEASE_TAG" \
+            "$ZIP_PATH#$ASSET_NAME" \
+            --clobber


### PR DESCRIPTION
## Summary
Replace the archived `actions/upload-release-asset@v1` step in the WP.org deploy workflow with `gh release upload`. The old action is unmaintained and triggers Node 12 deprecation warnings on every release run. Behavior stays the same: the zip from the 10up deploy action is still attached to the GitHub release as `stream.zip`.

Fixes #1526

## Changes
### `.github/workflows/deploy-to-wp-org.yml`
**Before:**
```yaml
- name: Upload release asset
  uses: actions/upload-release-asset@v1
  env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  with:
    upload_url: ${{ github.event.release.upload_url }}
    asset_path: ${{ steps.deploy.outputs.zip-path }}
    asset_name: ${{ github.event.repository.name }}.zip
    asset_content_type: application/zip
```
**After:**
```yaml
- name: Upload release asset
  env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    RELEASE_TAG: ${{ github.event.release.tag_name }}
    ZIP_PATH: ${{ steps.deploy.outputs.zip-path }}
    ASSET_NAME: ${{ github.event.repository.name }}.zip
  run: |
    gh release upload \
      "$RELEASE_TAG" \
      "$ZIP_PATH#$ASSET_NAME" \
      --clobber
```
**Why:** Drop the archived third-party action. `gh` is already on GitHub-hosted runners, and values go through `env` so expressions are not interpolated into the shell script.

## Testing
**Test 1: Disposable pre-release**
1. Publish a pre-release tag that includes this workflow change (e.g. `v0.0.0-test-1526`).
2. Confirm **Deploy to WordPress.org Repository** runs on `release: published`.
3. Check the run: WP.org deploy is dry-run, **Upload release asset** succeeds, no Node 12 / `upload-release-asset` warning.
4. On the release page, confirm `stream.zip` is attached and downloads cleanly.
5. Delete the disposable pre-release and tag.

Result: release asset uploads via `gh`; WP.org stays dry-run for pre-releases.