### PR TITLE
Add Rector 2.6 dev tooling and empty rector.php for PHP 8.2.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "phpcompatibility/php-compatibility": "dev-develop as 9.99.99",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
     "phpunit/phpunit": "^11.3.3",
+    "rector/rector": "^2.6",
     "roots/wordpress": "^6.9",
     "wordpress/mcp-adapter": "^0.5",
     "wp-cli/wp-cli-bundle": "^2.6",
@@ -87,6 +88,12 @@
     ],
     "lint-tests": [
       "phpcs ./tests --standard=./tests/phpcs.xml.dist"
+    ],
+    "lint-rector": [
+      "rector process --dry-run"
+    ],
+    "rector": [
+      "rector process"
     ],
     "format": [
       "phpcbf .",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ccf86efc366801a775693b6a1320fb02",
+    "content-hash": "9144c5a540bec867c45f2dd0ae234e49",
     "packages": [
         {
             "name": "composer/installers",
@@ -2866,6 +2866,70 @@
             "time": "2024-05-20T13:34:27+00:00"
         },
         {
+            "name": "phpstan/phpstan",
+            "version": "2.2.12",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/174b0d88710f00a42598886504dd7a146f91ace5",
+                "reference": "174b0d88710f00a42598886504dd7a146f91ace5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-08-31T19:09:43+00:00"
+        },
+        {
             "name": "phpunit/php-code-coverage",
             "version": "11.0.12",
             "source": {
@@ -3680,6 +3744,63 @@
                 }
             ],
             "time": "2025-08-19T18:57:03+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "2.6.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "f8686605798c755456327a3597201c3b5be76294"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/f8686605798c755456327a3597201c3b5be76294",
+                "reference": "f8686605798c755456327a3597201c3b5be76294",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0",
+                "phpstan/phpstan": "^2.2.10"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "homepage": "https://getrector.com/",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/2.6.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-08-30T22:02:04+00:00"
         },
         {
             "name": "roots/wordpress",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -32,6 +32,7 @@
 
 	<exclude-pattern>*.ruleset</exclude-pattern>
 	<exclude-pattern>*/.ai/*</exclude-pattern>
+	<exclude-pattern>*/artifacts/*</exclude-pattern>
 	<exclude-pattern>*/tests/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>*/build/*</exclude-pattern>

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Rector configuration for the Stream plugin.
+ *
+ * Rules are registered by the XWPENG-47 sub-PR that applies them, so this file
+ * always describes the transformations actually present in the committed source.
+ * Run `composer lint-rector` (dry run) or `composer rector` (apply).
+ *
+ * @package WP_Stream
+ */
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\ValueObject\PhpVersion;
+
+return RectorConfig::configure()
+	->withPaths(
+		array(
+			__DIR__ . '/stream.php',
+			__DIR__ . '/abilities',
+			__DIR__ . '/alerts',
+			__DIR__ . '/classes',
+			__DIR__ . '/connectors',
+			__DIR__ . '/exporters',
+			__DIR__ . '/includes',
+		)
+	)
+	->withSkip(
+		array(
+			__DIR__ . '/.ai',
+			__DIR__ . '/artifacts',
+			__DIR__ . '/build',
+			__DIR__ . '/local',
+			__DIR__ . '/node_modules',
+			__DIR__ . '/tests',
+			__DIR__ . '/vendor',
+			// Per-rule skips are appended by the PR that registers the rule (§3, §4).
+		)
+	)
+	->withPhpVersion( PhpVersion::PHP_82 )
+	->withCache( __DIR__ . '/artifacts/rector' )
+	->withRules( array() );


### PR DESCRIPTION
Fixes XWPENG-47.

Base branch: `ticket/XWPENG-46-php-minimum` (#1978). Config-only PR — first in the XWPENG-47 Rector modernization stack. Adds Rector 2.6 as a dev dependency and an empty `rector.php` scaffold so follow-on stacked PRs (#1982–#1986) can register rules and apply transformations incrementally. No plugin source changes in this PR.

## Summary

- **`composer.json`** — adds `rector/rector` ^2.6 to `require-dev` and on-demand scripts:
  - `composer lint-rector` — `rector process --dry-run`
  - `composer rector` — `rector process`
- **`composer.lock`** — locks Rector 2.6.5 (and its PHPStan dependency).
- **`rector.php`** — PHP 8.2 baseline config with scan paths for plugin source (`stream.php`, `abilities/`, `alerts/`, `classes/`, `connectors/`, `exporters/`, `includes/`), standard skip dirs, cache under `artifacts/rector`, and **no rules registered yet** (`withRules( array() )`). Sub-PRs append rules as they land.
- **`phpcs.xml.dist`** — excludes `artifacts/` so Rector cache is not scanned.

### Stacked follow-on PRs (same ticket)

| PR | Branch | Applies |
|----|--------|---------|
| #1982 | `ticket/XWPENG-47-typed-props-classes` | Typed properties in `classes/` |
| #1983 | `ticket/XWPENG-47-typed-props-connectors` | Connector family typing |
| #1984 | `ticket/XWPENG-47-typed-props-alerts` | Alert/Exporter typing |
| #1985 | `ticket/XWPENG-47-constructor-promotion` | Constructor property promotion |
| #1986 | `ticket/XWPENG-47-match` | `switch` → `match` |

## Test plan

- [x] `composer validate` passes
- [x] CI Lint/Test and E2E pass on PHP 8.2, 8.3, and 8.4 (no runtime behavior change)
- [ ] Reviewer: `composer install && composer lint-rector` exits 0 with no pending diffs
- [ ] Reviewer: confirm `artifacts/rector` is gitignored / PHPCS-excluded

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: N/A — dev tooling only, no user-facing change.
- New: N/A.


## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).


Change `[ ]` to `[x]` to mark the items as done.