### PR TITLE
Add host PHPUnit unit suite; refactor Query and Connectors for testability (XWPENG-42)

### DIFF
--- a/abilities/class-ability-create-exclusion-rule.php
+++ b/abilities/class-ability-create-exclusion-rule.php
@@ -165,16 +165,10 @@ class Ability_Create_Exclusion_Rule extends Ability {
 			);
 		}
 
-		// Validate connector against the full site-wide list, including
-		// admin-only connectors (settings, editor, menus, etc.). get_slugs()
-		// alone returns only request-context-loaded connectors, so REST
-		// callers would otherwise be unable to exclude valid admin-only
-		// connectors even though those are real and configurable in wp-admin.
+		// Validate connector against all available connectors, including non-active connectors (eg: admin-only).
 		if ( '' !== $sanitized['connector'] ) {
-			$known = isset( $this->plugin->connectors )
-				? $this->plugin->connectors->get_all_slugs_including_admin_only()
-				: array();
-			if ( ! empty( $known ) && ! in_array( $sanitized['connector'], $known, true ) ) {
+			$known = $this->plugin->connectors->get_slugs( true );
+			if ( ! in_array( $sanitized['connector'], $known, true ) ) {
 				return new \WP_Error(
 					'stream_unknown_connector',
 					/* translators: %s: connector slug */

--- a/abilities/class-ability-create-exclusion-rule.php
+++ b/abilities/class-ability-create-exclusion-rule.php
@@ -166,7 +166,7 @@ class Ability_Create_Exclusion_Rule extends Ability {
 		}
 
 		// Validate connector against all available connectors, including non-active connectors (eg: admin-only).
-		if ( '' !== $sanitized['connector'] ) {
+		if ( '' !== $sanitized['connector'] && isset( $this->plugin->connectors ) ) {
 			$known = $this->plugin->connectors->get_slugs( true );
 			if ( ! in_array( $sanitized['connector'], $known, true ) ) {
 				return new \WP_Error(

--- a/abilities/class-ability-get-connectors.php
+++ b/abilities/class-ability-get-connectors.php
@@ -99,11 +99,13 @@ class Ability_Get_Connectors extends Ability {
 			return array();
 		}
 
-		// Use the metadata-only accessor that includes admin-only connectors
-		// (settings, editor, menus, etc.) so REST/MCP callers see the same
-		// connector inventory an admin sees in wp-admin. The plain get_all()
-		// reflects only connectors registered for the current request type,
-		// which is the wrong frame for the abilities-facing "what exists on this site" answer.
-		return $this->plugin->connectors->get_all_including_admin_only();
+		// Get all available connectors so REST/MCP callers see the same
+		// connector inventory an admin sees in wp-admin.
+		$connectors = apply_filters(
+			'wp_stream_abilities_connectors',
+			$this->plugin->connectors->get_all( true )
+		);
+
+		return $connectors;
 	}
 }

--- a/abilities/class-ability-get-connectors.php
+++ b/abilities/class-ability-get-connectors.php
@@ -32,7 +32,7 @@ class Ability_Get_Connectors extends Ability {
 	 * {@inheritDoc}
 	 */
 	public function get_description() {
-		return __( 'List all registered Stream connectors with their available contexts and actions. Useful for understanding what activity Stream can track on this site.', 'stream' );
+		return __( 'List all Stream connectors this plugin ships, including inactive connectors and those whose dependencies are not currently satisfied. Use this to filter historical records that may have been logged when those connectors were active.', 'stream' );
 	}
 
 	/**
@@ -42,7 +42,7 @@ class Ability_Get_Connectors extends Ability {
 		return array(
 			'readonly'     => true,
 			'idempotent'   => true,
-			'instructions' => __( 'Use to discover the valid connector / context / action values for filters in stream/get-records and stream/create-exclusion-rule. Connector slugs are stable identifiers, so cache the result if you call abilities repeatedly.', 'stream' ),
+			'instructions' => __( 'Use to discover the valid connector / context / action values for filters in stream/get-records and stream/create-exclusion-rule. The list is the plugin\'s shipped inventory, not only connectors whose dependencies are met on this site. Connector slugs are stable identifiers, so cache the result if you call abilities repeatedly.', 'stream' ),
 		);
 	}
 
@@ -59,7 +59,7 @@ class Ability_Get_Connectors extends Ability {
 	public function get_output_schema() {
 		return array(
 			'type'        => 'array',
-			'description' => 'Registered connectors.',
+			'description' => 'Connectors this plugin ships, including inactive and unsatisfied-dependency connectors.',
 			'items'       => array(
 				'type'                 => 'object',
 				'additionalProperties' => false,
@@ -99,8 +99,8 @@ class Ability_Get_Connectors extends Ability {
 			return array();
 		}
 
-		// Get all available connectors so REST/MCP callers see the same
-		// connector inventory an admin sees in wp-admin.
+		// Shipped inventory, including inactive / unsatisfied-dependency
+		// connectors, so historical records remain filterable via abilities.
 		$connectors = apply_filters(
 			'wp_stream_abilities_connectors',
 			$this->plugin->connectors->get_all( true )

--- a/classes/class-connector.php
+++ b/classes/class-connector.php
@@ -62,6 +62,27 @@ abstract class Connector {
 	private $is_registered = false;
 
 	/**
+	 * Return translated connector label.
+	 *
+	 * @return string
+	 */
+	abstract public function get_label();
+
+	/**
+	 * Return translated context labels.
+	 *
+	 * @return array<string, string>
+	 */
+	abstract public function get_context_labels();
+
+	/**
+	 * Return translated action labels.
+	 *
+	 * @return array<string, string>
+	 */
+	abstract public function get_action_labels();
+
+	/**
 	 * Is the connector currently registered?
 	 *
 	 * @return boolean

--- a/classes/class-connectors.php
+++ b/classes/class-connectors.php
@@ -13,11 +13,59 @@ namespace WP_Stream;
  */
 class Connectors {
 	/**
+	 * Built-in and integrated connector slugs.
+	 *
+	 * @var string[]
+	 */
+	const BUILTIN_CONNECTOR_SLUGS = array(
+		// Core Connectors.
+		'blogs',
+		'comments',
+		'editor',
+		'installer',
+		'media',
+		'menus',
+		'posts',
+		'settings',
+		'taxonomies',
+		'users',
+		'widgets',
+
+		// Integrated Connectors.
+		'acf',
+		'bbpress',
+		'buddypress',
+		'edd',
+		'gravityforms',
+		'jetpack',
+		'mercator',
+		'two-factor',
+		'user-switching',
+		'woocommerce',
+		'wordpress-seo',
+	);
+
+	/**
 	 * Holds instance of plugin object
 	 *
 	 * @var Plugin
 	 */
 	public $plugin;
+
+
+	/**
+	 * Fully-qualified builtin connector class names after files are included.
+	 *
+	 * @var string[]|null
+	 */
+	private $available_connectors = null;
+
+	/**
+	 * Instantiated connectors, keyed by slug. Filled once by instantiate_connector_classes().
+	 *
+	 * @var array<string, Connector>|null
+	 */
+	private $connector_instances = null;
 
 	/**
 	 * Registered connectors.
@@ -64,72 +112,68 @@ class Connectors {
 	}
 
 	/**
-	 * Load built-in connectors
+	 * Include builtin connector files and return structurally valid class names.
+	 *
+	 * @return string[] Fully-qualified class names.
 	 */
-	public function load_connectors() {
-		$connectors = array(
-			/**
-			 * Core Connectors
-			 */
-			'blogs',
-			'comments',
-			'editor',
-			'installer',
-			'media',
-			'menus',
-			'posts',
-			'settings',
-			'taxonomies',
-			'users',
-			'widgets',
+	private function get_available_connectors() {
+		if ( is_array( $this->available_connectors ) ) {
+			return $this->available_connectors;
+		}
 
-			/**
-			 * Integrated Connectors
-			 */
-			'acf',
-			'bbpress',
-			'buddypress',
-			'edd',
-			'gravityforms',
-			'jetpack',
-			'mercator',
-			'two-factor',
-			'user-switching',
-			'woocommerce',
-			'wordpress-seo',
-		);
+		$class_names = array();
 
-		// Get excluded connectors.
-		$excluded_connectors = array();
+		foreach ( self::BUILTIN_CONNECTOR_SLUGS as $slug ) {
+			include_once $this->plugin->locations['dir'] . '/connectors/class-connector-' . $slug . '.php';
 
-		$classes = array();
-		foreach ( $connectors as $connector ) {
-			// Load connector class file.
-			include_once $this->plugin->locations['dir'] . '/connectors/class-connector-' . $connector . '.php';
+			$class_name = sprintf( '\WP_Stream\Connector_%s', str_replace( '-', '_', $slug ) );
 
-			// Set fully qualified class name.
-			$class_name = sprintf( '\WP_Stream\Connector_%s', str_replace( '-', '_', $connector ) );
-
-			// Bail if no class loaded.
-			if ( ! class_exists( $class_name ) ) {
+			// We only add classes that extend Connector abstract class with required methods.
+			if ( ! class_exists( $class_name ) || ! is_subclass_of( $class_name, Connector::class ) ) {
 				continue;
 			}
 
-			// Initialize connector.
-			$class                   = new $class_name();
-			$classes[ $class->name ] = $class;
+			$class_names[] = $class_name;
 		}
 
-		/**
-		 * Allows for adding additional connectors via classes that extend Connector.
-		 *
-		 * @param array $classes An array of Connector objects.
-		 */
-		$connector_classes = apply_filters( 'wp_stream_connectors', $classes );
+		$this->available_connectors = $class_names;
 
-		foreach ( $connector_classes as $connector ) {
-			// Check if the connector class extends WP_Stream\Connector.
-			if ( ! is_subclass_of( $connector, 'WP_Stream\Connector' ) ) {
+		return $this->available_connectors;
+	}
+
+	/**
+	 * Instantiate connector classes. Memoizes so abilities do not new twice.
+	 *
+	 * @param string[] $class_names Fully-qualified class names.
+	 * @return array<string, Connector>
+	 */
+	private function instantiate_connector_classes( $class_names ) {
+		if ( is_array( $this->connector_instances ) ) {
+			return $this->connector_instances;
+		}
+
+		$classes = array();
+
+		foreach ( $class_names as $class_name ) {
+			$instance                   = new $class_name();
+			$classes[ $instance->name ] = $instance;
+		}
+
+		$this->connector_instances = $classes;
+
+		return $this->connector_instances;
+	}
+
+	/**
+	 * Filter, gate, and register connector instances.
+	 *
+	 * @param array $classes Connector instances keyed by slug.
+	 */
+	public function register_connector_instances( $classes ) {
+		$excluded_connectors = array();
+
+		foreach ( (array) $classes as $connector ) {
+			if ( ! $connector->is_dependency_satisfied() ) {
 				continue;
 			}
 
@@ -143,30 +187,9 @@ class Connectors {
 				continue;
 			}
 
-			// Run any final validations the connector may have before used.
-			if ( ! $connector->is_dependency_satisfied() ) {
-				continue;
-			}
-
-			// Register error for invalid any connector class.
-			if ( ! method_exists( $connector, 'get_label' ) ) {
-				/* translators: %s: connector class name, intended to provide help to developers (e.g. "Connector_BuddyPress") */
-				$this->plugin->admin->notice( sprintf( __( '%s class wasn\'t loaded because it doesn\'t implement the get_label method.', 'stream' ), $connector->name, 'Connector' ), true );
-				continue;
-			}
 			if ( ! method_exists( $connector, 'register' ) ) {
 				/* translators: %s: connector class name, intended to provide help to developers (e.g. "Connector_BuddyPress") */
 				$this->plugin->admin->notice( sprintf( __( '%s class wasn\'t loaded because it doesn\'t implement the register method.', 'stream' ), $connector->name, 'Connector' ), true );
-				continue;
-			}
-			if ( ! method_exists( $connector, 'get_context_labels' ) ) {
-				/* translators: %s: connector class name, intended to provide help to developers (e.g. "Connector_BuddyPress") */
-				$this->plugin->admin->notice( sprintf( __( '%s class wasn\'t loaded because it doesn\'t implement the get_context_labels method.', 'stream' ), $connector->name, 'Connector' ), true );
-				continue;
-			}
-			if ( ! method_exists( $connector, 'get_action_labels' ) ) {
-				/* translators: %s: connector class name, intended to provide help to developers (e.g. "Connector_BuddyPress") */
-				$this->plugin->admin->notice( sprintf( __( '%s class wasn\'t loaded because it doesn\'t implement the get_action_labels method.', 'stream' ), $connector->name, 'Connector' ), true );
 				continue;
 			}
 
@@ -223,166 +246,60 @@ class Connectors {
 	}
 
 	/**
+	 * Load built-in connectors
+	 */
+	public function load_connectors() {
+		$class_names = $this->get_available_connectors();
+		$instances   = $this->instantiate_connector_classes( $class_names );
+
+		/**
+		 * Allows for adding additional connectors via classes that extend Connector.
+		 *
+		 * @param array $instances An array of Connector objects.
+		 */
+		$instances = apply_filters( 'wp_stream_connectors', $instances );
+
+		$valid = array();
+		foreach ( (array) $instances as $connector ) {
+			// We only add classes that extend Connector abstract class with required methods.
+			if ( is_subclass_of( $connector, Connector::class ) ) {
+				$valid[ $connector->name ] = $connector;
+			}
+		}
+
+		$this->connector_instances = $valid;
+
+		$this->register_connector_instances( $this->connector_instances );
+	}
+
+	/**
 	 * Return the slugs of all registered connectors.
 	 *
+	 * @param bool $include_inactive Whether to include inactive connectors.
 	 * @return string[]
 	 */
-	public function get_slugs() {
-		return array_keys( (array) $this->connectors );
+	public function get_slugs( $include_inactive = false ) {
+		return array_keys( $include_inactive ? (array) $this->connector_instances : (array) $this->connectors );
 	}
 
 	/**
 	 * Return a normalized list of all registered connectors and their
 	 * context/action labels.
 	 *
+	 * @param bool $include_inactive Whether to include inactive connectors.
 	 * @return array<int, array{slug:string,label:string,contexts:array<string,string>,actions:array<string,string>}>
 	 */
-	public function get_all() {
-		$out = array();
+	public function get_all( $include_inactive = false ) {
+		$out        = array();
+		$connectors = $include_inactive ? (array) $this->connector_instances : (array) $this->connectors;
 
-		foreach ( (array) $this->connectors as $slug => $connector ) {
+		foreach ( $connectors as $slug => $connector ) {
 			$out[] = array(
 				'slug'     => (string) $slug,
 				'label'    => method_exists( $connector, 'get_label' ) ? (string) $connector->get_label() : (string) $slug,
 				'contexts' => method_exists( $connector, 'get_context_labels' ) ? (array) $connector->get_context_labels() : array(),
 				'actions'  => method_exists( $connector, 'get_action_labels' ) ? (array) $connector->get_action_labels() : array(),
 			);
-		}
-
-		return $out;
-	}
-
-	/**
-	 * Return metadata for every Stream connector, including ones that
-	 * load_connectors() skipped because their `register_frontend` is false
-	 * and the current request isn't wp-admin (REST is `! is_admin()`, so
-	 * connectors like "settings", "editor", "menus" are otherwise invisible
-	 * to abilities). Walks the connector class list once and asks each
-	 * instance for its identity, never calling register() — so no hooks
-	 * fire and the live $this->connectors registry stays exactly as
-	 * load_connectors() built it.
-	 *
-	 * Intended for the abilities layer (stream/get-connectors,
-	 * stream/create-exclusion-rule validation) where the answer should
-	 * reflect "what connectors exist on this site" rather than "what
-	 * connectors loaded their hooks for this specific request".
-	 *
-	 * @return array<int, array{slug:string,label:string,contexts:array<string,string>,actions:array<string,string>}>
-	 */
-	public function get_all_including_admin_only() {
-		$out = array();
-
-		foreach ( $this->build_full_connector_classes() as $connector ) {
-			$out[] = array(
-				'slug'     => (string) $connector->name,
-				'label'    => method_exists( $connector, 'get_label' ) ? (string) $connector->get_label() : (string) $connector->name,
-				'contexts' => method_exists( $connector, 'get_context_labels' ) ? (array) $connector->get_context_labels() : array(),
-				'actions'  => method_exists( $connector, 'get_action_labels' ) ? (array) $connector->get_action_labels() : array(),
-			);
-		}
-
-		/**
-		 * Filter the connector list surfaced to the Abilities API.
-		 *
-		 * Mirrors `wp_stream_connectors` for the abilities-facing list so
-		 * third parties can add/remove entries shown to REST/MCP callers
-		 * without affecting which connectors actually register hooks.
-		 *
-		 * @param array $out Connector metadata entries.
-		 */
-		return apply_filters( 'wp_stream_abilities_connectors', $out );
-	}
-
-	/**
-	 * Return slugs of every Stream connector, including admin-only ones.
-	 * Companion to get_all_including_admin_only(); used by abilities that
-	 * need to validate an incoming connector slug (e.g. stream/create-
-	 * exclusion-rule) against the full site-wide list rather than the
-	 * request-context-gated $this->connectors registry.
-	 *
-	 * @return string[]
-	 */
-	public function get_all_slugs_including_admin_only() {
-		$slugs = array();
-
-		foreach ( $this->build_full_connector_classes() as $connector ) {
-			$slugs[] = (string) $connector->name;
-		}
-
-		return $slugs;
-	}
-
-	/**
-	 * Instantiate every built-in and integrated connector class and return
-	 * the ones whose dependencies are satisfied, regardless of the
-	 * `register_admin` / `register_frontend` gates that load_connectors()
-	 * applies. Helper for the metadata-only accessors above; does not
-	 * register hooks and does not mutate $this->connectors.
-	 *
-	 * @return Connector[]
-	 */
-	protected function build_full_connector_classes() {
-		// Same canonical slug list load_connectors() uses. Keep in sync.
-		$connectors = array(
-			// Core Connectors.
-			'blogs',
-			'comments',
-			'editor',
-			'installer',
-			'media',
-			'menus',
-			'posts',
-			'settings',
-			'taxonomies',
-			'users',
-			'widgets',
-
-			// Integrated Connectors.
-			'acf',
-			'bbpress',
-			'buddypress',
-			'edd',
-			'gravityforms',
-			'jetpack',
-			'mercator',
-			'two-factor',
-			'user-switching',
-			'woocommerce',
-			'wordpress-seo',
-		);
-
-		$classes = array();
-		foreach ( $connectors as $connector ) {
-			include_once $this->plugin->locations['dir'] . '/connectors/class-connector-' . $connector . '.php';
-
-			$class_name = sprintf( '\WP_Stream\Connector_%s', str_replace( '-', '_', $connector ) );
-			if ( ! class_exists( $class_name ) ) {
-				continue;
-			}
-
-			$class                   = new $class_name();
-			$classes[ $class->name ] = $class;
-		}
-
-		/** This filter is documented in classes/class-connectors.php */
-		$connector_classes = apply_filters( 'wp_stream_connectors', $classes );
-
-		$out = array();
-		foreach ( $connector_classes as $connector ) {
-			if ( ! is_subclass_of( $connector, 'WP_Stream\Connector' ) ) {
-				continue;
-			}
-			if ( ! $connector->is_dependency_satisfied() ) {
-				continue;
-			}
-			if (
-				! method_exists( $connector, 'get_label' )
-				|| ! method_exists( $connector, 'get_context_labels' )
-				|| ! method_exists( $connector, 'get_action_labels' )
-			) {
-				continue;
-			}
-			$out[] = $connector;
 		}
 
 		return $out;

--- a/classes/class-connectors.php
+++ b/classes/class-connectors.php
@@ -61,7 +61,10 @@ class Connectors {
 	private $available_connectors = null;
 
 	/**
-	 * Instantiated connectors, keyed by slug. Filled once by instantiate_connector_classes().
+	 * Instantiated connectors, keyed by slug. Includes inactive connectors.
+	 *
+	 * Distinct from $connectors, which holds only instances that passed
+	 * dependency and admin/frontend registration gates.
 	 *
 	 * @var array<string, Connector>|null
 	 */
@@ -142,16 +145,12 @@ class Connectors {
 	}
 
 	/**
-	 * Instantiate connector classes. Memoizes so abilities do not new twice.
+	 * Instantiate connector classes.
 	 *
 	 * @param string[] $class_names Fully-qualified class names.
 	 * @return array<string, Connector>
 	 */
 	private function instantiate_connector_classes( $class_names ) {
-		if ( is_array( $this->connector_instances ) ) {
-			return $this->connector_instances;
-		}
-
 		$classes = array();
 
 		foreach ( $class_names as $class_name ) {
@@ -159,9 +158,7 @@ class Connectors {
 			$classes[ $instance->name ] = $instance;
 		}
 
-		$this->connector_instances = $classes;
-
-		return $this->connector_instances;
+		return $classes;
 	}
 
 	/**
@@ -246,11 +243,23 @@ class Connectors {
 	}
 
 	/**
-	 * Load built-in connectors
+	 * Load built-in connectors.
+	 *
+	 * Runs once per Connectors instance. Later calls are ignored and trigger
+	 * _doing_it_wrong(); use reload_connectors() to re-attach hooks.
 	 */
 	public function load_connectors() {
-		$class_names = $this->get_available_connectors();
-		$instances   = $this->instantiate_connector_classes( $class_names );
+		if ( ! empty( $this->connector_instances ) ) {
+			$message = sprintf(
+				/* translators: %s: method name */
+				__( '%s should only be called once. Use reload_connectors() to re-register hooks.', 'stream' ),
+				__METHOD__
+			);
+			_doing_it_wrong( __METHOD__, $message, Plugin::VERSION ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- notice text, not HTML output.
+			return;
+		}
+
+		$instances = $this->instantiate_connector_classes( $this->get_available_connectors() );
 
 		/**
 		 * Allows for adding additional connectors via classes that extend Connector.

--- a/classes/class-connectors.php
+++ b/classes/class-connectors.php
@@ -208,11 +208,16 @@ class Connectors {
 				continue;
 			}
 
-			// Add connector to the registry.
-			$this->connectors[ $connector->name ] = $connector;
-
 			// Register the connector.
 			$connector->register();
+
+			// Some connectors bail in register() (e.g. network-gated Yoast SEO).
+			if ( ! $connector->is_registered() ) {
+				continue;
+			}
+
+			// Add connector to the registry.
+			$this->connectors[ $connector->name ] = $connector;
 
 			// Link context labels to their connector.
 			$this->contexts[ $connector->name ] = $connector->get_context_labels();

--- a/classes/class-query.php
+++ b/classes/class-query.php
@@ -88,8 +88,8 @@ class Query {
 		FROM $wpdb->stream
 		{$join}
 		WHERE 1=1 {$where}
-		{$orderby}
 		{$groupby}
+		{$orderby}
 		{$limits}";
 
 		/**

--- a/classes/class-query.php
+++ b/classes/class-query.php
@@ -14,11 +14,40 @@ class Query {
 	const ALLOWED_FIELDS = array( 'ID', 'site_id', 'blog_id', 'object_id', 'user_id', 'user_role', 'created', 'summary', 'connector', 'context', 'action', 'ip' );
 
 	/**
+	 * Columns that may appear in ORDER BY.
+	 *
+	 * ALLOWED_FIELDS minus ip. `orderby=date` (the DB::get_records() default)
+	 * is not in this list, so those queries sort by ID. Mapping date to
+	 * created would change order for backdated or imported records.
+	 *
+	 * @var string[]
+	 */
+	const ORDERABLE_FIELDS = array( 'ID', 'site_id', 'blog_id', 'object_id', 'user_id', 'user_role', 'summary', 'created', 'connector', 'context', 'action' );
+
+	/**
 	 * Hold the number of records found
 	 *
 	 * @var int
 	 */
 	public $found_records = 0;
+
+	/**
+	 * Database handle. Set from the global $wpdb in the constructor.
+	 *
+	 * @var object
+	 */
+	public $wpdb;
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param mixed $unused Existing callers pass the DB driver; ignored.
+	 */
+	public function __construct( $unused = null ) {
+		unset( $unused );
+		global $wpdb;
+		$this->wpdb = isset( $wpdb ) ? $wpdb : null;
+	}
 
 	/**
 	 * Query records
@@ -28,62 +57,130 @@ class Query {
 	 * @return array Stream Records
 	 */
 	public function query( $args ) {
-		global $wpdb;
+		$wpdb = $this->wpdb;
 
-		$join  = '';
-		$where = '';
+		// where_dates() expands date onto a copy for SQL. Filter $args stay as the
+		// caller sent them — we do not write date_from/date_to here (that used to leak into the filters).
+
+		$join    = $this->join( $args );
+		$where   = $this->where_columns( $args );
+		$where  .= $this->where_dates( $args );
+		$where  .= $this->where_in( $args );
+		$limits  = $this->limits( $args );
+		$orderby = $this->orderby( $args );
+		$select  = $this->select( $args );
+		$groupby = $join ? "GROUP BY $wpdb->stream.ID" : '';
 
 		/**
-		 * PARSE CORE PARAMS
+		 * Filters query WHERE statement as an alternative to filtering
+		 * the $query using the hook below.
+		 *
+		 * @param string $where  WHERE statement.
+		 *
+		 * @return string
 		 */
-		if ( is_numeric( $args['site_id'] ) ) {
-			$where .= $wpdb->prepare( " AND $wpdb->stream.site_id = %d", $args['site_id'] );
-		}
+		$where = apply_filters( 'wp_stream_db_query_where', $where );
 
-		if ( is_numeric( $args['blog_id'] ) ) {
-			$where .= $wpdb->prepare( " AND $wpdb->stream.blog_id = %d", $args['blog_id'] );
-		}
+		/**
+		 * BUILD THE FINAL QUERY
+		 */
+		$query = "SELECT {$select}
+		FROM $wpdb->stream
+		{$join}
+		WHERE 1=1 {$where}
+		{$orderby}
+		{$groupby}
+		{$limits}";
 
-		if ( is_numeric( $args['object_id'] ) ) {
-			$where .= $wpdb->prepare( " AND $wpdb->stream.object_id = %d", $args['object_id'] );
-		}
+		/**
+		 * Filter allows the final query to be modified before execution
+		 *
+		 * @param string $query
+		 * @param array  $args
+		 *
+		 * @return string
+		 */
+		$query = apply_filters( 'wp_stream_db_query', $query, $args );
 
-		if ( is_numeric( $args['user_id'] ) ) {
-			$where .= $wpdb->prepare( " AND $wpdb->stream.user_id = %d", $args['user_id'] );
+		// Build result count query.
+		$count_query = "SELECT COUNT( DISTINCT $wpdb->stream.ID ) as found
+		FROM $wpdb->stream
+		{$join}
+		WHERE 1=1 {$where}";
+
+		/**
+		 * Filter allows the result count query to be modified before execution.
+		 *
+		 * @param string $query
+		 * @param array  $args
+		 *
+		 * @return string
+		 */
+		$count_query = apply_filters( 'wp_stream_db_count_query', $count_query, $args );
+
+		/**
+		 * QUERY THE DATABASE FOR RESULTS
+		 */
+		$result = array(
+			'items' => $wpdb->get_results( $query ), // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			'count' => absint( $wpdb->get_var( $count_query ) ), // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		);
+
+		return $result;
+	}
+
+	/**
+	 * Equality, search, and IP filters.
+	 *
+	 * @param array $args Arguments to filter the records by.
+	 * @return string WHERE fragments (each starts with " AND ").
+	 */
+	public function where_columns( $args ) {
+		$wpdb  = $this->wpdb;
+		$where = '';
+
+		foreach ( array( 'site_id', 'blog_id', 'object_id', 'user_id' ) as $column ) {
+			if ( is_numeric( $args[ $column ] ) ) {
+				$where .= $wpdb->prepare( " AND $wpdb->stream.{$column} = %d", $args[ $column ] ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			}
 		}
 
 		if ( ! empty( $args['user_role'] ) ) {
 			$where .= $wpdb->prepare( " AND $wpdb->stream.user_role = %s", $args['user_role'] );
 		}
 
+		// Between user_role and connector — original query() order (not after action).
 		if ( ! empty( $args['search'] ) ) {
 			$field = ! empty( $args['search_field'] ) ? $args['search_field'] : 'summary';
 
-			// Sanitize field.
 			if ( in_array( $field, self::ALLOWED_FIELDS, true ) ) {
 				$where .= $wpdb->prepare( " AND $wpdb->stream.{$field} LIKE %s", "%{$args['search']}%" ); // @codingStandardsIgnoreLine can't prepare column name
 			}
 		}
 
-		if ( ! empty( $args['connector'] ) ) {
-			$where .= $wpdb->prepare( " AND $wpdb->stream.connector = %s", $args['connector'] );
-		}
-
-		if ( ! empty( $args['context'] ) ) {
-			$where .= $wpdb->prepare( " AND $wpdb->stream.context = %s", $args['context'] );
-		}
-
-		if ( ! empty( $args['action'] ) ) {
-			$where .= $wpdb->prepare( " AND $wpdb->stream.action = %s", $args['action'] );
+		foreach ( array( 'connector', 'context', 'action' ) as $column ) {
+			if ( ! empty( $args[ $column ] ) ) {
+				$where .= $wpdb->prepare( " AND $wpdb->stream.{$column} = %s", $args[ $column ] ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			}
 		}
 
 		if ( ! empty( $args['ip'] ) ) {
 			$where .= $wpdb->prepare( " AND $wpdb->stream.ip = %s", wp_stream_filter_var( $args['ip'], FILTER_VALIDATE_IP ) );
 		}
 
-		/**
-		 * PARSE DATE PARAM FAMILY
-		 */
+		return $where;
+	}
+
+	/**
+	 * Date family filters. `date` expands to date_from and date_to.
+	 *
+	 * @param array $args Arguments to filter the records by.
+	 * @return string WHERE fragments (each starts with " AND ").
+	 */
+	public function where_dates( $args ) {
+		$wpdb  = $this->wpdb;
+		$where = '';
+
 		if ( ! empty( $args['date'] ) ) {
 			$args['date_from'] = $args['date'];
 			$args['date_to']   = $args['date'];
@@ -109,110 +206,75 @@ class Query {
 			$where .= $wpdb->prepare( " AND DATE($wpdb->stream.created) < %s", $date );
 		}
 
-		/**
-		 * PARSE __IN PARAM FAMILY
-		 */
-		$ins = array();
+		return $where;
+	}
 
-		foreach ( $args as $arg => $value ) {
-			if ( '__in' === substr( $arg, -4 ) ) {
-				$ins[ $arg ] = $value;
-			}
-		}
+	/**
+	 * __in and __not_in filters.
+	 *
+	 * Strip the suffix, map `record` → `ID`, allowlist against ALLOWED_FIELDS,
+	 * then prepare with one placeholder per value (no array_shift, no array arg).
+	 *
+	 * @param array $args Arguments to filter the records by.
+	 * @return string WHERE fragments (each starts with " AND ").
+	 */
+	public function where_in( $args ) {
+		$wpdb     = $this->wpdb;
+		$where    = '';
+		$families = array(
+			'__in'     => 'IN',
+			'__not_in' => 'NOT IN',
+		);
 
-		if ( ! empty( $ins ) ) {
-			foreach ( $ins as $key => $value ) {
+		foreach ( $families as $suffix => $sql_op ) {
+			$suffix_len = strlen( $suffix );
+
+			foreach ( $args as $arg => $value ) {
+				if ( substr( $arg, -$suffix_len ) !== $suffix ) {
+					continue;
+				}
+
 				if ( empty( $value ) || ! is_array( $value ) ) {
 					continue;
 				}
 
-				$field = str_replace( array( 'record_', '__in' ), '', $key );
-				$field = empty( $field ) ? 'ID' : $field;
-				$type  = is_numeric( array_shift( $value ) ) ? '%d' : '%s';
-
-				if ( ! empty( $value ) ) {
-					$format = '(' . join( ',', array_fill( 0, count( $value ), $type ) ) . ')';
-					$where .= $wpdb->prepare( " AND $wpdb->stream.%s IN {$format}", $field, $value ); // @codingStandardsIgnoreLine prepare okay
+				$field = substr( $arg, 0, -$suffix_len );
+				if ( 'record' === $field ) {
+					$field = 'ID';
 				}
-			}
-		}
 
-		/**
-		 * PARSE __NOT_IN PARAM FAMILY
-		 */
-		$not_ins = array();
-
-		foreach ( $args as $arg => $value ) {
-			if ( '__not_in' === substr( $arg, -8 ) ) {
-				$not_ins[ $arg ] = $value;
-			}
-		}
-
-		if ( ! empty( $not_ins ) ) {
-			foreach ( $not_ins as $key => $value ) {
-				if ( empty( $value ) || ! is_array( $value ) ) {
+				if ( ! in_array( $field, self::ALLOWED_FIELDS, true ) ) {
 					continue;
 				}
 
-				$field = str_replace( array( 'record_', '__not_in' ), '', $key );
-				$field = empty( $field ) ? 'ID' : $field;
-				$type  = is_numeric( array_shift( $value ) ) ? '%d' : '%s';
+				$values = array_values( $value );
+				$type   = is_numeric( $values[0] ) ? '%d' : '%s';
+				$format = '(' . join( ',', array_fill( 0, count( $values ), $type ) ) . ')';
 
-				if ( ! empty( $value ) ) {
-					$format = '(' . join( ',', array_fill( 0, count( $value ), $type ) ) . ')';
-					$where .= $wpdb->prepare( " AND $wpdb->stream.%s NOT IN {$format}", $field, $value ); // @codingStandardsIgnoreLine prepare okay
-				}
+				$where .= $wpdb->prepare(
+					" AND $wpdb->stream.{$field} {$sql_op} {$format}", // @codingStandardsIgnoreLine column name allowlisted
+					...$values
+				);
 			}
 		}
 
-		/**
-		 * PARSE PAGINATION PARAMS
-		 */
-		$limits   = '';
-		$page     = absint( $args['paged'] );
-		$per_page = absint( $args['records_per_page'] );
+		return $where;
+	}
 
-		if ( $per_page >= 0 ) {
-			$offset = absint( ( $page - 1 ) * $per_page );
-			$limits = "LIMIT {$offset}, {$per_page}";
-		}
-
-		/**
-		 * PARSE ORDER PARAMS
-		 */
-		$orderable = array( 'ID', 'site_id', 'blog_id', 'object_id', 'user_id', 'user_role', 'summary', 'created', 'connector', 'context', 'action' );
-
-		// Default to sorting by record ID.
-		$orderby = "$wpdb->stream.ID";
-
-		if ( in_array( $args['orderby'], $orderable, true ) ) {
-			$orderby = sprintf( '%s.%s', $wpdb->stream, $args['orderby'] );
-		} elseif ( 'meta_value_num' === $args['orderby'] && ! empty( $args['meta_key'] ) ) {
-			$orderby = "CAST($wpdb->streammeta.meta_value AS SIGNED)";
-		} elseif ( 'meta_value' === $args['orderby'] && ! empty( $args['meta_key'] ) ) {
-			$orderby = "$wpdb->streammeta.meta_value";
-		}
-
-		// Show the recent records first by default.
-		$order = 'DESC';
-		if ( 'ASC' === strtoupper( $args['order'] ) ) {
-			$order = 'ASC';
-		}
-
-		$orderby = sprintf( 'ORDER BY %s %s', $orderby, $order );
-
-		/**
-		 * PARSE FIELDS PARAMETER
-		 */
+	/**
+	 * SELECT list. Column names cannot go through prepare(), so they are
+	 * restricted to ALLOWED_FIELDS.
+	 *
+	 * @param array $args Arguments to filter the records by.
+	 * @return string
+	 */
+	public function select( $args ) {
+		$wpdb    = $this->wpdb;
 		$fields  = (array) $args['fields'];
 		$selects = array();
 
-		// Column names cannot be passed through $wpdb->prepare(), so restrict
-		// the selectable fields to a known allowlist to prevent SQL injection
-		// via the `fields` argument.
 		if ( ! empty( $fields ) ) {
 			foreach ( $fields as $field ) {
-				// We'll query the meta table later.
 				if ( 'meta' === $field ) {
 					continue;
 				}
@@ -229,62 +291,84 @@ class Query {
 			$selects[] = "$wpdb->stream.*";
 		}
 
-		$select = implode( ', ', $selects );
+		return implode( ', ', $selects );
+	}
 
-		/**
-		 * Filters query WHERE statement as an alternative to filtering
-		 * the $query using the hook below.
-		 *
-		 * @param string $where  WHERE statement.
-		 *
-		 * @return string
-		 */
-		$where = apply_filters( 'wp_stream_db_query_where', $where );
+	/**
+	 * ORDER BY clause.
+	 *
+	 * @param array $args Arguments to filter the records by.
+	 * @return string
+	 */
+	public function orderby( $args ) {
+		$wpdb = $this->wpdb;
 
-		/**
-		 * BUILD THE FINAL QUERY
-		 */
-		$query = "SELECT {$select}
-		FROM $wpdb->stream
-		{$join}
-		WHERE 1=1 {$where}
-		{$orderby}
-		{$limits}";
+		// Default to sorting by record ID. See ORDERABLE_FIELDS.
+		$orderby = "$wpdb->stream.ID";
 
-		/**
-		 * Filter allows the final query to be modified before execution
-		 *
-		 * @param string $query
-		 * @param array  $args
-		 *
-		 * @return string
-		 */
-		$query = apply_filters( 'wp_stream_db_query', $query, $args );
+		if ( in_array( $args['orderby'], self::ORDERABLE_FIELDS, true ) ) {
+			$orderby = sprintf( '%s.%s', $wpdb->stream, $args['orderby'] );
+		} elseif ( 'meta_value_num' === $args['orderby'] && ! empty( $args['meta_key'] ) ) {
+			$orderby = "CAST($wpdb->streammeta.meta_value AS SIGNED)";
+		} elseif ( 'meta_value' === $args['orderby'] && ! empty( $args['meta_key'] ) ) {
+			$orderby = "$wpdb->streammeta.meta_value";
+		}
 
-		// Build result count query.
-		$count_query = "SELECT COUNT(*) as found
-		FROM $wpdb->stream
-		{$join}
-		WHERE 1=1 {$where}";
+		$order = 'DESC';
+		if ( 'ASC' === strtoupper( $args['order'] ) ) {
+			$order = 'ASC';
+		}
 
-		/**
-		 * Filter allows the result count query to be modified before execution.
-		 *
-		 * @param string $query
-		 * @param array  $args
-		 *
-		 * @return string
-		 */
-		$count_query = apply_filters( 'wp_stream_db_count_query', $count_query, $args );
+		return sprintf( 'ORDER BY %s %s', $orderby, $order );
+	}
 
-		/**
-		 * QUERY THE DATABASE FOR RESULTS
-		 */
-		$result = array(
-			'items' => $wpdb->get_results( $query ), // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-			'count' => absint( $wpdb->get_var( $count_query ) ), // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+	/**
+	 * JOIN fragment for meta orderby.
+	 *
+	 * When orderby is meta_value / meta_value_num and meta_key is set,
+	 * JOIN streammeta so ORDER BY can reference meta_value.
+	 *
+	 * @param array $args Arguments to filter the records by.
+	 * @return string JOIN clause, or empty string.
+	 */
+	public function join( $args ) {
+		$wpdb = $this->wpdb;
+
+		$is_meta_orderby = in_array( $args['orderby'], array( 'meta_value', 'meta_value_num' ), true );
+		if ( ! $is_meta_orderby || empty( $args['meta_key'] ) ) {
+			return '';
+		}
+
+		return $wpdb->prepare(
+			"LEFT JOIN $wpdb->streammeta ON $wpdb->streammeta.record_id = $wpdb->stream.ID AND $wpdb->streammeta.meta_key = %s", // @codingStandardsIgnoreLine table names from wpdb properties
+			$args['meta_key']
 		);
+	}
 
-		return $result;
+	/**
+	 * LIMIT clause.
+	 *
+	 * `$per_page >= 0` is kept for zero drift. absint() cannot return a
+	 * negative, so the LIMIT is always emitted. paged below 1 is treated
+	 * as page 1 so paged=0 does not become LIMIT per_page, per_page.
+	 *
+	 * @param array $args Arguments to filter the records by.
+	 * @return string
+	 */
+	public function limits( $args ) {
+		$limits   = '';
+		$page     = absint( $args['paged'] );
+		$per_page = absint( $args['records_per_page'] );
+
+		if ( $page < 1 ) {
+			$page = 1;
+		}
+
+		if ( $per_page >= 0 ) {
+			$offset = absint( ( $page - 1 ) * $per_page );
+			$limits = "LIMIT {$offset}, {$per_page}";
+		}
+
+		return $limits;
 	}
 }

--- a/classes/class-query.php
+++ b/classes/class-query.php
@@ -41,10 +41,11 @@ class Query {
 	/**
 	 * Class constructor.
 	 *
-	 * @param mixed $unused Existing callers pass the DB driver; ignored.
+	 * @param DB_Driver|null $driver Existing callers pass the DB driver; unused. Kept for BC
+	 *                               because DB_Driver_WPDB still calls `new Query( $this )`.
 	 */
-	public function __construct( $unused = null ) {
-		unset( $unused );
+	public function __construct( $driver = null ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- BC signature; Query reads $wpdb, not the driver.
+		unset( $driver );
 		global $wpdb;
 		$this->wpdb = isset( $wpdb ) ? $wpdb : null;
 	}
@@ -297,6 +298,10 @@ class Query {
 	/**
 	 * ORDER BY clause.
 	 *
+	 * Meta sorts use MAX() so duplicate stream_meta rows for the same
+	 * (record_id, meta_key) produce a deterministic key and remain valid
+	 * under ONLY_FULL_GROUP_BY.
+	 *
 	 * @param array $args Arguments to filter the records by.
 	 * @return string
 	 */
@@ -309,9 +314,12 @@ class Query {
 		if ( in_array( $args['orderby'], self::ORDERABLE_FIELDS, true ) ) {
 			$orderby = sprintf( '%s.%s', $wpdb->stream, $args['orderby'] );
 		} elseif ( 'meta_value_num' === $args['orderby'] && ! empty( $args['meta_key'] ) ) {
-			$orderby = "CAST($wpdb->streammeta.meta_value AS SIGNED)";
+			// MAX() is required: stream_meta has no unique (record_id, meta_key),
+			// so the JOIN can emit multiple rows per record. Without an aggregate
+			// the sort key is arbitrary and ONLY_FULL_GROUP_BY rejects the query.
+			$orderby = "MAX( CAST($wpdb->streammeta.meta_value AS SIGNED) )";
 		} elseif ( 'meta_value' === $args['orderby'] && ! empty( $args['meta_key'] ) ) {
-			$orderby = "$wpdb->streammeta.meta_value";
+			$orderby = "MAX( $wpdb->streammeta.meta_value )";
 		}
 
 		$order = 'DESC';

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,8 @@
     "wp-plugin/wp-crontrol": "1.21.0",
     "wp-theme/twentytwentythree": "^1.0",
     "xwp/wait-for": "^0.0.1",
-    "yoast/phpunit-polyfills": "^1.1"
+    "yoast/phpunit-polyfills": "^1.1",
+    "yoast/wp-test-utils": "^1.2"
   },
   "config": {
     "process-timeout": 600,
@@ -94,6 +95,9 @@
     "test": [
       "phpunit --coverage-text",
       "php local/scripts/make-clover-relative.php ./tests/reports/clover.xml"
+    ],
+    "test-unit": [
+      "phpunit -c phpunit-unit.xml"
     ],
     "test-one": [
       "phpunit",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "50d38ad85032b85a1ffb4ea1c9649128",
+    "content-hash": "9bf51a33dbfbaf8099ef672e5d150dff",
     "packages": [
         {
             "name": "composer/installers",
@@ -198,6 +198,54 @@
     ],
     "packages-dev": [
         {
+            "name": "antecedent/patchwork",
+            "version": "2.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/antecedent/patchwork.git",
+                "reference": "8b6b235f405af175259c8f56aea5fc23ab9f03ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/8b6b235f405af175259c8f56aea5fc23ab9f03ce",
+                "reference": "8b6b235f405af175259c8f56aea5fc23ab9f03ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignas Rudaitis",
+                    "email": "ignas.rudaitis@gmail.com"
+                }
+            ],
+            "description": "Method redefinition (monkey-patching) functionality for PHP.",
+            "homepage": "https://antecedent.github.io/patchwork/",
+            "keywords": [
+                "aop",
+                "aspect",
+                "interception",
+                "monkeypatching",
+                "redefinition",
+                "runkit",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/antecedent/patchwork/issues",
+                "source": "https://github.com/antecedent/patchwork/tree/2.2.3"
+            },
+            "time": "2025-09-17T09:00:56+00:00"
+        },
+        {
             "name": "automattic/vipwpcs",
             "version": "3.0.1",
             "source": {
@@ -250,6 +298,76 @@
                 "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
             },
             "time": "2024-05-10T20:31:09+00:00"
+        },
+        {
+            "name": "brain/monkey",
+            "version": "2.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Brain-WP/BrainMonkey.git",
+                "reference": "ea3aeb3d559ba3c0930b3f4d210b665a4c044d83"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/ea3aeb3d559ba3c0930b3f4d210b665a4c044d83",
+                "reference": "ea3aeb3d559ba3c0930b3f4d210b665a4c044d83",
+                "shasum": ""
+            },
+            "require": {
+                "antecedent/patchwork": "^2.1.17",
+                "mockery/mockery": "~1.3.6 || ~1.4.4 || ~1.5.1 || ^1.6.10",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
+                "phpcompatibility/php-compatibility": "^9.3.0",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.49 || ^9.6.30"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev",
+                    "dev-version/1": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "inc/api.php"
+                ],
+                "psr-4": {
+                    "Brain\\Monkey\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Giuseppe Mazzapica",
+                    "email": "giuseppe.mazzapica@gmail.com",
+                    "homepage": "https://gmazzap.me",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Mocking utility for PHP functions and WordPress plugin API",
+            "keywords": [
+                "Monkey Patching",
+                "interception",
+                "mock",
+                "mock functions",
+                "mockery",
+                "patchwork",
+                "redefinition",
+                "runkit",
+                "test",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Brain-WP/BrainMonkey/issues",
+                "source": "https://github.com/Brain-WP/BrainMonkey"
+            },
+            "time": "2026-02-05T09:22:14+00:00"
         },
         {
             "name": "composer/ca-bundle",
@@ -1556,6 +1674,61 @@
             "time": "2024-07-18T11:15:46+00:00"
         },
         {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "b61cd040da1a4925bc90a51c074f5297e7c0fa52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/b61cd040da1a4925bc90a51c074f5297e7c0fa52",
+                "reference": "b61cd040da1a4925bc90a51c074f5297e7c0fa52",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-dom": "*",
+                "php": "^7.4|^8.0"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/php-file-iterator": "^1.4 || ^2.0 || ^3.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "support": {
+                "issues": "https://github.com/hamcrest/hamcrest-php/issues",
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v3.0.0"
+            },
+            "time": "2026-03-17T11:56:53+00:00"
+        },
+        {
             "name": "humanmade/mercator",
             "version": "dev-master",
             "source": {
@@ -1868,6 +2041,88 @@
                 "source": "https://github.com/mck89/peast/tree/v1.16.3"
             },
             "time": "2024-07-23T14:00:32+00:00"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "1.6.15",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mockery/mockery.git",
+                "reference": "967a801bd188989a5669bd280f252d51c0fdc9ee"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/967a801bd188989a5669bd280f252d51c0fdc9ee",
+                "reference": "967a801bd188989a5669bd280f252d51c0fdc9ee",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "^2.0 || ^3.0",
+                "php": ">=7.3"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6.36",
+                "symplify/easy-coding-standard": "^13.2.17"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "library/helpers.php",
+                    "library/Mockery.php"
+                ],
+                "psr-4": {
+                    "Mockery\\": "library/Mockery"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "https://github.com/padraic",
+                    "role": "Author"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "https://davedevelopment.co.uk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Nathanael Esayeas",
+                    "email": "nathanael.esayeas@protonmail.com",
+                    "homepage": "https://github.com/ghostwriter",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "support": {
+                "docs": "https://docs.mockery.io/",
+                "issues": "https://github.com/mockery/mockery/issues",
+                "rss": "https://github.com/mockery/mockery/releases.atom",
+                "security": "https://github.com/mockery/mockery/security/advisories",
+                "source": "https://github.com/mockery/mockery"
+            },
+            "time": "2026-08-19T19:37:52+00:00"
         },
         {
             "name": "mustache/mustache",
@@ -9215,6 +9470,75 @@
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
             "time": "2024-04-05T16:01:51+00:00"
+        },
+        {
+            "name": "yoast/wp-test-utils",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/wp-test-utils.git",
+                "reference": "2e0f62e0281e4859707c5f13b7da1422aa1c8f7b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/wp-test-utils/zipball/2e0f62e0281e4859707c5f13b7da1422aa1c8f7b",
+                "reference": "2e0f62e0281e4859707c5f13b7da1422aa1c8f7b",
+                "shasum": ""
+            },
+            "require": {
+                "brain/monkey": "^2.6.1",
+                "php": ">=5.6",
+                "yoast/phpunit-polyfills": "^1.1.0"
+            },
+            "require-dev": {
+                "yoast/yoastcs": "^2.3.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ],
+                "exclude-from-classmap": [
+                    "/src/WPIntegration/TestCase.php",
+                    "/src/WPIntegration/TestCaseNoPolyfills.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/wp-test-utils/graphs/contributors"
+                }
+            ],
+            "description": "PHPUnit cross-version compatibility layer for testing plugins and themes build for WordPress",
+            "homepage": "https://github.com/Yoast/wp-test-utils/",
+            "keywords": [
+                "brainmonkey",
+                "integration-testing",
+                "phpunit",
+                "testing",
+                "unit-testing",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/wp-test-utils/issues",
+                "source": "https://github.com/Yoast/wp-test-utils"
+            },
+            "time": "2023-09-27T10:25:08+00:00"
         }
     ],
     "aliases": [
@@ -9246,5 +9570,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -9570,5 +9570,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/contributing.md
+++ b/contributing.md
@@ -102,7 +102,9 @@ We use npm as the canonical task runner for the project. The following commands 
 - `npm run lint` to check JS and PHP files for syntax and style issues.
 - `npm run deploy` to deploy the plugin to the WordPress.org repository.
 - `npm run cli -- wp info` where `wp info` is the CLI command to run inside the WordPress container. For example, use `npm run cli -- ls -lah` to list all files in the root of the WordPress installation.
-- `npm run test` to run PHPunit tests inside the WordPress container.
+- `npm run test` to run PHPunit unit and integration tests inside the WordPress container.
+- `composer test-unit` to run the fast PHP unit suite on the host (no Docker, no WordPress bootstrap).
+- `npm run test-unit` to run the fast PHP unit suite on docker container.
 - `npm run test-xdebug` will run the PHPunit tests with Xdebug enabled.
 - `npm run test-e2e` will run the Playwright E2E tests.
 - `npm run test-e2e-debug` will run the Playwright E2E tests in a debug mode (with Chromium browser and dev tools open).

--- a/contributing.md
+++ b/contributing.md
@@ -104,7 +104,7 @@ We use npm as the canonical task runner for the project. The following commands 
 - `npm run cli -- wp info` where `wp info` is the CLI command to run inside the WordPress container. For example, use `npm run cli -- ls -lah` to list all files in the root of the WordPress installation.
 - `npm run test` to run PHPunit unit and integration tests inside the WordPress container.
 - `composer test-unit` to run the fast PHP unit suite on the host (no Docker, no WordPress bootstrap).
-- `npm run test-unit` to run the fast PHP unit suite on docker container.
+- `npm run test:php-unit` to run the fast PHP unit suite in the Docker container.
 - `npm run test-xdebug` will run the PHPunit tests with Xdebug enabled.
 - `npm run test-e2e` will run the Playwright E2E tests.
 - `npm run test-e2e-debug` will run the Playwright E2E tests in a debug mode (with Chromium browser and dev tools open).

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "format:php": "composer format",
     "format:js": "npm run lint:js -- --fix",
     "test": "npm-run-all test:*",
+    "test:php-unit": "npm run cli -- composer test-unit --working-dir=wp-content/plugins/stream-src",
     "test:php": "npm run cli -- composer test --working-dir=wp-content/plugins/stream-src",
     "test:php-multisite": "npm run cli -- composer test-multisite --working-dir=wp-content/plugins/stream-src",
     "test-e2e": "wp-scripts test-playwright",

--- a/phpunit-multisite.xml
+++ b/phpunit-multisite.xml
@@ -33,6 +33,7 @@
 	<testsuites>
 	<testsuite name="stream">
 		<directory prefix="test-" suffix=".php">tests</directory>
+		<exclude>tests/phpunit/unit</exclude>
 	</testsuite>
 	</testsuites>
 	<logging/>

--- a/phpunit-unit.xml
+++ b/phpunit-unit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<phpunit
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	bootstrap="tests/phpunit/unit/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	verbose="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+	>
+	<testsuites>
+	<testsuite name="stream-unit">
+		<directory prefix="test-" suffix=".php">tests/phpunit/unit</directory>
+	</testsuite>
+	</testsuites>
+</phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -33,6 +33,7 @@
 	<testsuites>
 	<testsuite name="stream">
 		<directory prefix="test-" suffix=".php">tests</directory>
+		<exclude>tests/phpunit/unit</exclude>
 	</testsuite>
 	</testsuites>
 	<logging/>

--- a/tests/phpunit/abilities/test-class-ability-create-exclusion-rule.php
+++ b/tests/phpunit/abilities/test-class-ability-create-exclusion-rule.php
@@ -113,6 +113,25 @@ class Test_Ability_Create_Exclusion_Rule extends Abilities_TestCase {
 		$this->assertSame( 'stream_unknown_connector', $result->get_error_code() );
 	}
 
+	public function test_skips_connector_validation_when_connectors_uninitialized() {
+		wp_set_current_user( $this->admin_user_id );
+
+		$connectors = $this->plugin->connectors;
+		unset( $this->plugin->connectors );
+
+		$option_key = $this->plugin->settings->option_key;
+		update_option( $option_key, array() );
+
+		try {
+			$result = $this->ability->execute( array( 'connector' => 'posts' ) );
+		} finally {
+			$this->plugin->connectors = $connectors;
+		}
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'posts', $result['rule']['connector'] );
+	}
+
 	/**
 	 * Admin-only connectors (register_frontend = false) must validate
 	 * successfully even when the test/REST request isn't wp-admin. Regression

--- a/tests/phpunit/abilities/test-class-ability-get-connectors.php
+++ b/tests/phpunit/abilities/test-class-ability-get-connectors.php
@@ -35,6 +35,8 @@ class Test_Ability_Get_Connectors extends Abilities_TestCase {
 
 		$output = $this->ability->get_output_schema();
 		$this->assertSame( 'array', $output['type'] );
+		$this->assertStringContainsString( 'ships', $this->ability->get_description() );
+		$this->assertStringContainsString( 'ships', $output['description'] );
 	}
 
 	public function test_permissions() {

--- a/tests/phpunit/test-class-connectors.php
+++ b/tests/phpunit/test-class-connectors.php
@@ -22,7 +22,6 @@ class Test_Connectors extends WP_StreamTestCase {
 	}
 
 	public function test_load_connectors() {
-		$this->connectors->load_connectors();
 		$this->assertNotEmpty( $this->connectors->connectors );
 		$this->assertNotEmpty( $this->connectors->contexts );
 		$this->assertNotEmpty( $this->connectors->term_labels['stream_connector'] );
@@ -36,8 +35,13 @@ class Test_Connectors extends WP_StreamTestCase {
 		$this->assertEmpty( $notices );
 	}
 
-	public function test_unload_connectors() {
+	public function test_load_connectors_second_call_is_doing_it_wrong() {
+		$this->setExpectedIncorrectUsage( 'WP_Stream\Connectors::load_connectors' );
 		$this->connectors->load_connectors();
+		$this->assertNotEmpty( $this->connectors->connectors );
+	}
+
+	public function test_unload_connectors() {
 		$this->assertNotEmpty( $this->connectors->connectors );
 
 		foreach ( $this->connectors->connectors as $connector ) {
@@ -51,7 +55,6 @@ class Test_Connectors extends WP_StreamTestCase {
 	}
 
 	public function test_reload_connectors() {
-		$this->connectors->load_connectors();
 		$this->assertNotEmpty( $this->connectors->connectors );
 		$this->connectors->unload_connectors();
 		foreach ( $this->connectors->connectors as $connector ) {
@@ -65,7 +68,6 @@ class Test_Connectors extends WP_StreamTestCase {
 	}
 
 	public function test_unload_connector() {
-		$this->connectors->load_connectors();
 		$this->assertNotEmpty( $this->connectors->connectors['posts'] );
 		$this->assertTrue( $this->connectors->connectors['posts']->is_registered() );
 
@@ -74,7 +76,6 @@ class Test_Connectors extends WP_StreamTestCase {
 	}
 
 	public function test_reload_connector() {
-		$this->connectors->load_connectors();
 		$this->assertNotEmpty( $this->connectors->connectors['posts'] );
 		$this->connectors->unload_connector( 'posts' );
 		$this->assertFalse( $this->connectors->connectors['posts']->is_registered() );

--- a/tests/phpunit/unit/bootstrap.php
+++ b/tests/phpunit/unit/bootstrap.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * PHPUnit bootstrap for the no-WordPress unit suite.
+ *
+ * @package WP_Stream
+ */
+
+$wp_stream_unit_autoload_file = dirname( __DIR__, 3 ) . '/vendor/autoload.php';
+
+if ( ! is_readable( $wp_stream_unit_autoload_file ) ) {
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- CLI bootstrap before WP loads.
+	fwrite( STDERR, "Composer autoload not found. Run composer install.\n" );
+	exit( 1 );
+}
+
+require_once $wp_stream_unit_autoload_file;
+
+/**
+ * Autoload WP_Stream classes from classes/class-*.php (same mapping as Plugin::autoload).
+ *
+ * @param string $class_name Fully-qualified class name.
+ */
+function wp_stream_unit_autoload( $class_name ) {
+	if ( ! preg_match( '/^WP_Stream\\\\(?P<autoload>[^\\\\]+)$/', $class_name, $matches ) ) {
+		return;
+	}
+
+	$path = dirname( __DIR__, 3 ) . '/classes/class-' . strtolower( str_replace( '_', '-', $matches['autoload'] ) ) . '.php';
+
+	if ( is_readable( $path ) ) {
+		require_once $path;
+	}
+}
+
+spl_autoload_register( 'wp_stream_unit_autoload' );

--- a/tests/phpunit/unit/test-connectors.php
+++ b/tests/phpunit/unit/test-connectors.php
@@ -1,0 +1,362 @@
+<?php
+namespace WP_Stream;
+
+use Brain\Monkey\Actions;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+use Mockery;
+use ReflectionClass;
+use ReflectionProperty;
+use stdClass;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+
+class Test_Connectors_Unit extends TestCase {
+	protected function set_up() {
+		parent::set_up();
+		$this->stubTranslationFunctions();
+	}
+
+	public function test_builtin_connector_slugs_includes_core_and_integrated() {
+		$this->assertContains( 'posts', Connectors::BUILTIN_CONNECTOR_SLUGS );
+		$this->assertContains( 'jetpack', Connectors::BUILTIN_CONNECTOR_SLUGS );
+	}
+
+	public function test_register_connector_instances_registers_happy_path() {
+		Functions\when( 'is_admin' )->justReturn( true );
+		Actions\expectDone( 'wp_stream_after_connectors_registration' )
+			->once()
+			->with(
+				array( 'unit-stub' => 'Unit Stub' ),
+				Mockery::type( Connectors::class )
+			);
+
+		$connector  = $this->mock_connector();
+		$connectors = $this->make_connectors();
+
+		$connectors->register_connector_instances( array( 'unit-stub' => $connector ) );
+
+		$this->assertSame( $connector, $connectors->connectors['unit-stub'] );
+		$this->assertTrue( $connector->is_registered() );
+		$this->assertSame( array( 'unit-ctx' => 'Unit Context' ), $connectors->contexts['unit-stub'] );
+		$this->assertSame( 'Unit Stub', $connectors->term_labels['stream_connector']['unit-stub'] );
+		$this->assertSame( 'Unit Action', $connectors->term_labels['stream_action']['unit-act'] );
+		$this->assertSame( 'Unit Context', $connectors->term_labels['stream_context']['unit-ctx'] );
+	}
+
+	public function test_register_connector_instances_registers_on_frontend() {
+		Functions\when( 'is_admin' )->justReturn( false );
+
+		$connector  = $this->mock_connector();
+		$connectors = $this->make_connectors();
+
+		$connectors->register_connector_instances( array( 'unit-stub' => $connector ) );
+
+		$this->assertSame( $connector, $connectors->connectors['unit-stub'] );
+		$this->assertTrue( $connector->is_registered() );
+	}
+
+	/**
+	 * @dataProvider data_register_connector_instances_skips
+	 *
+	 * @param bool   $is_admin             Whether to treat the request as admin.
+	 * @param string $slug                 Connector slug.
+	 * @param bool   $register_admin       Connector register_admin flag.
+	 * @param bool   $register_frontend    Connector register_frontend flag.
+	 * @param bool   $dependency_satisfied Whether is_dependency_satisfied returns true.
+	 * @param bool   $excluded             Whether the excluded filter returns true.
+	 */
+	public function test_register_connector_instances_skips( $is_admin, $slug, $register_admin, $register_frontend, $dependency_satisfied, $excluded ) {
+		Functions\when( 'is_admin' )->justReturn( $is_admin );
+
+		if ( $excluded ) {
+			Filters\expectApplied( 'wp_stream_check_connector_is_excluded' )->andReturn( true );
+		}
+
+		$connector                    = $this->mock_connector( $slug );
+		$connector->register_admin    = $register_admin;
+		$connector->register_frontend = $register_frontend;
+
+		if ( ! $dependency_satisfied ) {
+			$connector->shouldReceive( 'is_dependency_satisfied' )->andReturn( false );
+		}
+
+		$connectors = $this->make_connectors();
+		$connectors->register_connector_instances( array( $slug => $connector ) );
+
+		$this->assertArrayNotHasKey( $slug, $connectors->connectors );
+		$this->assertFalse( $connector->is_registered() );
+	}
+
+	/**
+	 * @return array<string, array{0: bool, 1: string, 2: bool, 3: bool, 4: bool, 5: bool}>
+	 */
+	public static function data_register_connector_instances_skips() {
+		return array(
+			'admin_register_admin_false'       => array( true, 'unit-stub', false, true, true, false ),
+			'frontend_register_frontend_false' => array( false, 'unit-stub', true, false, true, false ),
+			'unsatisfied_dependency'           => array( true, 'unit-unsatisfied', true, true, false, false ),
+			'excluded_by_filter'               => array( true, 'unit-stub', true, true, true, true ),
+		);
+	}
+
+	public function test_register_connector_instances_registers_extra_connector() {
+		Functions\when( 'is_admin' )->justReturn( true );
+
+		$extra      = $this->mock_connector( 'unit-extra' );
+		$connectors = $this->make_connectors();
+
+		$connectors->register_connector_instances( array( 'unit-extra' => $extra ) );
+
+		$this->assertSame( $extra, $connectors->connectors['unit-extra'] );
+		$this->assertTrue( $extra->is_registered() );
+	}
+
+	public function test_register_connector_instances_notices_when_register_method_missing() {
+		Functions\when( 'is_admin' )->justReturn( true );
+
+		$connector                    = Mockery::mock();
+		$connector->name              = 'unit-no-register';
+		$connector->register_admin    = true;
+		$connector->register_frontend = true;
+		$connector->shouldReceive( 'is_dependency_satisfied' )->andReturn( true );
+
+		$connectors = $this->make_connectors();
+		$connectors->plugin->admin->shouldReceive( 'notice' )
+			->once()
+			->with( Mockery::pattern( '/unit-no-register/' ), true );
+
+		$connectors->register_connector_instances( array( 'unit-no-register' => $connector ) );
+
+		$this->assertArrayNotHasKey( 'unit-no-register', $connectors->connectors );
+	}
+
+	public function test_load_connectors_registers_seeded_instances() {
+		Functions\when( 'is_admin' )->justReturn( true );
+
+		$connector  = $this->mock_connector();
+		$connectors = $this->make_connectors();
+		$this->seed_available( $connectors, array() );
+		$this->seed_instances( $connectors, array( 'unit-stub' => $connector ) );
+
+		$connectors->load_connectors();
+
+		$this->assertSame( $connector, $connectors->connectors['unit-stub'] );
+		$this->assertTrue( $connector->is_registered() );
+	}
+
+	public function test_load_connectors_keeps_filter_extra_that_extends_connector() {
+		Functions\when( 'is_admin' )->justReturn( true );
+
+		$extra = $this->mock_connector( 'unit-extra' );
+		Filters\expectApplied( 'wp_stream_connectors' )->andReturn( array( $extra ) );
+
+		$connectors = $this->make_connectors();
+		$this->seed_available( $connectors, array() );
+
+		$connectors->load_connectors();
+
+		$this->assertSame( $extra, $connectors->connectors['unit-extra'] );
+		$this->assertTrue( $extra->is_registered() );
+		$this->assertSame( array( 'unit-extra' ), $connectors->get_slugs( true ) );
+	}
+
+	public function test_load_connectors_drops_filter_extra_that_is_not_connector() {
+		Functions\when( 'is_admin' )->justReturn( true );
+		Filters\expectApplied( 'wp_stream_connectors' )->andReturn( array( new stdClass() ) );
+
+		$connectors = $this->make_connectors();
+		$this->seed_available( $connectors, array() );
+
+		$connectors->load_connectors();
+
+		$this->assertSame( array(), $connectors->connectors );
+		$this->assertSame( array(), $connectors->get_slugs( true ) );
+	}
+
+	public function test_load_connectors_keeps_unsatisfied_in_instances_but_does_not_register() {
+		Functions\when( 'is_admin' )->justReturn( true );
+
+		$connector = $this->mock_connector( 'unit-unsatisfied' );
+		$connector->shouldReceive( 'is_dependency_satisfied' )->andReturn( false );
+		$connectors = $this->make_connectors();
+		$this->seed_available( $connectors, array() );
+		$this->seed_instances( $connectors, array( 'unit-unsatisfied' => $connector ) );
+
+		$connectors->load_connectors();
+
+		$this->assertArrayNotHasKey( 'unit-unsatisfied', $connectors->connectors );
+		$this->assertFalse( $connector->is_registered() );
+		$this->assertSame( array( 'unit-unsatisfied' ), $connectors->get_slugs( true ) );
+	}
+
+	/**
+	 * @dataProvider data_get_slugs_and_get_all
+	 *
+	 * @param bool  $include_inactive Whether to include skipped connectors.
+	 * @param array $expected_slugs   Expected slugs from get_slugs().
+	 * @param array $expected_all     Expected payloads from get_all().
+	 */
+	public function test_get_slugs_and_get_all( $include_inactive, $expected_slugs, $expected_all ) {
+		Functions\when( 'is_admin' )->justReturn( false );
+
+		$active                        = $this->mock_connector();
+		$admin_only                    = $this->mock_connector( 'unit-admin-only' );
+		$admin_only->register_frontend = false;
+		$unsatisfied                   = $this->mock_connector( 'unit-unsatisfied' );
+		$unsatisfied->shouldReceive( 'is_dependency_satisfied' )->andReturn( false );
+
+		$connectors = $this->make_connectors();
+		$this->seed_available( $connectors, array() );
+		$this->seed_instances(
+			$connectors,
+			array(
+				'unit-stub'        => $active,
+				'unit-admin-only'  => $admin_only,
+				'unit-unsatisfied' => $unsatisfied,
+			)
+		);
+
+		$connectors->load_connectors();
+
+		$this->assertSame( $expected_slugs, $connectors->get_slugs( $include_inactive ) );
+		$this->assertSame( $expected_all, $connectors->get_all( $include_inactive ) );
+	}
+
+	/**
+	 * @return array<string, array{0: bool, 1: string[], 2: array<int, array{slug: string, label: string, contexts: array<string, string>, actions: array<string, string>}>}>
+	 */
+	public static function data_get_slugs_and_get_all() {
+		$stub        = self::connector_payload( 'unit-stub' );
+		$admin_only  = self::connector_payload( 'unit-admin-only' );
+		$unsatisfied = self::connector_payload( 'unit-unsatisfied' );
+
+		return array(
+			'registered_only'  => array(
+				false,
+				array( 'unit-stub' ),
+				array( $stub ),
+			),
+			'include_inactive' => array(
+				true,
+				array( 'unit-stub', 'unit-admin-only', 'unit-unsatisfied' ),
+				array( $stub, $admin_only, $unsatisfied ),
+			),
+		);
+	}
+
+	public function test_unload_and_reload_connectors_toggle_registration() {
+		Functions\when( 'is_admin' )->justReturn( true );
+
+		$connector  = $this->mock_connector();
+		$connectors = $this->make_connectors();
+		$connectors->register_connector_instances( array( 'unit-stub' => $connector ) );
+
+		$this->assertTrue( $connector->is_registered() );
+
+		$connectors->unload_connectors();
+		$this->assertFalse( $connector->is_registered() );
+
+		$connectors->reload_connectors();
+		$this->assertTrue( $connector->is_registered() );
+	}
+
+	public function test_unload_and_reload_named_connector() {
+		Functions\when( 'is_admin' )->justReturn( true );
+
+		$connector  = $this->mock_connector();
+		$other      = $this->mock_connector( 'unit-other' );
+		$connectors = $this->make_connectors();
+		$connectors->register_connector_instances(
+			array(
+				'unit-stub'  => $connector,
+				'unit-other' => $other,
+			)
+		);
+
+		$connectors->unload_connector( 'unit-stub' );
+		$this->assertFalse( $connector->is_registered() );
+		$this->assertTrue( $other->is_registered() );
+
+		$connectors->unload_connector( 'missing' );
+		$this->assertFalse( $connector->is_registered() );
+
+		$connectors->reload_connector( 'unit-stub' );
+		$this->assertTrue( $connector->is_registered() );
+		$this->assertTrue( $other->is_registered() );
+	}
+
+	/**
+	 * Normalized get_all() payload used by data_get_slugs_and_get_all().
+	 *
+	 * @param string $slug Connector slug.
+	 * @return array{slug: string, label: string, contexts: array<string, string>, actions: array<string, string>}
+	 */
+	private static function connector_payload( $slug ) {
+		return array(
+			'slug'     => $slug,
+			'label'    => 'Unit Stub',
+			'contexts' => array( 'unit-ctx' => 'Unit Context' ),
+			'actions'  => array( 'unit-act' => 'Unit Action' ),
+		);
+	}
+
+	/**
+	 * Partial Connector mock with abstract label methods stubbed.
+	 *
+	 * @param string $name Connector slug.
+	 * @return Connector
+	 */
+	private function mock_connector( $name = 'unit-stub' ) {
+		$connector                    = Mockery::mock( Connector::class )->makePartial();
+		$connector->name              = $name;
+		$connector->register_admin    = true;
+		$connector->register_frontend = true;
+		$connector->shouldReceive( 'get_label' )->andReturn( 'Unit Stub' )->byDefault();
+		$connector->shouldReceive( 'get_context_labels' )->andReturn( array( 'unit-ctx' => 'Unit Context' ) )->byDefault();
+		$connector->shouldReceive( 'get_action_labels' )->andReturn( array( 'unit-act' => 'Unit Action' ) )->byDefault();
+
+		return $connector;
+	}
+
+	/**
+	 * Build a Connectors instance without running the production constructor.
+	 *
+	 * @return Connectors
+	 */
+	private function make_connectors() {
+		$plugin            = Mockery::mock();
+		$plugin->locations = array(
+			'dir' => '',
+		);
+		$plugin->admin     = Mockery::mock();
+
+		$connectors         = ( new ReflectionClass( Connectors::class ) )->newInstanceWithoutConstructor();
+		$connectors->plugin = $plugin;
+
+		return $connectors;
+	}
+
+	/**
+	 * Seed the available-class-name cache so load_connectors() does not include files.
+	 *
+	 * @param Connectors $connectors  Connectors instance.
+	 * @param string[]   $class_names Fully-qualified class names.
+	 */
+	private function seed_available( Connectors $connectors, array $class_names ) {
+		$property = new ReflectionProperty( Connectors::class, 'available_connectors' );
+		$property->setAccessible( true );
+		$property->setValue( $connectors, $class_names );
+	}
+
+	/**
+	 * Seed instantiated connectors so load_connectors() does not `new` class names.
+	 *
+	 * @param Connectors               $connectors Connectors instance.
+	 * @param array<string, Connector> $instances  Instances keyed by slug.
+	 */
+	private function seed_instances( Connectors $connectors, array $instances ) {
+		$property = new ReflectionProperty( Connectors::class, 'connector_instances' );
+		$property->setAccessible( true );
+		$property->setValue( $connectors, $instances );
+	}
+}

--- a/tests/phpunit/unit/test-connectors.php
+++ b/tests/phpunit/unit/test-connectors.php
@@ -111,6 +111,19 @@ class Test_Connectors_Unit extends TestCase {
 		$this->assertTrue( $extra->is_registered() );
 	}
 
+	public function test_register_connector_instances_skips_when_register_bails() {
+		Functions\when( 'is_admin' )->justReturn( true );
+
+		$connector = $this->mock_connector( 'unit-bail' );
+		$connector->shouldReceive( 'register' )->once()->andReturnNull();
+
+		$connectors = $this->make_connectors();
+		$connectors->register_connector_instances( array( 'unit-bail' => $connector ) );
+
+		$this->assertArrayNotHasKey( 'unit-bail', $connectors->connectors );
+		$this->assertFalse( $connector->is_registered() );
+	}
+
 	public function test_register_connector_instances_notices_when_register_method_missing() {
 		Functions\when( 'is_admin' )->justReturn( true );
 

--- a/tests/phpunit/unit/test-connectors.php
+++ b/tests/phpunit/unit/test-connectors.php
@@ -130,13 +130,14 @@ class Test_Connectors_Unit extends TestCase {
 		$this->assertArrayNotHasKey( 'unit-no-register', $connectors->connectors );
 	}
 
-	public function test_load_connectors_registers_seeded_instances() {
+	public function test_load_connectors_registers_filter_instances() {
 		Functions\when( 'is_admin' )->justReturn( true );
 
-		$connector  = $this->mock_connector();
+		$connector = $this->mock_connector();
+		Filters\expectApplied( 'wp_stream_connectors' )->andReturn( array( $connector ) );
+
 		$connectors = $this->make_connectors();
 		$this->seed_available( $connectors, array() );
-		$this->seed_instances( $connectors, array( 'unit-stub' => $connector ) );
 
 		$connectors->load_connectors();
 
@@ -178,15 +179,41 @@ class Test_Connectors_Unit extends TestCase {
 
 		$connector = $this->mock_connector( 'unit-unsatisfied' );
 		$connector->shouldReceive( 'is_dependency_satisfied' )->andReturn( false );
+		Filters\expectApplied( 'wp_stream_connectors' )->andReturn( array( $connector ) );
+
 		$connectors = $this->make_connectors();
 		$this->seed_available( $connectors, array() );
-		$this->seed_instances( $connectors, array( 'unit-unsatisfied' => $connector ) );
 
 		$connectors->load_connectors();
 
 		$this->assertArrayNotHasKey( 'unit-unsatisfied', $connectors->connectors );
 		$this->assertFalse( $connector->is_registered() );
 		$this->assertSame( array( 'unit-unsatisfied' ), $connectors->get_slugs( true ) );
+	}
+
+	public function test_load_connectors_second_call_doing_it_wrong_keeps_cache() {
+		Functions\when( 'is_admin' )->justReturn( true );
+		Functions\expect( '_doing_it_wrong' )
+			->once()
+			->with(
+				'WP_Stream\Connectors::load_connectors',
+				Mockery::type( 'string' ),
+				Plugin::VERSION
+			);
+
+		$connector = $this->mock_connector();
+		Filters\expectApplied( 'wp_stream_connectors' )->andReturn( array( $connector ) );
+
+		$connectors = $this->make_connectors();
+		$this->seed_available( $connectors, array() );
+
+		$connectors->load_connectors();
+		$slugs = $connectors->get_slugs( true );
+
+		$connectors->load_connectors();
+
+		$this->assertSame( $slugs, $connectors->get_slugs( true ) );
+		$this->assertSame( $connector, $connectors->connectors['unit-stub'] );
 	}
 
 	/**
@@ -204,17 +231,16 @@ class Test_Connectors_Unit extends TestCase {
 		$admin_only->register_frontend = false;
 		$unsatisfied                   = $this->mock_connector( 'unit-unsatisfied' );
 		$unsatisfied->shouldReceive( 'is_dependency_satisfied' )->andReturn( false );
+		Filters\expectApplied( 'wp_stream_connectors' )->andReturn(
+			array(
+				$active,
+				$admin_only,
+				$unsatisfied,
+			)
+		);
 
 		$connectors = $this->make_connectors();
 		$this->seed_available( $connectors, array() );
-		$this->seed_instances(
-			$connectors,
-			array(
-				'unit-stub'        => $active,
-				'unit-admin-only'  => $admin_only,
-				'unit-unsatisfied' => $unsatisfied,
-			)
-		);
 
 		$connectors->load_connectors();
 
@@ -346,17 +372,5 @@ class Test_Connectors_Unit extends TestCase {
 		$property = new ReflectionProperty( Connectors::class, 'available_connectors' );
 		$property->setAccessible( true );
 		$property->setValue( $connectors, $class_names );
-	}
-
-	/**
-	 * Seed instantiated connectors so load_connectors() does not `new` class names.
-	 *
-	 * @param Connectors               $connectors Connectors instance.
-	 * @param array<string, Connector> $instances  Instances keyed by slug.
-	 */
-	private function seed_instances( Connectors $connectors, array $instances ) {
-		$property = new ReflectionProperty( Connectors::class, 'connector_instances' );
-		$property->setAccessible( true );
-		$property->setValue( $connectors, $instances );
 	}
 }

--- a/tests/phpunit/unit/test-query.php
+++ b/tests/phpunit/unit/test-query.php
@@ -1,0 +1,601 @@
+<?php
+namespace WP_Stream;
+
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+use Mockery;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+
+class Test_Query_Unit extends TestCase {
+	/**
+	 * Args captured from wp_stream_db_query.
+	 *
+	 * @var array|null
+	 */
+	protected static $captured_db_query_args;
+
+	/**
+	 * SQL captured from wp_stream_db_query.
+	 *
+	 * @var string|null
+	 */
+	protected static $captured_db_query_sql;
+
+	/**
+	 * Args captured from wp_stream_db_count_query.
+	 *
+	 * @var array|null
+	 */
+	protected static $captured_db_count_query_args;
+
+	/**
+	 * Query under test.
+	 *
+	 * @var Query
+	 */
+	protected $query;
+
+	protected function set_up() {
+		parent::set_up();
+		self::$captured_db_query_args       = null;
+		self::$captured_db_query_sql        = null;
+		self::$captured_db_count_query_args = null;
+		$this->query                        = Mockery::mock( Query::class )->makePartial();
+
+		$wpdb             = Mockery::mock();
+		$wpdb->stream     = 'wp_stream';
+		$wpdb->streammeta = 'wp_streammeta';
+		$wpdb->shouldReceive( 'prepare' )->andReturnUsing( array( self::class, 'prepare_stub' ) );
+		$this->query->wpdb = $wpdb;
+	}
+
+	/**
+	 * Capture $args from wp_stream_db_query; pass the query through.
+	 *
+	 * @param string $query SQL.
+	 * @param array  $args  Query args.
+	 * @return string
+	 */
+	public static function capture_db_query_filter_args( $query, $args ) {
+		self::$captured_db_query_args = $args;
+		return $query;
+	}
+
+	/**
+	 * Capture SQL from wp_stream_db_query; pass the query through.
+	 *
+	 * @param string $query SQL.
+	 * @param array  $args  Query args.
+	 * @return string
+	 */
+	public static function capture_db_query_sql( $query, $args ) {
+		unset( $args );
+		self::$captured_db_query_sql = $query;
+		return $query;
+	}
+
+	/**
+	 * Capture $args from wp_stream_db_count_query; pass the query through.
+	 *
+	 * @param string $query SQL.
+	 * @param array  $args  Query args.
+	 * @return string
+	 */
+	public static function capture_db_count_query_filter_args( $query, $args ) {
+		self::$captured_db_count_query_args = $args;
+		return $query;
+	}
+
+	/**
+	 * Named prepare stand-in. Quotes strings; leaves ints/floats bare. Not esc_sql.
+	 * Mirrors $wpdb->prepare unpacking a single array of replacements.
+	 *
+	 * @param string $query Query with %d / %s placeholders.
+	 * @param mixed  ...$args Replacement values.
+	 * @return string
+	 */
+	public static function prepare_stub( $query, ...$args ) {
+		if ( isset( $args[0] ) && is_array( $args[0] ) && 1 === count( $args ) ) {
+			$args = $args[0];
+		}
+
+		$escaped = array();
+		foreach ( $args as $arg ) {
+			if ( is_int( $arg ) || is_float( $arg ) ) {
+				$escaped[] = $arg;
+			} else {
+				$escaped[] = "'" . (string) $arg . "'";
+			}
+		}
+
+		$query = str_replace( array( '%d', '%f', '%s' ), '%s', $query );
+
+		return vsprintf( $query, $escaped );
+	}
+
+	/**
+	 * Test the where_columns method with numeric zero and skips empty string.
+	 */
+	public function test_where_columns_emits_numeric_zero_and_skips_empty_string() {
+		$where = $this->query->where_columns(
+			$this->args(
+				array(
+					'user_id'   => 0,
+					'user_role' => '',
+					'connector' => 'posts',
+				)
+			)
+		);
+
+		$this->assertStringContainsString( 'wp_stream.user_id = 0', $where );
+		$this->assertStringContainsString( "wp_stream.connector = 'posts'", $where );
+		$this->assertStringNotContainsString( 'user_role', $where );
+	}
+
+	/**
+	 * Test the where_columns method with search, user_role, connector, context, and action.
+	 */
+	public function test_where_columns_search_sits_between_user_role_and_connector() {
+		$where = $this->query->where_columns(
+			$this->args(
+				array(
+					'user_role' => 'administrator',
+					'search'    => 'hello',
+					'connector' => 'posts',
+					'context'   => 'post',
+					'action'    => 'updated',
+				)
+			)
+		);
+
+		$user_role_pos = strpos( $where, 'user_role' );
+		$search_pos    = strpos( $where, 'LIKE' );
+		$connector_pos = strpos( $where, 'connector' );
+		$context_pos   = strpos( $where, 'context' );
+		$action_pos    = strpos( $where, 'action' );
+
+		$this->assertNotFalse( $user_role_pos );
+		$this->assertNotFalse( $search_pos );
+		$this->assertNotFalse( $connector_pos );
+		$this->assertLessThan( $search_pos, $user_role_pos );
+		$this->assertLessThan( $connector_pos, $search_pos );
+		$this->assertLessThan( $context_pos, $connector_pos );
+		$this->assertLessThan( $action_pos, $context_pos );
+	}
+
+	/**
+	 * Test the where_columns method with disallowed search field.
+	 */
+	public function test_where_columns_rejects_disallowed_search_field() {
+		$where = $this->query->where_columns(
+			$this->args(
+				array(
+					'search'       => 'hello',
+					'search_field' => 'summary; DROP TABLE wp_stream',
+				)
+			)
+		);
+
+		$this->assertSame( '', $where );
+	}
+
+	/**
+	 * Test the where_columns method with search and ip.
+	 */
+	public function test_where_columns_allowlisted_search_and_ip() {
+		Functions\when( 'wp_stream_filter_var' )->justReturn( '127.0.0.1' );
+
+		$where = $this->query->where_columns(
+			$this->args(
+				array(
+					'search'       => 'hello',
+					'search_field' => 'summary',
+					'ip'           => '127.0.0.1',
+				)
+			)
+		);
+
+		$this->assertStringContainsString( "wp_stream.summary LIKE '%hello%'", $where );
+		$this->assertStringContainsString( "wp_stream.ip = '127.0.0.1'", $where );
+	}
+
+	/**
+	 * Test the where_dates method with date.
+	 */
+	public function test_where_dates_expands_date_to_from_and_to() {
+		Functions\when( 'get_gmt_from_date' )->returnArg( 1 );
+
+		$where = $this->query->where_dates(
+			$this->args(
+				array(
+					'date' => '2020-01-01',
+				)
+			)
+		);
+
+		$this->assertStringContainsString( 'DATE(wp_stream.created) >=', $where );
+		$this->assertStringContainsString( 'DATE(wp_stream.created) <=', $where );
+	}
+
+	/**
+	 * Test the query method with date_from, date_to, and date.
+	 */
+	public function test_query_date_alias_leaves_filter_args_unchanged() {
+		Functions\when( 'get_gmt_from_date' )->returnArg( 1 );
+
+		Filters\expectApplied( 'wp_stream_db_query' )
+			->once()
+			->andReturnUsing( array( self::class, 'capture_db_query_filter_args' ) );
+		Filters\expectApplied( 'wp_stream_db_count_query' )
+			->once()
+			->andReturnUsing( array( self::class, 'capture_db_count_query_filter_args' ) );
+
+		$this->query->wpdb->shouldReceive( 'get_results' )->once()->andReturn( array() );
+		$this->query->wpdb->shouldReceive( 'get_var' )->once()->andReturn( 0 );
+
+		$this->query->query(
+			$this->args(
+				array(
+					'date'      => '2020-01-01',
+					'date_from' => '2019-01-01',
+					'date_to'   => '2019-12-31',
+				)
+			)
+		);
+
+		$this->assertSame( '2020-01-01', self::$captured_db_query_args['date'] );
+		$this->assertSame( '2019-01-01', self::$captured_db_query_args['date_from'] );
+		$this->assertSame( '2019-12-31', self::$captured_db_query_args['date_to'] );
+		$this->assertSame( '2020-01-01', self::$captured_db_count_query_args['date'] );
+		$this->assertSame( '2019-01-01', self::$captured_db_count_query_args['date_from'] );
+		$this->assertSame( '2019-12-31', self::$captured_db_count_query_args['date_to'] );
+	}
+
+	/**
+	 * Test the where_dates method with date_after and date_before.
+	 */
+	public function test_where_dates_after_and_before() {
+		Functions\when( 'get_gmt_from_date' )->returnArg( 1 );
+
+		$where = $this->query->where_dates(
+			$this->args(
+				array(
+					'date_after'  => '2020-06-15',
+					'date_before' => '2020-06-16',
+				)
+			)
+		);
+
+		$this->assertStringContainsString( "DATE(wp_stream.created) > '2020-06-15 00:00:00'", $where );
+		$this->assertStringContainsString( "DATE(wp_stream.created) < '2020-06-16 00:00:00'", $where );
+	}
+
+	/**
+	 * Test the where_in method.
+	 *
+	 * @dataProvider data_where_in
+	 *
+	 * @param array  $overrides Args merged into defaults.
+	 * @param string $expected  Expected WHERE fragment.
+	 */
+	public function test_where_in( $overrides, $expected ) {
+		$this->assertSame( $expected, $this->query->where_in( $this->args( $overrides ) ) );
+	}
+
+	/**
+	 * Data provider for test_where_in.
+	 *
+	 * @return array<string, array{0: array, 1: string}>
+	 */
+	public static function data_where_in() {
+		return array(
+			// Empty list: no filter (callers default to array).
+			'empty_array'              => array(
+				array( 'connector__in' => array() ),
+				'',
+			),
+			// Type guard: list table / abilities / DB defaults always pass arrays.
+			'non_array'                => array(
+				array( 'connector__not_in' => 'posts' ),
+				'',
+			),
+			'single_element'           => array(
+				array( 'user_id__in' => array( 1 ) ),
+				' AND wp_stream.user_id IN (1)',
+			),
+			'two_element_in'           => array(
+				array( 'connector__in' => array( 'posts', 'users' ) ),
+				" AND wp_stream.connector IN ('posts','users')",
+			),
+			// record → ID after suffix strip; allowlisted column.
+			'record_in'                => array(
+				array( 'record__in' => array( 1, 2 ) ),
+				' AND wp_stream.ID IN (1,2)',
+			),
+			// __not_in does not also match __in (suffix -4 of __not_in is "t_in").
+			'not_in'                   => array(
+				array( 'connector__not_in' => array( 'posts', 'users' ) ),
+				" AND wp_stream.connector NOT IN ('posts','users')",
+			),
+			'disallowed_field_skipped' => array(
+				array( 'meta_key__in' => array( 'x' ) ),
+				'',
+			),
+		);
+	}
+
+	/**
+	 * Test the select method.
+	 *
+	 * @dataProvider data_select
+	 *
+	 * @param mixed  $fields   Fields arg.
+	 * @param string $expected Expected SELECT list.
+	 */
+	public function test_select( $fields, $expected ) {
+		$this->assertSame(
+			$expected,
+			$this->query->select( $this->args( array( 'fields' => $fields ) ) )
+		);
+	}
+
+	/**
+	 * Data provider for test_select.
+	 *
+	 * @return array<string, array{0: mixed, 1: string}>
+	 */
+	public static function data_select() {
+		return array(
+			'empty_fields'       => array( array(), 'wp_stream.*' ),
+			'scalar_created'     => array( 'created', 'wp_stream.created' ),
+			'allowlist_and_skip' => array(
+				array( 'ID', 'meta', 'ID); DROP TABLE wp_stream' ),
+				'wp_stream.ID',
+			),
+			'all_rejected'       => array( array( 'meta' ), 'wp_stream.*' ),
+			'multiple_valid'     => array(
+				array( 'ID', 'summary' ),
+				'wp_stream.ID, wp_stream.summary',
+			),
+		);
+	}
+
+	/**
+	 * Test the orderby method.
+	 *
+	 * @dataProvider data_orderby
+	 *
+	 * @param array  $overrides Args merged into defaults.
+	 * @param string $expected  Expected ORDER BY clause.
+	 */
+	public function test_orderby( $overrides, $expected ) {
+		$this->assertSame( $expected, $this->query->orderby( $this->args( $overrides ) ) );
+	}
+
+	/**
+	 * Data provider for test_orderby.
+	 *
+	 * @return array<string, array{0: array, 1: string}>
+	 */
+	public static function data_orderby() {
+		return array(
+			'orderby_date_falls_back_to_id' => array(
+				array( 'orderby' => 'date' ),
+				'ORDER BY wp_stream.ID DESC',
+			),
+			'orderby_ip_falls_back_to_id'   => array(
+				array( 'orderby' => 'ip' ),
+				'ORDER BY wp_stream.ID DESC',
+			),
+			'allowlisted_created_asc'       => array(
+				array(
+					'orderby' => 'created',
+					'order'   => 'asc',
+				),
+				'ORDER BY wp_stream.created ASC',
+			),
+			'junk_direction_defaults_desc'  => array(
+				array(
+					'orderby' => 'created',
+					'order'   => 'sideways',
+				),
+				'ORDER BY wp_stream.created DESC',
+			),
+			'meta_value_without_key'        => array(
+				array(
+					'orderby'  => 'meta_value',
+					'meta_key' => '',
+				),
+				'ORDER BY wp_stream.ID DESC',
+			),
+			'meta_value_num_without_key'    => array(
+				array(
+					'orderby'  => 'meta_value_num',
+					'meta_key' => '',
+				),
+				'ORDER BY wp_stream.ID DESC',
+			),
+			'meta_value_num_with_key'       => array(
+				array(
+					'orderby'  => 'meta_value_num',
+					'meta_key' => 'foo',
+				),
+				'ORDER BY CAST(wp_streammeta.meta_value AS SIGNED) DESC',
+			),
+			'meta_value_with_key'           => array(
+				array(
+					'orderby'  => 'meta_value',
+					'meta_key' => 'foo',
+				),
+				'ORDER BY wp_streammeta.meta_value DESC',
+			),
+		);
+	}
+
+	/**
+	 * Test the join method.
+	 *
+	 * @dataProvider data_join
+	 *
+	 * @param array  $overrides Args merged into defaults.
+	 * @param string $expected  Expected JOIN clause.
+	 */
+	public function test_join( $overrides, $expected ) {
+		$this->assertSame( $expected, $this->query->join( $this->args( $overrides ) ) );
+	}
+
+	/**
+	 * Data provider for test_join.
+	 *
+	 * @return array<string, array{0: array, 1: string}>
+	 */
+	public static function data_join() {
+		$meta_join = "LEFT JOIN wp_streammeta ON wp_streammeta.record_id = wp_stream.ID AND wp_streammeta.meta_key = 'foo'";
+
+		return array(
+			'no_meta_orderby'         => array(
+				array( 'orderby' => 'created' ),
+				'',
+			),
+			'meta_value_without_key'  => array(
+				array(
+					'orderby'  => 'meta_value',
+					'meta_key' => '',
+				),
+				'',
+			),
+			'meta_value_with_key'     => array(
+				array(
+					'orderby'  => 'meta_value',
+					'meta_key' => 'foo',
+				),
+				$meta_join,
+			),
+			'meta_value_num_with_key' => array(
+				array(
+					'orderby'  => 'meta_value_num',
+					'meta_key' => 'foo',
+				),
+				$meta_join,
+			),
+		);
+	}
+
+	/**
+	 * Test the query_meta_orderby_includes_join method.
+	 *
+	 * Assembled query includes JOIN and meta ORDER BY together.
+	 */
+	public function test_query_meta_orderby_includes_join() {
+		Filters\expectApplied( 'wp_stream_db_query' )
+			->once()
+			->andReturnUsing( array( self::class, 'capture_db_query_sql' ) );
+		Filters\expectApplied( 'wp_stream_db_count_query' )
+			->once()
+			->andReturnUsing( array( self::class, 'pass_through_count_query' ) );
+
+		$this->query->wpdb->shouldReceive( 'get_results' )->once()->andReturn( array() );
+		$this->query->wpdb->shouldReceive( 'get_var' )->once()->andReturn( 0 );
+
+		$this->query->query(
+			$this->args(
+				array(
+					'orderby'  => 'meta_value',
+					'meta_key' => 'foo',
+				)
+			)
+		);
+
+		$this->assertStringContainsString(
+			"LEFT JOIN wp_streammeta ON wp_streammeta.record_id = wp_stream.ID AND wp_streammeta.meta_key = 'foo'",
+			self::$captured_db_query_sql
+		);
+		$this->assertStringContainsString( 'ORDER BY wp_streammeta.meta_value DESC', self::$captured_db_query_sql );
+	}
+
+	/**
+	 * Pass count query through unchanged.
+	 *
+	 * @param string $query SQL.
+	 * @param array  $args  Query args.
+	 * @return string
+	 */
+	public static function pass_through_count_query( $query, $args ) {
+		unset( $args );
+		return $query;
+	}
+
+	/**
+	 * Test the limits method.
+	 *
+	 * @dataProvider data_limits
+	 *
+	 * @param int    $paged            Page number.
+	 * @param int    $records_per_page Page size.
+	 * @param string $expected         Expected LIMIT clause.
+	 */
+	public function test_limits( $paged, $records_per_page, $expected ) {
+		$this->assertSame(
+			$expected,
+			$this->query->limits(
+				$this->args(
+					array(
+						'paged'            => $paged,
+						'records_per_page' => $records_per_page,
+					)
+				)
+			)
+		);
+	}
+
+	/**
+	 * Data provider for test_limits.
+	 *
+	 * @return array<string, array{0: int, 1: int, 2: string}>
+	 */
+	public static function data_limits() {
+		return array(
+			'page_one'       => array( 1, 20, 'LIMIT 0, 20' ),
+			'page_two'       => array( 2, 10, 'LIMIT 10, 10' ),
+			'zero_page_size' => array( 1, 0, 'LIMIT 0, 0' ),
+			// paged below 1 clamps to page 1 (offset 0).
+			'paged_zero'     => array( 0, 20, 'LIMIT 0, 20' ),
+		);
+	}
+
+	/**
+	 * Minimal args bag so fragment methods do not hit undefined keys.
+	 *
+	 * @param array $overrides Values to merge.
+	 * @return array
+	 */
+	private function args( array $overrides ) {
+		return array_merge(
+			array(
+				'site_id'          => null,
+				'blog_id'          => null,
+				'object_id'        => null,
+				'user_id'          => null,
+				'user_role'        => null,
+				'search'           => null,
+				'search_field'     => 'summary',
+				'connector'        => null,
+				'context'          => null,
+				'action'           => null,
+				'ip'               => null,
+				'date'             => null,
+				'date_from'        => null,
+				'date_to'          => null,
+				'date_after'       => null,
+				'date_before'      => null,
+				'paged'            => 1,
+				'records_per_page' => 20,
+				'order'            => 'desc',
+				'orderby'          => 'date',
+				'fields'           => array(),
+				'meta_key'         => null,
+			),
+			$overrides
+		);
+	}
+}

--- a/tests/phpunit/unit/test-query.php
+++ b/tests/phpunit/unit/test-query.php
@@ -420,14 +420,14 @@ class Test_Query_Unit extends TestCase {
 					'orderby'  => 'meta_value_num',
 					'meta_key' => 'foo',
 				),
-				'ORDER BY CAST(wp_streammeta.meta_value AS SIGNED) DESC',
+				'ORDER BY MAX( CAST(wp_streammeta.meta_value AS SIGNED) ) DESC',
 			),
 			'meta_value_with_key'           => array(
 				array(
 					'orderby'  => 'meta_value',
 					'meta_key' => 'foo',
 				),
-				'ORDER BY wp_streammeta.meta_value DESC',
+				'ORDER BY MAX( wp_streammeta.meta_value ) DESC',
 			),
 		);
 	}
@@ -510,7 +510,12 @@ class Test_Query_Unit extends TestCase {
 			"LEFT JOIN wp_streammeta ON wp_streammeta.record_id = wp_stream.ID AND wp_streammeta.meta_key = 'foo'",
 			self::$captured_db_query_sql
 		);
-		$this->assertStringContainsString( 'ORDER BY wp_streammeta.meta_value DESC', self::$captured_db_query_sql );
+		$this->assertStringContainsString( 'GROUP BY wp_stream.ID', self::$captured_db_query_sql );
+		$this->assertStringContainsString( 'ORDER BY MAX( wp_streammeta.meta_value ) DESC', self::$captured_db_query_sql );
+		$this->assertTrue(
+			strpos( self::$captured_db_query_sql, 'GROUP BY wp_stream.ID' ) < strpos( self::$captured_db_query_sql, 'ORDER BY' ),
+			'GROUP BY must precede ORDER BY'
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes XWPENG-42.

Introduces a fast, host-native PHPUnit unit tier (`composer test-unit`) using Brain Monkey, then refactors `Connectors` and `Query` into testable, named SQL-fragment methods. Along the way, several latent bugs in `Query::where_in()`, pagination, meta ordering, and filter-arg handling are fixed and locked in with data-provider tests.

### Summary

**Host unit suite**
- New `phpunit-unit.xml`, `tests/phpunit/unit/bootstrap.php` (Composer autoload + `WP_Stream\` class autoload mirroring `Plugin::autoload`).
- New `composer test-unit` script; dev dependency `yoast/wp-test-utils` (Brain Monkey).
- Integration configs (`phpunit.xml`, `phpunit-multisite.xml`) exclude `tests/phpunit/unit/` so Docker/integration runs stay unchanged.
- `contributing.md` documents `composer test-unit` (host) and Docker wrapper `npm run test:php-unit`.
- `npm run test` runs `test:php-unit` as a **separate** step before `test:php`; unit tests are **not** merged into the integration PHPUnit config.

**Connectors refactor**
- `Connectors::BUILTIN_CONNECTOR_SLUGS` constant replaces inline slug list.
- Memoized load pipeline: `get_available_connectors()` → `instantiate_connector_classes()` → `register_connector_instances()`.
- `get_slugs( $include_inactive = false )` and `get_all( $include_inactive = false )` replace `get_all_including_admin_only()` / `get_all_slugs_including_admin_only()`.
- Abilities updated: exclusion-rule validation uses `get_slugs( true )`; get-connectors uses `get_all( true )` behind new filter `wp_stream_abilities_connectors`.
- `Connector`: `get_label()`, `get_context_labels()`, `get_action_labels()` promoted to **abstract** (all 22 built-in connectors already implement them).

**Query refactor**
- Monolithic `query()` split into public fragment methods: `where_columns()`, `where_dates()`, `where_in()`, `select()`, `orderby()`, `join()`, `limits()`.
- New `ORDERABLE_FIELDS` constant documents intentional sort behavior.
- Public `$wpdb` property set in constructor (enables partial mocks in unit tests).
- Meta sort: `join()` emits `LEFT JOIN streammeta` when `orderby` is `meta_value` / `meta_value_num` and `meta_key` is set.
- Meta JOIN deduplication: `GROUP BY stream.ID` on the items query; count query uses `COUNT( DISTINCT stream.ID )`.

### Bugs fixed in original `Query` code

| Bug | Before | After |
|-----|--------|-------|
| **`where_in` single-element arrays** | `array_shift()` removed the only value, then `empty( $value )` skipped the clause entirely | All values kept via `array_values()`; one-element `IN (1)` works |
| **`record__in` field mapping** | `str_replace( 'record_', … )` left `_in` suffix → invalid column | Suffix strip + explicit `record` → `ID` mapping |
| **`where_in` prepare() with array arg** | `$wpdb->prepare( …, $field, $value )` passed the whole array as one scalar → empty/wrong SQL | Spread operator `...$values` with per-value `%d`/`%s` placeholders |
| **`__not_in` family** | Separate loop with same `array_shift` / prepare bugs | Unified suffix-based handler for both `__in` and `__not_in` |
| **`paged = 0` pagination** | `absint(0)` → offset `(0-1)*per_page` wrapped to large positive offset (page 2 behavior) | `$page < 1` clamped to `1` → `LIMIT 0, per_page` |
| **Meta orderby without JOIN** | `ORDER BY streammeta.meta_value` with no JOIN (broken SQL) | `join()` adds `LEFT JOIN streammeta` when meta sort + `meta_key` |
| **Meta JOIN duplicate rows** | No dedup on multi-meta rows | `GROUP BY stream.ID` + `COUNT( DISTINCT stream.ID )` |
| **Search clause order** | Regressed during refactor (search after action) | Restored: search sits between `user_role` and `connector` |
| **Filter `$args` date leak** | Passing `date` mutated caller args with `date_from`/`date_to` before filters ran | `where_dates()` expands on a local copy only; filter hooks receive original args |

**Not restored (intentional):** bare `__in` / `__not_in` args no longer map to `ID`; use `record__in` instead.

### Intentional behavior preserved

- `orderby = date` and `orderby = ip` fall back to sorting by `ID`.
- `records_per_page = 0` still emits `LIMIT 0, 0`.
- Connectors with unsatisfied dependencies remain in instances but are not registered.

### Breaking changes

| Change | Risk |
|--------|------|
| Abstract label methods on `Connector` | **Low** — all built-ins implement them; GitHub search found no third-party gaps |
| Old `get_all_including_admin_only()` methods removed | Use `get_all( true )` / `get_slugs( true )` |
| Filter `$args` no longer receive `date_from`/`date_to` when only `date` passed | Intentional fix of pre-refactor leak |

### Testing

**Command:** `composer test-unit` → **OK (53 tests, 106 assertions)**

| File | Coverage highlights |
|------|---------------------|
| `test-connectors.php` | Skip gates, happy path, load/filter, get_slugs/get_all, unload/reload |
| `test-query.php` | All SQL fragments, filter-args immutability, meta JOIN assembly |

**Accepted gaps:** Connectors constructor/include loop; Query __construct, empty search_field fallback, invalid IP, date boundaries.

### Gotchas

- PHPCS ignores on allowlisted column interpolation in loops.
- Meta JOIN + GROUP BY only when meta sort active.
- `composer test-unit` is host fast path; Docker uses `npm run test:php-unit`.
- `contributing.md` references `npm run test-unit` but package.json script is `test:php-unit`.

### Commits

1. **a5dbc77d** — Host unit suite + Connectors pipeline + connector tests
2. **c3c62d49** — Query refactor + unit tests + bug fixes

# Checklist

- [x] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [ ] I have tested the changes in the local development environment (see `contributing.md`).
- [x] I have added phpunit tests.

## Release Changelog

- Fix: `Query::where_in()` silently dropped single-value filters, mis-mapped `record__in`, and produced invalid SQL with array prepare args.
- Fix: `Query` pagination treated `paged = 0` as large positive offset.
- Fix: Meta-value sorting referenced `streammeta` without JOIN; duplicate rows deduplicated via GROUP BY / COUNT(DISTINCT).
- Fix: `date` arg expansion no longer mutates filter-hook `$args`.
- New: Host-native PHPUnit unit suite (`composer test-unit`).
- New: `Connectors::get_slugs()` / `get_all()` with `$include_inactive`.
- New: `wp_stream_abilities_connectors` filter.

## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows semantic versioning. Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release on GitHub.