### PR TITLE
fix(settings): keep wp_stream option autoload explicit

### DIFF
--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -65,6 +65,11 @@ class Settings {
 		// Register settings, and fields.
 		add_action( 'admin_init', array( $this, 'register_settings' ) );
 
+		// One-shot repair for installs whose wp_stream row was flipped off
+		// autoload. admin_init is enough: default writes already use yes, and
+		// a single admin hit after upgrade fixes any stray no. See #1482.
+		add_action( 'admin_init', array( $this, 'ensure_option_autoload' ) );
+
 		// Remove records when records TTL is shortened.
 		add_action(
 			'update_option_' . $this->option_key,
@@ -577,7 +582,10 @@ class Settings {
 		if ( $is_network ) {
 			$result = update_site_option( $this->network_options_key, $options );
 		} else {
-			$result = update_option( $this->option_key, $options );
+			// Autoload on purpose: Settings loads this option on every request
+			// (Plugin::init -> Settings::__construct -> get_options) for exclude
+			// rules, logging gates, and role access. See issue #1482.
+			$result = update_option( $this->option_key, $options, true );
 		}
 
 		// Refresh the in-memory copy so subsequent reads in the same request
@@ -598,6 +606,31 @@ class Settings {
 		}
 
 		return (bool) $result;
+	}
+
+	/**
+	 * Ensure the per-site settings option stays autoloaded.
+	 *
+	 * Settings are read on every request via get_options(), so autoload=yes
+	 * avoids an extra query. Idempotent. No-op for the network option key
+	 * (sitemeta has no autoload flag) and when wp_set_option_autoload() is
+	 * unavailable (WordPress < 6.4).
+	 *
+	 * @see https://github.com/xwp/stream/issues/1482
+	 *
+	 * @return void
+	 */
+	public function ensure_option_autoload() {
+		if ( ! function_exists( 'wp_set_option_autoload' ) ) {
+			return;
+		}
+
+		// Network settings live in sitemeta; no autoload flag to maintain.
+		if ( $this->option_key === $this->network_options_key ) {
+			return;
+		}
+
+		wp_set_option_autoload( $this->option_key, true );
 	}
 
 	/**
@@ -695,8 +728,10 @@ class Settings {
 			$this->option_key,
 			$this->option_key,
 			array(
-				$this,
-				'sanitize_settings',
+				'type'              => 'array',
+				'sanitize_callback' => array( $this, 'sanitize_settings' ),
+				// Autoload on purpose — see ensure_option_autoload() / issue #1482.
+				'autoload'          => true,
 			)
 		);
 

--- a/tests/phpunit/test-class-settings.php
+++ b/tests/phpunit/test-class-settings.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Tests for Settings option autoload behaviour (issue #1482).
+ *
+ * @package WP_Stream
+ */
+
+namespace WP_Stream;
+
+/**
+ * Class - Test_Settings
+ */
+class Test_Settings extends WP_StreamTestCase {
+
+	/**
+	 * Autoload column values that mean "load on every request".
+	 *
+	 * Modern WordPress may store on / auto-on instead of the legacy yes.
+	 *
+	 * @var string[]
+	 */
+	const AUTOLOAD_YES_FAMILY = array( 'yes', 'on', 'auto-on' );
+
+	/**
+	 * Autoload column values that mean "do not autoload".
+	 *
+	 * @var string[]
+	 */
+	const AUTOLOAD_NO_FAMILY = array( 'no', 'off', 'auto-off' );
+
+	/**
+	 * Read the autoload column for a blog option.
+	 *
+	 * @param string $option_name Option name.
+	 * @return string|null Autoload value, or null if the row is missing.
+	 */
+	private function get_option_autoload( $option_name ) {
+		global $wpdb;
+
+		$value = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT autoload FROM {$wpdb->options} WHERE option_name = %s LIMIT 1",
+				$option_name
+			)
+		);
+
+		return null === $value ? null : (string) $value;
+	}
+
+	/**
+	 * Whether the current run is a network-activated multisite install.
+	 *
+	 * The update_all_setting_values() method writes to sitemeta in that case,
+	 * which has no autoload column to assert against.
+	 *
+	 * @return bool
+	 */
+	private function is_network_settings_store() {
+		return is_multisite() && $this->plugin->is_network_activated();
+	}
+
+	public function test_update_all_setting_values_passes_autoload_true() {
+		if ( $this->is_network_settings_store() ) {
+			$this->markTestSkipped( 'Network-activated installs write sitemeta, not wp_options.autoload.' );
+		}
+
+		$option_key = $this->plugin->settings->option_key;
+
+		$result = $this->plugin->settings->update_all_setting_values(
+			array(
+				'general_records_ttl' => 42,
+			)
+		);
+
+		$this->assertTrue( $result );
+
+		$stored = get_option( $option_key );
+		$this->assertTrue( is_array( $stored ) );
+		$this->assertSame( 42, (int) $stored['general_records_ttl'] );
+
+		$autoload = $this->get_option_autoload( $option_key );
+		$this->assertNotNull( $autoload );
+		$this->assertContains(
+			$autoload,
+			self::AUTOLOAD_YES_FAMILY,
+			'wp_stream must stay autoloaded after update_all_setting_values().'
+		);
+	}
+
+	public function test_ensure_option_autoload_sets_yes_when_no() {
+		if ( ! function_exists( 'wp_set_option_autoload' ) ) {
+			$this->markTestSkipped( 'wp_set_option_autoload() requires WordPress 6.4+.' );
+		}
+
+		if ( $this->is_network_settings_store() ) {
+			$this->markTestSkipped( 'Network-activated installs write sitemeta, not wp_options.autoload.' );
+		}
+
+		$option_key = $this->plugin->settings->option_key;
+
+		delete_option( $option_key );
+		add_option( $option_key, array( 'general_records_ttl' => 30 ), '', 'no' );
+
+		$before = $this->get_option_autoload( $option_key );
+		$this->assertContains(
+			$before,
+			self::AUTOLOAD_NO_FAMILY,
+			'Precondition: option must start as not-autoloaded.'
+		);
+
+		$this->plugin->settings->ensure_option_autoload();
+
+		$after = $this->get_option_autoload( $option_key );
+		$this->assertContains(
+			$after,
+			self::AUTOLOAD_YES_FAMILY,
+			'ensure_option_autoload() must flip a no-autoload row to yes-family.'
+		);
+	}
+
+	public function test_ensure_option_autoload_is_idempotent() {
+		if ( ! function_exists( 'wp_set_option_autoload' ) ) {
+			$this->markTestSkipped( 'wp_set_option_autoload() requires WordPress 6.4+.' );
+		}
+
+		if ( $this->is_network_settings_store() ) {
+			$this->markTestSkipped( 'Network-activated installs write sitemeta, not wp_options.autoload.' );
+		}
+
+		$option_key = $this->plugin->settings->option_key;
+
+		// Ensure a yes-family row exists.
+		delete_option( $option_key );
+		add_option( $option_key, array( 'general_records_ttl' => 30 ), '', 'yes' );
+		$this->plugin->settings->ensure_option_autoload();
+
+		$first = $this->get_option_autoload( $option_key );
+		$this->assertContains( $first, self::AUTOLOAD_YES_FAMILY );
+
+		$this->plugin->settings->ensure_option_autoload();
+
+		$second = $this->get_option_autoload( $option_key );
+		$this->assertSame( $first, $second );
+		$this->assertContains( $second, self::AUTOLOAD_YES_FAMILY );
+	}
+
+	public function test_ensure_option_autoload_skips_network_option_key() {
+		if ( ! function_exists( 'wp_set_option_autoload' ) ) {
+			$this->markTestSkipped( 'wp_set_option_autoload() requires WordPress 6.4+.' );
+		}
+
+		if ( $this->is_network_settings_store() ) {
+			$this->markTestSkipped( 'Network-activated installs write sitemeta, not wp_options.autoload.' );
+		}
+
+		$settings     = $this->plugin->settings;
+		$original_key = $settings->option_key;
+		$network_key  = $settings->network_options_key;
+
+		// Seed a blog option under the network key name with autoload=no.
+		// ensure_option_autoload() must leave it alone when option_key points
+		// at the network settings key (sitemeta has no autoload flag).
+		delete_option( $network_key );
+		add_option( $network_key, array( 'general_records_ttl' => 30 ), '', 'no' );
+
+		$before               = $this->get_option_autoload( $network_key );
+		$settings->option_key = $network_key;
+		$settings->ensure_option_autoload();
+		$after                = $this->get_option_autoload( $network_key );
+		$settings->option_key = $original_key;
+
+		$this->assertSame( $before, $after );
+		$this->assertContains( $after, self::AUTOLOAD_NO_FAMILY );
+
+		delete_option( $network_key );
+	}
+}


### PR DESCRIPTION
## Summary
The `wp_stream` settings option is loaded on every request (`Plugin::init` → `Settings::__construct` → `get_options`) for exclude rules, logging gates, and role access. Autoload must stay on; turning it off without lazy-loading would add a `get_option` query on every page load.

This change makes that intent explicit on write paths and repairs any install whose row was flipped to no-autoload.

Fixes #1482

## Changes
### `classes/class-settings.php`
**Before:**
```php
$result = update_option( $this->option_key, $options );

register_setting(
    $this->option_key,
    $this->option_key,
    array( $this, 'sanitize_settings' )
);
```
**After:**
```php
// Autoload on purpose: Settings loads this option on every request ...
$result = update_option( $this->option_key, $options, true );

register_setting(
    $this->option_key,
    $this->option_key,
    array(
        'type'              => 'array',
        'sanitize_callback' => array( $this, 'sanitize_settings' ),
        'autoload'          => true,
    )
);

// ensure_option_autoload() on admin_init repairs stray no-autoload rows
// via wp_set_option_autoload() when available (WP 6.4+).
```
**Why:** New writes and Settings API saves keep autoload on. A one-shot admin repair covers existing installs that somehow ended up with autoload off. Network settings (`wp_stream_network` / sitemeta) are untouched.

### `tests/phpunit/test-class-settings.php`
**Why:** Cover the write path, no→yes repair, idempotency, and network-key no-op.

## Testing
**Test 1: Fresh save keeps autoload on**
1. Stream → Settings, change a value, Save.
2. `wp db query "SELECT option_name, autoload FROM wp_options WHERE option_name = 'wp_stream'"`
Result: `autoload` is `yes` / `on` / `auto-on`.

**Test 2: Repair path**
1. `wp db query "UPDATE wp_options SET autoload = 'no' WHERE option_name = 'wp_stream'"`
2. Load any WP Admin page once.
3. Re-check the query above.
Result: `autoload` is back in the yes-family.

**Test 3: Settings still work**
1. Add an exclude rule and trigger matching / non-matching events.
Result: matching event not logged; non-matching event logged. No PHP notices.

**Automated:** `composer lint`, `composer lint-tests`, PHPUnit `Test_Settings` (single-site + multisite) pass.