### PR TITLE
Keep thousands separator in record and site counts

### DIFF
--- a/classes/class-live-update.php
+++ b/classes/class-live-update.php
@@ -197,8 +197,8 @@ class Live_Update {
 
 		if ( isset( $data['wp-stream-heartbeat'] ) && isset( $total_items ) ) {
 			$response['total_items'] = $total_items;
-			/* translators: %d: number of items (e.g. "42") */
-			$response['total_items_i18n'] = sprintf( _n( '%d item', '%d items', $total_items, 'stream' ), number_format_i18n( $total_items ) );
+			/* translators: %s: number of items (e.g. "1,234") */
+			$response['total_items_i18n'] = sprintf( _n( '%s item', '%s items', $total_items, 'stream' ), number_format_i18n( $total_items ) );
 		}
 
 		if ( isset( $data['wp-stream-heartbeat'] ) && 'live-update' === $data['wp-stream-heartbeat'] && $enable_stream_update ) {

--- a/classes/class-network.php
+++ b/classes/class-network.php
@@ -563,8 +563,8 @@ class Network {
 	 */
 	public function network_admin_page_title( $page_title ) {
 		if ( is_network_admin() ) {
-			/* translators: %d: number of sites on the network (e.g. "42") */
-			$site_count = sprintf( _n( '%d site', '%d sites', get_blog_count(), 'stream' ), number_format( get_blog_count() ) );
+			/* translators: %s: number of sites on the network (e.g. "1,234") */
+			$site_count = sprintf( _n( '%s site', '%s sites', get_blog_count(), 'stream' ), number_format( get_blog_count() ) );
 			$page_title = sprintf( '%s (%s)', $page_title, $site_count );
 		}
 

--- a/tests/phpunit/test-class-live-update.php
+++ b/tests/phpunit/test-class-live-update.php
@@ -83,4 +83,37 @@ class Test_Live_Update extends WP_StreamTestCase {
 
 		$this->assertSame( 'off', get_user_meta( $user_id, $this->live_update->user_meta_key, true ) );
 	}
+
+	public function test_heartbeat_item_count_keeps_thousands_separator() {
+		global $wpdb;
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$this->plugin->settings->options['general_role_access'] = array( 'administrator' );
+
+		$values = array();
+		for ( $i = 0; $i < 1000; $i++ ) {
+			$values[] = $wpdb->prepare(
+				'( 1, %d, 0, 0, %s, %s, %s, %s, %s, %s, %s )',
+				get_current_blog_id(),
+				'administrator',
+				'Record ' . $i,
+				gmdate( 'Y-m-d H:i:s' ),
+				'settings',
+				'settings',
+				'updated',
+				'127.0.0.1'
+			);
+		}
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery -- Each row is prepared above.
+		$wpdb->query( "INSERT INTO {$wpdb->stream} ( site_id, blog_id, object_id, user_id, user_role, summary, created, connector, context, action, ip ) VALUES " . implode( ',', $values ) );
+
+		$response = $this->live_update->heartbeat_received( array(), array( 'wp-stream-heartbeat' => 'live-update' ) );
+
+		$this->assertGreaterThan( 999, $response['total_items'] );
+		$this->assertSame(
+			sprintf( '%s items', number_format_i18n( $response['total_items'] ) ),
+			$response['total_items_i18n']
+		);
+	}
 }


### PR DESCRIPTION
Fixes #1477.

`total_items_i18n` and the network admin site count formatted an already-separated number with `%d`, truncating it at the first comma — `1,501 items` rendered as `1 items`. Switched both to `%s`, matching `WP_List_Table::pagination()`. The network count has no test because `is_network_admin()` reads a constant the suite cannot set per-test.

# Checklist

- [x] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [x] I have added phpunit tests.

## Release Changelog

- Fix: Keep the thousands separator in the records table item count and the network admin site count.