### PR TITLE
Type the Connector family with all 22 children.

### DIFF
--- a/classes/class-connector.php
+++ b/classes/class-connector.php
@@ -17,49 +17,40 @@ abstract class Connector {
 	 *
 	 * @var string
 	 */
-	public $name = null;
+	public string $name = '';
 
 	/**
 	 * Actions registered for this connector
-	 *
-	 * @var array
 	 */
-	public $actions = array();
+	public array $actions = array();
 
 	/**
 	 * Store delayed logs
-	 *
-	 * @var array
 	 */
-	public $delayed = array();
+	public array $delayed = array();
 
 	/**
-	 * Previous Stream entry in same request
+	 * Previous Stream entry in same request.
+	 * Nothing in the plugin writes this property.
 	 *
-	 * @var int
+	 * @var int|null
 	 */
-	public $prev_stream = null;
+	public ?int $prev_stream = null;
 
 	/**
 	 * Register connector in the WP Admin
-	 *
-	 * @var bool
 	 */
-	public $register_admin = true;
+	public bool $register_admin = true;
 
 	/**
 	 * Register connector in the WP Frontend
-	 *
-	 * @var bool
 	 */
-	public $register_frontend = true;
+	public bool $register_frontend = true;
 
 	/**
 	 * Holds connector registration status flag.
-	 *
-	 * @var bool
 	 */
-	private $is_registered = false;
+	private bool $is_registered = false;
 
 	/**
 	 * Return translated connector label.

--- a/connectors/class-connector-acf.php
+++ b/connectors/class-connector-acf.php
@@ -13,10 +13,8 @@ namespace WP_Stream;
 class Connector_ACF extends Connector {
 	/**
 	 * Connector slug
-	 *
-	 * @var string
 	 */
-	public $name = 'acf';
+	public string $name = 'acf';
 
 	/**
 	 * Holds tracked plugin minimum version required
@@ -27,10 +25,8 @@ class Connector_ACF extends Connector {
 
 	/**
 	 * Actions registered for this connector
-	 *
-	 * @var array
 	 */
-	public $actions = array(
+	public array $actions = array(
 		'save_post',
 		'post_updated',
 		'added_post_meta',
@@ -47,17 +43,13 @@ class Connector_ACF extends Connector {
 
 	/**
 	 * Cached location rules, used in shutdown callback to verify changes in meta
-	 *
-	 * @var array
 	 */
-	public $cached_location_rules = array();
+	public array $cached_location_rules = array();
 
 	/**
 	 * Cached field values updates, used by shutdown callback to verify actual changes
-	 *
-	 * @var array
 	 */
-	public $cached_field_values_updates = array();
+	public array $cached_field_values_updates = array();
 
 
 	/**

--- a/connectors/class-connector-bbpress.php
+++ b/connectors/class-connector-bbpress.php
@@ -13,10 +13,8 @@ namespace WP_Stream;
 class Connector_BbPress extends Connector {
 	/**
 	 * Connector slug
-	 *
-	 * @var string
 	 */
-	public $name = 'bbpress';
+	public string $name = 'bbpress';
 
 	/**
 	 * Holds tracked plugin minimum version required
@@ -27,49 +25,37 @@ class Connector_BbPress extends Connector {
 
 	/**
 	 * Actions registered for this connector
-	 *
-	 * @var array
 	 */
-	public $actions = array(
+	public array $actions = array(
 		'bbp_toggle_topic_admin',
 	);
 
 	/**
 	 * Tracked option keys
-	 *
-	 * @var array
 	 */
-	public $options = array(
+	public array $options = array(
 		'bbpress' => null,
 	);
 
 	/**
 	 * Flag to stop logging update logic twice
-	 *
-	 * @var bool
 	 */
-	public $is_update = false;
+	public bool $is_update = false;
 
 	/**
 	 * Stores an activity to be deleted for use across multiple callbacks.
-	 *
-	 * @var bool
 	 */
-	public $deleted_activity = false;
+	public bool $deleted_activity = false;
 
 	/**
 	 * Stores post data of an activity to be deleted for use across multiple callbacks.
-	 *
-	 * @var array
 	 */
-	public $delete_activity_args = array();
+	public array $delete_activity_args = array();
 
 	/**
 	 * Flag for ignoring irrelevant activity deletions.
-	 *
-	 * @var bool
 	 */
-	public $ignore_activity_bulk_deletion = false;
+	public bool $ignore_activity_bulk_deletion = false;
 
 	/**
 	 * Check if plugin dependencies are satisfied and add an admin notice if not

--- a/connectors/class-connector-blogs.php
+++ b/connectors/class-connector-blogs.php
@@ -13,17 +13,13 @@ namespace WP_Stream;
 class Connector_Blogs extends Connector {
 	/**
 	 * Connector slug
-	 *
-	 * @var string
 	 */
-	public $name = 'blogs';
+	public string $name = 'blogs';
 
 	/**
 	 * Actions registered for this connector
-	 *
-	 * @var array
 	 */
-	public $actions = array(
+	public array $actions = array(
 		'wp_initialize_site',
 		'wp_delete_site',
 		'wpmu_activate_blog',
@@ -43,10 +39,8 @@ class Connector_Blogs extends Connector {
 
 	/**
 	 * Register connector in the WP Frontend
-	 *
-	 * @var bool
 	 */
-	public $register_frontend = false;
+	public bool $register_frontend = false;
 
 	/**
 	 * Return translated connector label

--- a/connectors/class-connector-buddypress.php
+++ b/connectors/class-connector-buddypress.php
@@ -14,10 +14,8 @@ class Connector_BuddyPress extends Connector {
 
 	/**
 	 * Connector slug
-	 *
-	 * @var string
 	 */
-	public $name = 'buddypress';
+	public string $name = 'buddypress';
 
 	/**
 	 * Holds tracked plugin minimum version required
@@ -28,10 +26,8 @@ class Connector_BuddyPress extends Connector {
 
 	/**
 	 * Actions registered for this connector
-	 *
-	 * @var array
 	 */
-	public $actions = array(
+	public array $actions = array(
 		'update_option',
 		'add_option',
 		'delete_option',
@@ -70,10 +66,8 @@ class Connector_BuddyPress extends Connector {
 
 	/**
 	 * Tracked option keys
-	 *
-	 * @var array
 	 */
-	public $options = array(
+	public array $options = array(
 		'bp-active-components' => null,
 		'bp-pages'             => null,
 		'buddypress'           => null,
@@ -81,10 +75,8 @@ class Connector_BuddyPress extends Connector {
 
 	/**
 	 * Flag to stop logging update logic twice
-	 *
-	 * @var bool
 	 */
-	public $is_update = false;
+	public bool $is_update = false;
 
 	/**
 	 * Stores an activity to be deleted for use across multiple callbacks.
@@ -102,10 +94,8 @@ class Connector_BuddyPress extends Connector {
 
 	/**
 	 * Flag for ignoring irrelevant activity deletions.
-	 *
-	 * @var bool
 	 */
-	public $ignore_activity_bulk_deletion = false;
+	public bool $ignore_activity_bulk_deletion = false;
 
 	/**
 	 * Check if plugin dependencies are satisfied and add an admin notice if not

--- a/connectors/class-connector-comments.php
+++ b/connectors/class-connector-comments.php
@@ -13,17 +13,13 @@ namespace WP_Stream;
 class Connector_Comments extends Connector {
 	/**
 	 * Connector slug
-	 *
-	 * @var string
 	 */
-	public $name = 'comments';
+	public string $name = 'comments';
 
 	/**
 	 * Actions registered for this connector
-	 *
-	 * @var array
 	 */
-	public $actions = array(
+	public array $actions = array(
 		'comment_flood_trigger',
 		'wp_insert_comment',
 		'edit_comment',

--- a/connectors/class-connector-edd.php
+++ b/connectors/class-connector-edd.php
@@ -14,10 +14,8 @@ class Connector_EDD extends Connector {
 
 	/**
 	 * Connector slug
-	 *
-	 * @var string
 	 */
-	public $name = 'edd';
+	public string $name = 'edd';
 
 	/**
 	 * Holds tracked plugin minimum version required
@@ -28,10 +26,8 @@ class Connector_EDD extends Connector {
 
 	/**
 	 * Actions registered for this connector
-	 *
-	 * @var array
 	 */
-	public $actions = array(
+	public array $actions = array(
 		'update_option',
 		'add_option',
 		'delete_option',
@@ -53,40 +49,30 @@ class Connector_EDD extends Connector {
 
 	/**
 	 * Tracked option keys
-	 *
-	 * @var array
 	 */
-	public $options = array();
+	public array $options = array();
 
 	/**
 	 * Tracking registered Settings, with overridden data
-	 *
-	 * @var array
 	 */
-	public $options_override = array();
+	public array $options_override = array();
 
 	/**
 	 * Tracking user meta updates related to this connector
-	 *
-	 * @var array
 	 */
-	public $user_meta = array(
+	public array $user_meta = array(
 		'edd_user_public_key',
 	);
 
 	/**
 	 * Flag status changes to not create duplicate entries
-	 *
-	 * @var bool
 	 */
-	public $is_discount_status_change = false;
+	public bool $is_discount_status_change = false;
 
 	/**
 	 * Flag status changes to not create duplicate entries
-	 *
-	 * @var bool
 	 */
-	public $is_payment_status_change = false;
+	public bool $is_payment_status_change = false;
 
 	/**
 	 * Check if plugin dependencies are satisfied and add an admin notice if not

--- a/connectors/class-connector-editor.php
+++ b/connectors/class-connector-editor.php
@@ -13,17 +13,13 @@ namespace WP_Stream;
 class Connector_Editor extends Connector {
 	/**
 	 * Connector slug
-	 *
-	 * @var string
 	 */
-	public $name = 'editor';
+	public string $name = 'editor';
 
 	/**
 	 * Actions registered for this connector
-	 *
-	 * @var array
 	 */
-	public $actions = array();
+	public array $actions = array();
 
 	/**
 	 * Actions registered for this connector
@@ -34,10 +30,8 @@ class Connector_Editor extends Connector {
 
 	/**
 	 * Register connector in the WP Frontend
-	 *
-	 * @var bool
 	 */
-	public $register_frontend = false;
+	public bool $register_frontend = false;
 
 	/**
 	 * Register all context hooks

--- a/connectors/class-connector-gravityforms.php
+++ b/connectors/class-connector-gravityforms.php
@@ -13,10 +13,8 @@ namespace WP_Stream;
 class Connector_GravityForms extends Connector {
 	/**
 	 * Connector slug
-	 *
-	 * @var string
 	 */
-	public $name = 'gravityforms';
+	public string $name = 'gravityforms';
 
 	/**
 	 * Holds tracked plugin minimum version required
@@ -27,10 +25,8 @@ class Connector_GravityForms extends Connector {
 
 	/**
 	 * Actions registered for this connector
-	 *
-	 * @var array
 	 */
-	public $actions = array(
+	public array $actions = array(
 		'gform_after_save_form',
 		'gform_pre_confirmation_save',
 		'gform_pre_notification_save',
@@ -61,17 +57,13 @@ class Connector_GravityForms extends Connector {
 
 	/**
 	 * Tracked option keys
-	 *
-	 * @var array
 	 */
-	public $options = array();
+	public array $options = array();
 
 	/**
 	 * Tracking registered Settings, with overridden data
-	 *
-	 * @var array
 	 */
-	public $options_override = array();
+	public array $options_override = array();
 
 	/**
 	 * Check if plugin dependencies are satisfied and add an admin notice if not

--- a/connectors/class-connector-installer.php
+++ b/connectors/class-connector-installer.php
@@ -14,17 +14,13 @@ class Connector_Installer extends Connector {
 
 	/**
 	 * Connector slug
-	 *
-	 * @var string
 	 */
-	public $name = 'installer';
+	public string $name = 'installer';
 
 	/**
 	 * Actions registered for this connector
-	 *
-	 * @var array
 	 */
-	public $actions = array(
+	public array $actions = array(
 		'upgrader_process_complete', // plugins::installed | themes::installed.
 		'activate_plugin', // plugins::activated.
 		'deactivate_plugin', // plugins::deactivated.
@@ -37,10 +33,8 @@ class Connector_Installer extends Connector {
 
 	/**
 	 * Register connector in the WP Frontend
-	 *
-	 * @var bool
 	 */
-	public $register_frontend = false;
+	public bool $register_frontend = false;
 
 	/**
 	 * Return translated connector label

--- a/connectors/class-connector-jetpack.php
+++ b/connectors/class-connector-jetpack.php
@@ -13,10 +13,8 @@ namespace WP_Stream;
 class Connector_Jetpack extends Connector {
 	/**
 	 * Connector slug
-	 *
-	 * @var string
 	 */
-	public $name = 'jetpack';
+	public string $name = 'jetpack';
 
 	/**
 	 * Holds tracked plugin minimum version required
@@ -27,10 +25,8 @@ class Connector_Jetpack extends Connector {
 
 	/**
 	 * Actions registered for this connector
-	 *
-	 * @var array
 	 */
-	public $actions = array(
+	public array $actions = array(
 		'jetpack_log_entry',
 		'sharing_get_services_state',
 		'update_option',
@@ -44,24 +40,18 @@ class Connector_Jetpack extends Connector {
 
 	/**
 	 * Register connector in the WP Frontend
-	 *
-	 * @var bool
 	 */
-	public $register_frontend = false;
+	public bool $register_frontend = false;
 
 	/**
 	 * Tracked option keys
-	 *
-	 * @var array
 	 */
-	public $options = array();
+	public array $options = array();
 
 	/**
 	 * Tracking registered Settings, with overridden data
-	 *
-	 * @var array
 	 */
-	public $options_override = array();
+	public array $options_override = array();
 
 	/**
 	 * Check if plugin dependencies are satisfied and add an admin notice if not

--- a/connectors/class-connector-media.php
+++ b/connectors/class-connector-media.php
@@ -13,17 +13,13 @@ namespace WP_Stream;
 class Connector_Media extends Connector {
 	/**
 	 * Connector slug
-	 *
-	 * @var string
 	 */
-	public $name = 'media';
+	public string $name = 'media';
 
 	/**
 	 * Actions registered for this connector
-	 *
-	 * @var array
 	 */
-	public $actions = array(
+	public array $actions = array(
 		'add_attachment',
 		'edit_attachment',
 		'delete_attachment',

--- a/connectors/class-connector-menus.php
+++ b/connectors/class-connector-menus.php
@@ -13,17 +13,13 @@ namespace WP_Stream;
 class Connector_Menus extends Connector {
 	/**
 	 * Connector slug
-	 *
-	 * @var string
 	 */
-	public $name = 'menus';
+	public string $name = 'menus';
 
 	/**
 	 * Actions registered for this connector
-	 *
-	 * @var array
 	 */
-	public $actions = array(
+	public array $actions = array(
 		'wp_create_nav_menu',
 		'wp_update_nav_menu',
 		'delete_nav_menu',
@@ -31,10 +27,8 @@ class Connector_Menus extends Connector {
 
 	/**
 	 * Register connector in the WP Frontend
-	 *
-	 * @var bool
 	 */
-	public $register_frontend = false;
+	public bool $register_frontend = false;
 
 	/**
 	 * Return translated connector label

--- a/connectors/class-connector-mercator.php
+++ b/connectors/class-connector-mercator.php
@@ -13,17 +13,13 @@ namespace WP_Stream;
 class Connector_Mercator extends Connector {
 	/**
 	 * Connector slug
-	 *
-	 * @var string
 	 */
-	public $name = 'mercator';
+	public string $name = 'mercator';
 
 	/**
 	 * Actions registered for this connector
-	 *
-	 * @var array
 	 */
-	public $actions = array(
+	public array $actions = array(
 		'mercator.mapping.updated',
 		'mercator.mapping.deleted',
 		'mercator.mapping.created',
@@ -32,10 +28,8 @@ class Connector_Mercator extends Connector {
 
 	/**
 	 * Register connector in the WP Frontend
-	 *
-	 * @var bool
 	 */
-	public $register_frontend = false;
+	public bool $register_frontend = false;
 
 	/**
 	 * Return translated connector label

--- a/connectors/class-connector-posts.php
+++ b/connectors/class-connector-posts.php
@@ -13,17 +13,13 @@ namespace WP_Stream;
 class Connector_Posts extends Connector {
 	/**
 	 * Connector slug
-	 *
-	 * @var string
 	 */
-	public $name = 'posts';
+	public string $name = 'posts';
 
 	/**
 	 * Actions registered for this connector
-	 *
-	 * @var array
 	 */
-	public $actions = array(
+	public array $actions = array(
 		'transition_post_status',
 		'deleted_post',
 	);

--- a/connectors/class-connector-settings.php
+++ b/connectors/class-connector-settings.php
@@ -20,17 +20,13 @@ class Connector_Settings extends Connector {
 
 	/**
 	 * Connector slug
-	 *
-	 * @var string
 	 */
-	public $name = 'settings';
+	public string $name = 'settings';
 
 	/**
 	 * Actions registered for this connector
-	 *
-	 * @var array
 	 */
-	public $actions = array(
+	public array $actions = array(
 		'allowed_options',
 		'update_option',
 		'update_site_option',
@@ -41,17 +37,13 @@ class Connector_Settings extends Connector {
 
 	/**
 	 * Labels used for WordPress Settings
-	 *
-	 * @var array
 	 */
-	public $labels = array();
+	public array $labels = array();
 
 	/**
 	 * Option names used in options-permalink.php
-	 *
-	 * @var array
 	 */
-	public $permalink_options = array(
+	public array $permalink_options = array(
 		'permalink_structure',
 		'category_base',
 		'tag_base',
@@ -59,10 +51,8 @@ class Connector_Settings extends Connector {
 
 	/**
 	 * Option names used in network/settings.php
-	 *
-	 * @var array
 	 */
-	public $network_options = array(
+	public array $network_options = array(
 		'registrationnotification',
 		'registration',
 		'add_new_users',
@@ -92,10 +82,8 @@ class Connector_Settings extends Connector {
 
 	/**
 	 * Register connector in the WP Frontend
-	 *
-	 * @var bool
 	 */
-	public $register_frontend = false;
+	public bool $register_frontend = false;
 
 	/**
 	 * Register all context hooks

--- a/connectors/class-connector-taxonomies.php
+++ b/connectors/class-connector-taxonomies.php
@@ -13,17 +13,13 @@ namespace WP_Stream;
 class Connector_Taxonomies extends Connector {
 	/**
 	 * Connector slug
-	 *
-	 * @var string
 	 */
-	public $name = 'taxonomies';
+	public string $name = 'taxonomies';
 
 	/**
 	 * Actions registered for this connector
-	 *
-	 * @var array
 	 */
-	public $actions = array(
+	public array $actions = array(
 		'created_term',
 		'delete_term',
 		'edit_term',
@@ -46,10 +42,8 @@ class Connector_Taxonomies extends Connector {
 
 	/**
 	 * Register connector in the WP Frontend
-	 *
-	 * @var bool
 	 */
-	public $register_frontend = false;
+	public bool $register_frontend = false;
 
 	/**
 	 * Return translated connector label

--- a/connectors/class-connector-two-factor.php
+++ b/connectors/class-connector-two-factor.php
@@ -13,17 +13,13 @@ namespace WP_Stream;
 class Connector_Two_Factor extends Connector {
 	/**
 	 * Connector slug
-	 *
-	 * @var string
 	 */
-	public $name = 'twofactor';
+	public string $name = 'twofactor';
 
 	/**
 	 * Actions registered for this connector
-	 *
-	 * @var array
 	 */
-	public $actions = array(
+	public array $actions = array(
 		'update_user_meta', // Before user meta changes.
 		'updated_user_meta', // After user meta changes.
 		'added_user_meta', // After user meta is added.
@@ -34,17 +30,13 @@ class Connector_Two_Factor extends Connector {
 
 	/**
 	 * Tracked option keys
-	 *
-	 * @var array
 	 */
-	public $options = array();
+	public array $options = array();
 
 	/**
 	 * Record the user_meta meta_value before updates.
-	 *
-	 * @var array
 	 */
-	public $user_meta = array();
+	public array $user_meta = array();
 
 	/**
 	 * Check if plugin dependencies are satisfied and add an admin notice if not

--- a/connectors/class-connector-user-switching.php
+++ b/connectors/class-connector-user-switching.php
@@ -14,17 +14,13 @@ class Connector_User_Switching extends Connector {
 
 	/**
 	 * Connector slug
-	 *
-	 * @var string
 	 */
-	public $name = 'userswitching';
+	public string $name = 'userswitching';
 
 	/**
 	 * Actions registered for this connector
-	 *
-	 * @var array
 	 */
-	public $actions = array(
+	public array $actions = array(
 		'wp_stream_after_connectors_registration',
 		'switch_to_user',
 		'switch_back_user',

--- a/connectors/class-connector-users.php
+++ b/connectors/class-connector-users.php
@@ -14,10 +14,8 @@ class Connector_Users extends Connector {
 
 	/**
 	 * Connector slug
-	 *
-	 * @var string
 	 */
-	public $name = 'users';
+	public string $name = 'users';
 
 	/**
 	 * Stores users object before the user being deleted.
@@ -25,13 +23,10 @@ class Connector_Users extends Connector {
 	 * @var WP_User
 	 */
 	protected $_users_object_pre_deleted = array(); // @codingStandardsIgnoreLine
-
 	/**
 	 * Actions registered for this connector
-	 *
-	 * @var array
 	 */
-	public $actions = array(
+	public array $actions = array(
 		'user_register',
 		'profile_update',
 		'password_reset',

--- a/connectors/class-connector-widgets.php
+++ b/connectors/class-connector-widgets.php
@@ -16,24 +16,18 @@ class Connector_Widgets extends Connector {
 	 * Whether or not 'created' and 'deleted' actions should be logged. Normally
 	 * the sidebar 'added' and 'removed' actions will correspond with these.
 	 * See note below with usage.
-	 *
-	 * @var bool
 	 */
-	public $verbose_widget_created_deleted_actions = false;
+	public bool $verbose_widget_created_deleted_actions = false;
 
 	/**
 	 * Connector slug
-	 *
-	 * @var string
 	 */
-	public $name = 'widgets';
+	public string $name = 'widgets';
 
 	/**
 	 * Actions registered for this connector
-	 *
-	 * @var array
 	 */
-	public $actions = array(
+	public array $actions = array(
 		'update_option_sidebars_widgets',
 		'updated_option',
 	);
@@ -42,9 +36,9 @@ class Connector_Widgets extends Connector {
 	 * Store the initial sidebars_widgets option when the customizer does its
 	 * multiple rounds of saving to the sidebars_widgets option.
 	 *
-	 * @var array
+	 * @var array|null
 	 */
-	protected $customizer_initial_sidebars_widgets = null;
+	protected ?array $customizer_initial_sidebars_widgets = null;
 
 	/**
 	 * Return translated connector label

--- a/connectors/class-connector-woocommerce.php
+++ b/connectors/class-connector-woocommerce.php
@@ -13,10 +13,8 @@ namespace WP_Stream;
 class Connector_Woocommerce extends Connector {
 	/**
 	 * Context name
-	 *
-	 * @var string
 	 */
-	public $name = 'woocommerce';
+	public string $name = 'woocommerce';
 
 	/**
 	 * Holds tracked plugin minimum version required
@@ -27,10 +25,8 @@ class Connector_Woocommerce extends Connector {
 
 	/**
 	 * Actions registered for this context
-	 *
-	 * @var array
 	 */
-	public $actions = array(
+	public array $actions = array(
 		'wp_stream_record_array',
 		'updated_option',
 		'transition_post_status',
@@ -46,10 +42,8 @@ class Connector_Woocommerce extends Connector {
 
 	/**
 	 * Taxonomies tracked by this connector.
-	 *
-	 * @var array
 	 */
-	public $taxonomies = array(
+	public array $taxonomies = array(
 		'product_type',
 		'product_cat',
 		'product_tag',
@@ -59,10 +53,8 @@ class Connector_Woocommerce extends Connector {
 
 	/**
 	 * Post-types tracked by this connector.
-	 *
-	 * @var array
 	 */
-	public $post_types = array(
+	public array $post_types = array(
 		'product',
 		'product_variation',
 		'shop_order',
@@ -85,17 +77,15 @@ class Connector_Woocommerce extends Connector {
 
 	/**
 	 * Caches WooCommerce settings.
-	 *
-	 * @var array
 	 */
-	private $settings = array();
+	private array $settings = array();
 
 	/**
 	 * Stores the WooCommerce version number.
 	 *
 	 * @var string|null
 	 */
-	private $plugin_version = null;
+	private ?string $plugin_version = null;
 
 	/**
 	 * Register connection

--- a/connectors/class-connector-wordpress-seo.php
+++ b/connectors/class-connector-wordpress-seo.php
@@ -14,10 +14,8 @@ class Connector_WordPress_SEO extends Connector {
 
 	/**
 	 * Connector slug
-	 *
-	 * @var string
 	 */
-	public $name = 'wordpressseo';
+	public string $name = 'wordpressseo';
 
 	/**
 	 * Holds tracked plugin minimum version required
@@ -28,10 +26,8 @@ class Connector_WordPress_SEO extends Connector {
 
 	/**
 	 * Actions registered for this connector
-	 *
-	 * @var array
 	 */
-	public $actions = array(
+	public array $actions = array(
 		'wpseo_handle_import',
 		'wpseo_import',
 		'seo_page_wpseo_files',
@@ -42,10 +38,8 @@ class Connector_WordPress_SEO extends Connector {
 
 	/**
 	 * Tracking registered Settings, with overridden data
-	 *
-	 * @var array
 	 */
-	public $option_groups = array();
+	public array $option_groups = array();
 
 	/**
 	 * Check if plugin dependencies are satisfied and add an admin notice if not

--- a/rector.php
+++ b/rector.php
@@ -37,15 +37,11 @@ return RectorConfig::configure()
 			__DIR__ . '/tests',
 			__DIR__ . '/vendor',
 			TypedPropertyFromAssignsRector::class => array(
-				// Public extension-point bases. Children are typed with the
-				// parent in later PRs (Q7). Directory skips keep this PR inside
-				// classes/ so a first-pass run cannot type a child while its
-				// parent stays untyped (T1.3).
-				__DIR__ . '/classes/class-connector.php',
+				// Remaining extension-point bases. Alert/exporter families
+				// are typed with their children in PR 3 (Q7).
 				__DIR__ . '/classes/class-alert-type.php',
 				__DIR__ . '/classes/class-alert-trigger.php',
 				__DIR__ . '/classes/class-exporter.php',
-				__DIR__ . '/connectors',
 				__DIR__ . '/alerts',
 				__DIR__ . '/exporters',
 			),

--- a/tests/phpunit/Connector_Test.php
+++ b/tests/phpunit/Connector_Test.php
@@ -18,14 +18,14 @@ class Connector_Test extends WP_StreamTestCase {
 			 *
 			 * @var string
 			 */
-			public $name = 'maintenance';
+			public string $name = 'maintenance';
 
 			/**
 			 * Actions registered for this connector
 			 *
 			 * @var array
 			 */
-			public $actions = array(
+			public array $actions = array(
 				'simulate_fault',
 				'hyphenated-action',
 			);


### PR DESCRIPTION
Part of [XWPENG-47](https://xwpproduct.atlassian.net/browse/XWPENG-47) — typed properties rollout for PHP 8.2+.

Adds native PHP type declarations to the `Connector` abstract base and all 22 built-in connector children so property contracts are enforced at runtime and redundant `@var` docblocks can be removed.

## Approach

- Typed every assignable property on `Connector`: `string $name`, `array $actions` / `$delayed`, `?int $prev_stream`, `bool $register_admin` / `$register_frontend`, and `private bool $is_registered`.
- Normalized `$name` default from `null` to `''` so the `string` type is valid without coercion.
- Applied matching typed declarations across all 22 files in `connectors/` (e.g. `Connector_Settings` also types `$labels`, `$permalink_options`, and `$network_options`).
- Updated the inline test double in `Connector_Test` to use the new typed properties.
- Removed `classes/class-connector.php` and `connectors/` from the Rector skip list now that the family is fully typed; alert and exporter families remain skipped for a follow-up PR.

No behavior changes — this is a static-analysis and type-safety pass only.

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- N/A — internal refactor stacked under XWPENG-47; not targeting `master` directly.


## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).


Change `[ ]` to `[x]` to mark the items as done.

[XWPENG-47]: https://xwp-co.atlassian.net/browse/XWPENG-47?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ