### PR TITLE
Apply typed properties in classes/ via Rector.

### DIFF
--- a/classes/class-abilities.php
+++ b/classes/class-abilities.php
@@ -35,17 +35,15 @@ class Abilities {
 
 	/**
 	 * Holds instance of plugin object.
-	 *
-	 * @var Plugin
 	 */
-	public $plugin;
+	public Plugin $plugin;
 
 	/**
 	 * Registered ability objects keyed by namespaced name.
 	 *
 	 * @var array<string, Ability>
 	 */
-	public $abilities = array();
+	public array $abilities = array();
 
 	/**
 	 * Class constructor.

--- a/classes/class-ability.php
+++ b/classes/class-ability.php
@@ -19,10 +19,8 @@ abstract class Ability {
 
 	/**
 	 * Holds instance of plugin object.
-	 *
-	 * @var Plugin
 	 */
-	protected $plugin;
+	protected Plugin $plugin;
 
 	/**
 	 * Class constructor.

--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -85,101 +85,73 @@ class Admin {
 
 	/**
 	 * Holds Network class
-	 *
-	 * @var Network
 	 */
-	public $network;
+	public ?Network $network = null;
 
 	/**
 	 * Holds Live Update class
-	 *
-	 * @var Live_Update
 	 */
-	public $live_update;
+	public ?Live_Update $live_update = null;
 
 	/**
 	 * Holds Export class
-	 *
-	 * @var Export
 	 */
-	public $export;
+	public ?Export $export = null;
 
 	/**
 	 * Menu page screen id
-	 *
-	 * @var string
 	 */
-	public $screen_id = array();
+	public array $screen_id = array();
 
 	/**
 	 * List table object
-	 *
-	 * @var List_Table
 	 */
-	public $list_table = null;
+	public ?List_Table $list_table = null;
 
 	/**
 	 * Option to disable access to Stream
-	 *
-	 * @var bool
 	 */
-	public $disable_access = false;
+	public bool $disable_access = false;
 
 	/**
 	 * Class applied to the body of the admin screen
-	 *
-	 * @var string
 	 */
-	public $admin_body_class = 'wp_stream_screen';
+	public string $admin_body_class = 'wp_stream_screen';
 
 	/**
 	 * Slug of the records page
-	 *
-	 * @var string
 	 */
-	public $records_page_slug = 'wp_stream';
+	public string $records_page_slug = 'wp_stream';
 
 	/**
 	 * Slug of the settings page
-	 *
-	 * @var string
 	 */
-	public $settings_page_slug = 'wp_stream_settings';
+	public string $settings_page_slug = 'wp_stream_settings';
 
 	/**
 	 * Parent page of the records and settings pages
-	 *
-	 * @var string
 	 */
-	public $admin_parent_page = 'admin.php';
+	public string $admin_parent_page = 'admin.php';
 
 	/**
 	 * Capability name for viewing records
-	 *
-	 * @var string
 	 */
-	public $view_cap = 'view_stream';
+	public string $view_cap = 'view_stream';
 
 	/**
 	 * Capability name for managing settings
-	 *
-	 * @var string
 	 */
-	public $settings_cap = WP_STREAM_SETTINGS_CAPABILITY;
+	public string $settings_cap = WP_STREAM_SETTINGS_CAPABILITY;
 
 	/**
 	 * Total amount of authors to pre-load
-	 *
-	 * @var int
 	 */
-	public $preload_users_max = 50;
+	public int $preload_users_max = 50;
 
 	/**
 	 * Admin notices, collected and displayed on proper action
-	 *
-	 * @var array
 	 */
-	public $notices = array();
+	public array $notices = array();
 
 	/**
 	 * Class constructor.

--- a/classes/class-alerts.php
+++ b/classes/class-alerts.php
@@ -48,10 +48,8 @@ class Alerts {
 
 	/**
 	 * Post meta prefix
-	 *
-	 * @var string
 	 */
-	public $meta_prefix = 'wp_stream';
+	public string $meta_prefix = 'wp_stream';
 
 	/**
 	 * Alert Types

--- a/classes/class-connectors.php
+++ b/classes/class-connectors.php
@@ -58,37 +58,31 @@ class Connectors {
 	 *
 	 * @var string[]|null
 	 */
-	private $available_connectors = null;
+	private ?array $available_connectors = null;
 
 	/**
 	 * Instantiated connectors, keyed by slug. Filled once by instantiate_connector_classes().
 	 *
 	 * @var array<string, Connector>|null
 	 */
-	private $connector_instances = null;
+	private ?array $connector_instances = null;
 
 	/**
 	 * Registered connectors.
-	 *
-	 * @var array
 	 */
-	public $connectors = array();
+	public array $connectors = array();
 
 	/**
 	 * Contexts registered to Connectors
-	 *
-	 * @var array
 	 */
-	public $contexts = array();
+	public array $contexts = array();
 
 	/**
 	 * Action taxonomy terms
 	 *
 	 * Holds slug to localized label association
-	 *
-	 * @var array
 	 */
-	public $term_labels = array(
+	public array $term_labels = array(
 		'stream_connector' => array(),
 		'stream_context'   => array(),
 		'stream_action'    => array(),
@@ -96,10 +90,8 @@ class Connectors {
 
 	/**
 	 * Admin notice messages
-	 *
-	 * @var array
 	 */
-	protected $admin_notices = array();
+	protected array $admin_notices = array();
 
 	/**
 	 * Class constructor.

--- a/classes/class-db-driver-wpdb.php
+++ b/classes/class-db-driver-wpdb.php
@@ -13,24 +13,18 @@ namespace WP_Stream;
 class DB_Driver_WPDB implements DB_Driver {
 	/**
 	 * Holds Query class
-	 *
-	 * @var Query
 	 */
-	protected $query;
+	protected Query $query;
 
 	/**
 	 * Hold records table name
-	 *
-	 * @var string
 	 */
-	public $table;
+	public string $table;
 
 	/**
 	 * Hold meta table name
-	 *
-	 * @var string
 	 */
-	public $table_meta;
+	public string $table_meta;
 
 	/**
 	 * Class constructor.

--- a/classes/class-db-driver-wpdb.php
+++ b/classes/class-db-driver-wpdb.php
@@ -160,7 +160,7 @@ class DB_Driver_WPDB implements DB_Driver {
 	 * @param \WP_Stream\Plugin $plugin Instance of the plugin.
 	 * @return \WP_Stream\Install
 	 */
-	public function setup_storage( $plugin ) {
+	public function setup_storage( $plugin ): Install {
 		return new Install( $plugin );
 	}
 

--- a/classes/class-db-driver.php
+++ b/classes/class-db-driver.php
@@ -51,8 +51,10 @@ interface DB_Driver {
 	 * Init storage.
 	 *
 	 * @param \WP_Stream\Plugin $plugin Instance of the plugin.
+	 *
+	 * @return \WP_Stream\Install
 	 */
-	public function setup_storage( $plugin );
+	public function setup_storage( $plugin ): Install;
 
 	/**
 	 * Purge storage.

--- a/classes/class-filter-input.php
+++ b/classes/class-filter-input.php
@@ -14,10 +14,8 @@ class Filter_Input {
 
 	/**
 	 * Callbacks to be used for input validation/sanitation.
-	 *
-	 * @var array
 	 */
-	public static $filter_callbacks = array(
+	public static array $filter_callbacks = array(
 		FILTER_DEFAULT                     => null,
 		// Validate.
 		FILTER_VALIDATE_BOOLEAN            => 'is_bool',

--- a/classes/class-form-generator.php
+++ b/classes/class-form-generator.php
@@ -14,10 +14,8 @@ class Form_Generator {
 
 	/**
 	 * List of all registered fields.
-	 *
-	 * @var array
 	 */
-	public $fields = array();
+	public array $fields = array();
 
 	/**
 	 * Adds a new field to the form.

--- a/classes/class-install.php
+++ b/classes/class-install.php
@@ -20,10 +20,8 @@ class Install {
 
 	/**
 	 * Option key to store database version
-	 *
-	 * @var string
 	 */
-	public $option_key = 'wp_stream_db';
+	public string $option_key = 'wp_stream_db';
 
 	/**
 	 * Holds version of database at last update
@@ -48,10 +46,8 @@ class Install {
 
 	/**
 	 * Holds status of whether it's safe to run Stream or not
-	 *
-	 * @var bool
 	 */
-	public $update_required = false;
+	public bool $update_required = false;
 
 	/**
 	 * Holds status of whether the database update worked

--- a/classes/class-live-update.php
+++ b/classes/class-live-update.php
@@ -20,17 +20,13 @@ class Live_Update {
 
 	/**
 	 * User meta key/identifier
-	 *
-	 * @var string
 	 */
-	public $user_meta_key = 'stream_live_update_records';
+	public string $user_meta_key = 'stream_live_update_records';
 
 	/**
 	 * List table object instance
-	 *
-	 * @var List_Table
 	 */
-	public $list_table = null;
+	public ?List_Table $list_table = null;
 
 	/**
 	 * Class constructor.

--- a/classes/class-network.php
+++ b/classes/class-network.php
@@ -21,17 +21,13 @@ class Network {
 
 	/**
 	 * Network page slug
-	 *
-	 * @var string
 	 */
-	public $network_settings_page_slug = 'wp_stream_network_settings';
+	public string $network_settings_page_slug = 'wp_stream_network_settings';
 
 	/**
 	 * The option name for the network settings.
-	 *
-	 * @var string
 	 */
-	public $network_settings_option = 'wp_stream_network';
+	public string $network_settings_option = 'wp_stream_network';
 
 	/**
 	 * Class constructor

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -53,45 +53,33 @@ class Plugin {
 
 	/**
 	 * Holds and manages WordPress Admin configurations.
-	 *
-	 * @var Admin
 	 */
-	public $admin;
+	public ?Admin $admin = null;
 
 	/**
 	 * Holds and manages alerts.
-	 *
-	 * @var Alerts
 	 */
-	public $alerts;
+	public ?Alerts $alerts = null;
 
 	/**
 	 * Holds and manages alerts lists.
-	 *
-	 * @var Alerts_List
 	 */
-	public $alerts_list;
+	public ?Alerts_List $alerts_list = null;
 
 	/**
 	 * Holds and manages WordPress Abilities API integration.
-	 *
-	 * @var Abilities
 	 */
-	public $abilities;
+	public ?Abilities $abilities = null;
 
 	/**
 	 * Holds and manages connectors
-	 *
-	 * @var Connectors
 	 */
-	public $connectors;
+	public ?Connectors $connectors = null;
 
 	/**
 	 * Holds and manages DB connections.
-	 *
-	 * @var DB
 	 */
-	public $db;
+	public ?DB $db = null;
 
 	/**
 	 * Holds and manages records.
@@ -102,17 +90,13 @@ class Plugin {
 
 	/**
 	 * Stores and manages WordPress settings.
-	 *
-	 * @var Settings
 	 */
-	public $settings;
+	public ?Settings $settings = null;
 
 	/**
 	 * Process DB migrations.
-	 *
-	 * @var Install
 	 */
-	public $install;
+	public ?Install $install = null;
 
 	/**
 	 * Backend used to schedule Stream's deferred work (purge / reset).
@@ -120,10 +104,8 @@ class Plugin {
 	 * Either an {@see AS_Scheduler} (Action Scheduler, default) or a
 	 * {@see Cron_Scheduler} (WP-Cron fallback), selected at construction via
 	 * the `wp_stream_use_action_scheduler` filter.
-	 *
-	 * @var Scheduler
 	 */
-	public $scheduler;
+	public Scheduler $scheduler;
 
 	/**
 	 * Whether the bundled Action Scheduler library was loaded.
@@ -131,17 +113,13 @@ class Plugin {
 	 * Set from a file_exists() check at construction (see __construct), so it
 	 * is reliable on `plugins_loaded` even though AS only declares its as_*()
 	 * API later on `init`.
-	 *
-	 * @var bool
 	 */
-	protected $action_scheduler_available = false;
+	protected bool $action_scheduler_available = false;
 
 	/**
 	 * URLs and Paths used by the plugin
-	 *
-	 * @var array
 	 */
-	public $locations = array();
+	public array $locations = array();
 
 	/**
 	 * IP address for the current request to be associated with the log entry.

--- a/classes/class-query.php
+++ b/classes/class-query.php
@@ -26,10 +26,8 @@ class Query {
 
 	/**
 	 * Hold the number of records found
-	 *
-	 * @var int
 	 */
-	public $found_records = 0;
+	public int $found_records = 0;
 
 	/**
 	 * Database handle. Set from the global $wpdb in the constructor.

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -32,10 +32,8 @@ class Settings {
 
 	/**
 	 * Network settings key/identifier
-	 *
-	 * @var string
 	 */
-	public $network_options_key = 'wp_stream_network';
+	public string $network_options_key = 'wp_stream_network';
 
 	/**
 	 * Plugin settings

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -286,7 +286,12 @@ class Settings {
 			$option_key = $this->network_options_key;
 		}
 
-		return apply_filters( 'wp_stream_settings_option_key', $option_key );
+		$filtered_key = apply_filters( 'wp_stream_settings_option_key', $option_key );
+
+		// Guard against filters returning a non-string: the result is assigned
+		// to the string-typed Settings::$option_key property, where anything but
+		// a string would throw a TypeError (XWPENG-47).
+		return is_string( $filtered_key ) ? $filtered_key : $option_key;
 	}
 
 	/**
@@ -412,9 +417,16 @@ class Settings {
 		/**
 		 * Filter allows for modification of options fields
 		 *
-		 * @return array  Array of option fields
+		 * @param array $fields Option fields.
+		 *
+		 * @return array Array of option fields
 		 */
-		$this->fields = apply_filters( 'wp_stream_settings_option_fields', $fields );
+		$filtered_fields = apply_filters( 'wp_stream_settings_option_fields', $fields );
+
+		// Guard against filters returning a non-array: the value feeds the
+		// Settings::$fields property, which becomes array-typed in XWPENG-47 —
+		// a non-array would throw a TypeError once typed.
+		$this->fields = is_array( $filtered_fields ) ? $filtered_fields : $fields;
 
 		// Sort option fields in each tab by title ASC.
 		foreach ( $this->fields as $tab => $options ) {
@@ -607,21 +619,25 @@ class Settings {
 		$option_key = $this->option_key;
 		$defaults   = $this->get_defaults( $option_key );
 
+		$options = wp_parse_args(
+			is_network_admin() ? (array) get_site_option( $option_key, array() ) : (array) get_option( $option_key, array() ),
+			$defaults
+		);
+
 		/**
 		 * Filter allows for modification of options
 		 *
-		 * @param array
+		 * @param array  $options    Options.
+		 * @param string $option_key Option key.
 		 *
 		 * @return array Updated array of options
 		 */
-		return apply_filters(
-			'wp_stream_settings_options',
-			wp_parse_args(
-				is_network_admin() ? (array) get_site_option( $option_key, array() ) : (array) get_option( $option_key, array() ),
-				$defaults
-			),
-			$option_key
-		);
+		$filtered = apply_filters( 'wp_stream_settings_options', $options, $option_key );
+
+		// Guard against filters returning a non-array: the result is assigned
+		// to the array-typed Settings::$options property, where anything but an
+		// array would throw a TypeError (XWPENG-47).
+		return is_array( $filtered ) ? $filtered : $options;
 	}
 
 	/**

--- a/rector.php
+++ b/rector.php
@@ -12,6 +12,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
 use Rector\ValueObject\PhpVersion;
 
 return RectorConfig::configure()
@@ -35,9 +36,25 @@ return RectorConfig::configure()
 			__DIR__ . '/node_modules',
 			__DIR__ . '/tests',
 			__DIR__ . '/vendor',
-			// Per-rule skips are appended by the PR that registers the rule (§3, §4).
+			TypedPropertyFromAssignsRector::class => array(
+				// Public extension-point bases. Children are typed with the
+				// parent in later PRs (Q7). Directory skips keep this PR inside
+				// classes/ so a first-pass run cannot type a child while its
+				// parent stays untyped (T1.3).
+				__DIR__ . '/classes/class-connector.php',
+				__DIR__ . '/classes/class-alert-type.php',
+				__DIR__ . '/classes/class-alert-trigger.php',
+				__DIR__ . '/classes/class-exporter.php',
+				__DIR__ . '/connectors',
+				__DIR__ . '/alerts',
+				__DIR__ . '/exporters',
+			),
 		)
 	)
 	->withPhpVersion( PhpVersion::PHP_82 )
 	->withCache( __DIR__ . '/artifacts/rector' )
-	->withRules( array() );
+	->withRules( array() )
+	->withConfiguredRule(
+		TypedPropertyFromAssignsRector::class,
+		array( TypedPropertyFromAssignsRector::INLINE_PUBLIC => true )
+	);

--- a/tests/phpunit/unit/Connectors_Unit_Test.php
+++ b/tests/phpunit/unit/Connectors_Unit_Test.php
@@ -331,11 +331,11 @@ class Connectors_Unit_Test extends TestCase {
 	 * @return Connectors
 	 */
 	private function make_connectors() {
-		$plugin            = Mockery::mock();
+		$plugin            = Mockery::mock( Plugin::class );
 		$plugin->locations = array(
 			'dir' => '',
 		);
-		$plugin->admin     = Mockery::mock();
+		$plugin->admin     = Mockery::mock( Admin::class );
 
 		$connectors         = ( new ReflectionClass( Connectors::class ) )->newInstanceWithoutConstructor();
 		$connectors->plugin = $plugin;

--- a/tests/phpunit/unit/bootstrap.php
+++ b/tests/phpunit/unit/bootstrap.php
@@ -33,3 +33,7 @@ function wp_stream_unit_autoload( $class_name ) {
 }
 
 spl_autoload_register( 'wp_stream_unit_autoload' );
+
+if ( ! defined( 'WP_STREAM_SETTINGS_CAPABILITY' ) ) {
+	define( 'WP_STREAM_SETTINGS_CAPABILITY', 'manage_options' );
+}


### PR DESCRIPTION
XWPENG-47 (sub-PR 2 of the typed-properties stack; base: `ticket/XWPENG-47-rector-config`).

Registers Rector `TypedPropertyFromAssignsRector` and applies it to the `classes/` directory, converting untyped properties with `@var` docblocks into native PHP 8.2 typed properties across 15 core classes (`Plugin`, `Admin`, `Settings`, `Connectors`, `Install`, etc.). Nullable types (`?Admin`, `?List_Table`, `?array`) are used where properties default to `null`. Redundant `@var` docblocks are removed where the type is expressed in the property declaration.

`rector.php` configures the rule with `INLINE_PUBLIC => true` and skips extension-point base classes (`Connector`, `Alert_Type`, `Alert_Trigger`, `Exporter`) plus the `connectors/`, `alerts/`, and `exporters/` directories so child classes are typed in later PRs (Q7 / T1.3).

**Follow-up hardening (commit 2):** `Settings` filter return values are guarded with `is_string()` / `is_array()` fallbacks so third-party filters returning unexpected types cannot trigger `TypeError` on the newly typed `$option_key`, `$fields`, and `$options` properties. `DB_Driver::setup_storage()` gains an `: Install` return type on the interface and `DB_Driver_WPDB` implementation.

**Test adjustments:** unit bootstrap defines `WP_STREAM_SETTINGS_CAPABILITY`; `Connectors_Unit_Test` Mockery mocks are typed as `Plugin::class` / `Admin::class` to satisfy typed property assignments.

No runtime behavior changes under normal operation — this is a static-analysis and type-safety improvement only.

### Commits

| Commit | Description |
|--------|-------------|
| `47ed6f88` | Apply typed properties in `classes/` via Rector. |
| `ea122a51` | Harden Settings filter boundaries; add `Install` return type to `DB_Driver::setup_storage()`. |

## Test plan

- [x] CI lint-and-test matrix (PHP 8.2 / 8.3 / 8.4) pass
- [x] CI E2E matrix pass
- [x] `composer lint` pass locally
- [ ] Reviewer: confirm stacked merge order after #1981 lands

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: N/A — internal typing refactor, no user-facing change.
- New: N/A.


## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).


Change `[ ]` to `[x]` to mark the items as done.