### PR TITLE
Fix false "SITE IS DISCONNECTED" error on empty query results

### DIFF
--- a/classes/class-cli.php
+++ b/classes/class-cli.php
@@ -223,14 +223,19 @@ class CLI extends \WP_CLI_Command {
 	 * @return void
 	 */
 	private function connection() {
-		$query = wp_stream_get_instance()->db->query(
+		global $wpdb;
+
+		wp_stream_get_instance()->db->query(
 			array(
 				'records_per_page' => 1,
 				'fields'           => 'created',
 			)
 		);
 
-		if ( ! $query ) {
+		// An empty result set is valid (e.g. a fresh site with no logged
+		// activity yet); only a genuine database error means the site is
+		// disconnected.
+		if ( ! empty( $wpdb->last_error ) ) {
 			\WP_CLI::error( esc_html__( 'SITE IS DISCONNECTED', 'stream' ) );
 		}
 	}

--- a/tests/phpunit/test-class-cli.php
+++ b/tests/phpunit/test-class-cli.php
@@ -1,0 +1,74 @@
+<?php
+namespace WP_Stream;
+
+use ReflectionMethod;
+use ReflectionProperty;
+use WP_CLI;
+use WP_CLI\ExitException;
+
+class Test_CLI extends WP_StreamTestCase {
+	/**
+	 * Invokes the private CLI::connection() method, capturing any
+	 * WP_CLI::error() exit as an ExitException instead of terminating
+	 * the test process.
+	 *
+	 * @throws ExitException When the connection check fails.
+	 */
+	private function invoke_connection() {
+		$capture_exit = new ReflectionProperty( WP_CLI::class, 'capture_exit' );
+		$capture_exit->setAccessible( true );
+		$capture_exit->setValue( null, true );
+
+		$connection = new ReflectionMethod( CLI::class, 'connection' );
+		$connection->setAccessible( true );
+
+		try {
+			$connection->invoke( new CLI() );
+		} finally {
+			$capture_exit->setValue( null, false );
+		}
+	}
+
+	/**
+	 * A query that legitimately matches zero records is not a disconnection.
+	 */
+	public function test_connection_does_not_error_on_empty_result() {
+		global $wpdb;
+
+		// Force the connection check's query to match nothing, without
+		// touching any actual data other tests rely on.
+		$force_no_matches = function ( $where ) {
+			return $where . ' AND 1=0';
+		};
+		add_filter( 'wp_stream_db_query_where', $force_no_matches );
+
+		try {
+			$this->invoke_connection();
+		} finally {
+			remove_filter( 'wp_stream_db_query_where', $force_no_matches );
+		}
+
+		// Reaching this line means WP_CLI::error() was never triggered.
+		$this->assertEmpty( $wpdb->last_error );
+	}
+
+	/**
+	 * A genuine database error should still be reported as a disconnected site.
+	 */
+	public function test_connection_errors_on_database_failure() {
+		global $wpdb;
+
+		$original_table = $wpdb->stream;
+		$wpdb->stream   = $wpdb->prefix . 'stream_table_that_does_not_exist';
+		$wpdb->suppress_errors( true );
+
+		try {
+			$this->expectException( ExitException::class );
+			$this->invoke_connection();
+		} finally {
+			$wpdb->stream = $original_table;
+			$wpdb->suppress_errors( false );
+			$wpdb->last_error = '';
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1829

## Problem

`wp stream query` runs a connectivity check (`CLI::connection()`) before executing, by running a real query for 1 record and treating a falsy result as "disconnected":

```php
$query = wp_stream_get_instance()->db->query( [ ... ] );

if ( ! $query ) {
    \WP_CLI::error( 'SITE IS DISCONNECTED' );
}
```

`DB::get_records()` returns a plain `array()` when the query runs successfully but matches zero rows. In PHP, an empty array is falsy, so "no records yet" and "the query actually failed" were indistinguishable — any site with an empty `wp_stream` table (a fresh install, or a multisite subsite with no site-level activity logged) hit `SITE IS DISCONNECTED` even though nothing was actually wrong.

This matches the report in #1829: one multisite install logs plenty of activity and works fine, while a second logs almost nothing (only network-level actions) and fails on every `wp stream query` call.

## Fix

Check `$wpdb->last_error` instead of the query's return shape. WordPress only populates `last_error` when a query genuinely fails at the database level (bad SQL, missing table, dropped connection, etc.), never for a query that simply matched nothing. This restores the original intent of the check — "is the database actually reachable" — without misreading an empty-but-healthy result as a failure.

## Testing

- Reproduced the bug locally: network-activated Stream on a multisite install, created a fresh subsite with zero logged activity, ran `wp stream query --url=<subsite>` → `SITE IS DISCONNECTED` (confirmed the root cause, not just multisite-specific — a single-site install with an empty `wp_stream` table hits the same bug).
- Applied the fix, re-ran the same commands against the root site and two empty subsites — all now return a clean, empty results table instead of erroring.
- Verified the check still fires correctly on a genuine failure: temporarily renamed away the `wp_stream` table and confirmed `SITE IS DISCONNECTED` is still reported, then restored the table.
- Full PHP test suite: 392 passing (pre-existing skipped/incomplete tests unrelated to this change).
- `composer lint` (PHPCS): clean.

<img width="916" height="730" alt="Screenshot 2026-08-13 at 7 45 21 AM" src="https://github.com/user-attachments/assets/f42be934-d8d8-4976-ac5a-0e719bae53c3" />

`Test_CLI` coverage added for the fix (both the empty-result and genuine-failure paths):

<img width="1087" height="461" alt="Screenshot 2026-08-13 at 9 00 56 AM" src="https://github.com/user-attachments/assets/86b79eeb-d14f-4ec0-9e38-65ceda3a466c" />


# Checklist

- [x] Project documentation has been updated to reflect the changes in this pull request, if applicable. _(N/A — internal WP-CLI logic fix, no user-facing docs affected)_
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [x] I have added phpunit tests.

## Release Changelog

- Fix: `wp stream query` no longer reports "SITE IS DISCONNECTED" when a site simply has no logged activity yet.


