### PR TITLE
Type Alert_Type, Alert_Trigger, and Exporter families.

### DIFF
--- a/alerts/class-alert-trigger-action.php
+++ b/alerts/class-alert-trigger-action.php
@@ -16,24 +16,18 @@ class Alert_Trigger_Action extends Alert_Trigger {
 
 	/**
 	 * Unique identifier
-	 *
-	 * @var string
 	 */
-	public $slug = 'action';
+	public string $slug = 'action';
 
 	/**
 	 * Meta key used in forms.
-	 *
-	 * @var string
 	 */
-	public $meta_key = 'trigger_action';
+	public string $meta_key = 'trigger_action';
 
 	/**
 	 * Field key used in database
-	 *
-	 * @var string
 	 */
-	public $field_key = 'wp_stream_trigger_action';
+	public string $field_key = 'wp_stream_trigger_action';
 
 	/**
 	 * Checks if a record matches the criteria from the trigger.

--- a/alerts/class-alert-trigger-author.php
+++ b/alerts/class-alert-trigger-author.php
@@ -16,17 +16,13 @@ class Alert_Trigger_Author extends Alert_Trigger {
 
 	/**
 	 * Unique identifier
-	 *
-	 * @var string
 	 */
-	public $slug = 'author';
+	public string $slug = 'author';
 
 	/**
 	 * Field key used in database
-	 *
-	 * @var string
 	 */
-	public $field_key = 'wp_stream_trigger_author';
+	public string $field_key = 'wp_stream_trigger_author';
 
 	/**
 	 * Checks if a record matches the criteria from the trigger.

--- a/alerts/class-alert-trigger-context.php
+++ b/alerts/class-alert-trigger-context.php
@@ -16,17 +16,13 @@ class Alert_Trigger_Context extends Alert_Trigger {
 
 	/**
 	 * Unique identifier
-	 *
-	 * @var string
 	 */
-	public $slug = 'context';
+	public string $slug = 'context';
 
 	/**
 	 * Field key used in database
-	 *
-	 * @var string
 	 */
-	public $field_key = 'wp_stream_trigger_context';
+	public string $field_key = 'wp_stream_trigger_context';
 
 	/**
 	 * Checks if a record matches the criteria from the trigger.

--- a/alerts/class-alert-type-die.php
+++ b/alerts/class-alert-type-die.php
@@ -16,17 +16,13 @@ class Alert_Type_Die extends Alert_Type {
 
 	/**
 	 * Alert type name
-	 *
-	 * @var string
 	 */
-	public $name = 'Die Notifier';
+	public string $name = 'Die Notifier';
 
 	/**
 	 * Alert type slug
-	 *
-	 * @var string
 	 */
-	public $slug = 'die';
+	public string $slug = 'die';
 
 	/**
 	 * Triggers a script exit when an alert is triggered. Debugging use only.

--- a/alerts/class-alert-type-email.php
+++ b/alerts/class-alert-type-email.php
@@ -18,17 +18,13 @@ class Alert_Type_Email extends Alert_Type {
 
 	/**
 	 * Alert type name
-	 *
-	 * @var string
 	 */
-	public $name = 'Email';
+	public string $name = 'Email';
 
 	/**
 	 * Alert type slug
-	 *
-	 * @var string
 	 */
-	public $slug = 'email';
+	public string $slug = 'email';
 
 	/**
 	 * Class Constructor

--- a/alerts/class-alert-type-highlight.php
+++ b/alerts/class-alert-type-highlight.php
@@ -33,17 +33,13 @@ class Alert_Type_Highlight extends Alert_Type {
 
 	/**
 	 * Alert type name
-	 *
-	 * @var string
 	 */
-	public $name = 'Highlight';
+	public string $name = 'Highlight';
 
 	/**
 	 * Alert type slug
-	 *
-	 * @var string
 	 */
-	public $slug = 'highlight';
+	public string $slug = 'highlight';
 
 	/**
 	 * The single Alert ID.

--- a/alerts/class-alert-type-ifttt.php
+++ b/alerts/class-alert-type-ifttt.php
@@ -52,17 +52,13 @@ class Alert_Type_IFTTT extends Alert_Type {
 
 	/**
 	 * Alert type name
-	 *
-	 * @var string
 	 */
-	public $name = 'IFTTT';
+	public string $name = 'IFTTT';
 
 	/**
 	 * Alert type slug
-	 *
-	 * @var string
 	 */
-	public $slug = 'ifttt';
+	public string $slug = 'ifttt';
 
 	/**
 	 * Class Constructor

--- a/alerts/class-alert-type-menu-alert.php
+++ b/alerts/class-alert-type-menu-alert.php
@@ -16,17 +16,13 @@ class Alert_Type_Menu_Alert extends Alert_Type {
 
 	/**
 	 * Alert type name
-	 *
-	 * @var string
 	 */
-	public $name = 'Create Menu Alert';
+	public string $name = 'Create Menu Alert';
 
 	/**
 	 * Alert type slug
-	 *
-	 * @var string
 	 */
-	public $slug = 'menu-alert';
+	public string $slug = 'menu-alert';
 
 	/**
 	 * Class Constructor

--- a/alerts/class-alert-type-none.php
+++ b/alerts/class-alert-type-none.php
@@ -15,17 +15,13 @@ namespace WP_Stream;
 class Alert_Type_None extends Alert_Type {
 	/**
 	 * Notifier name
-	 *
-	 * @var string
 	 */
-	public $name = 'Do Nothing';
+	public string $name = 'Do Nothing';
 
 	/**
 	 * Notifier slug
-	 *
-	 * @var string
 	 */
-	public $slug = 'none';
+	public string $slug = 'none';
 
 	/**
 	 * Does not notify user.

--- a/alerts/class-alert-type-slack.php
+++ b/alerts/class-alert-type-slack.php
@@ -16,17 +16,13 @@ class Alert_Type_Slack extends Alert_Type {
 
 	/**
 	 * Alert type name
-	 *
-	 * @var string
 	 */
-	public $name = 'Slack';
+	public string $name = 'Slack';
 
 	/**
 	 * Alert type slug
-	 *
-	 * @var string
 	 */
-	public $slug = 'slack';
+	public string $slug = 'slack';
 
 	/**
 	 * Class Constructor

--- a/classes/class-alert-trigger.php
+++ b/classes/class-alert-trigger.php
@@ -26,7 +26,7 @@ abstract class Alert_Trigger {
 	 *
 	 * @var string
 	 */
-	public $slug;
+	public string $slug = '';
 
 	/**
 	 * Class constructor

--- a/classes/class-alert-type.php
+++ b/classes/class-alert-type.php
@@ -28,7 +28,7 @@ abstract class Alert_Type {
 	 *
 	 * @var string
 	 */
-	public $slug;
+	public string $slug = '';
 
 	/**
 	 * Class constructor.

--- a/classes/class-exporter.php
+++ b/classes/class-exporter.php
@@ -16,14 +16,14 @@ abstract class Exporter {
 	 *
 	 * @var string
 	 */
-	public $name;
+	public string $name = '';
 
 	/**
 	 * Exporter slug
 	 *
 	 * @var string
 	 */
-	public $slug;
+	public string $slug = '';
 
 	/**
 	 * Output formatted data for download

--- a/exporters/class-exporter-csv.php
+++ b/exporters/class-exporter-csv.php
@@ -13,17 +13,13 @@ namespace WP_Stream;
 class Exporter_CSV extends Exporter {
 	/**
 	 * Exporter name
-	 *
-	 * @var string
 	 */
-	public $name = 'CSV';
+	public string $name = 'CSV';
 
 	/**
 	 * Exporter slug
-	 *
-	 * @var string
 	 */
-	public $slug = 'csv';
+	public string $slug = 'csv';
 
 	/**
 	 * Outputs CSV data for download

--- a/exporters/class-exporter-json.php
+++ b/exporters/class-exporter-json.php
@@ -13,17 +13,13 @@ namespace WP_Stream;
 class Exporter_JSON extends Exporter {
 	/**
 	 * Exporter name
-	 *
-	 * @var string
 	 */
-	public $name = 'JSON';
+	public string $name = 'JSON';
 
 	/**
 	 * Exporter slug
-	 *
-	 * @var string
 	 */
-	public $slug = 'json';
+	public string $slug = 'json';
 
 	/**
 	 * Outputs JSON data for download

--- a/rector.php
+++ b/rector.php
@@ -36,15 +36,6 @@ return RectorConfig::configure()
 			__DIR__ . '/node_modules',
 			__DIR__ . '/tests',
 			__DIR__ . '/vendor',
-			TypedPropertyFromAssignsRector::class => array(
-				// Remaining extension-point bases. Alert/exporter families
-				// are typed with their children in PR 3 (Q7).
-				__DIR__ . '/classes/class-alert-type.php',
-				__DIR__ . '/classes/class-alert-trigger.php',
-				__DIR__ . '/classes/class-exporter.php',
-				__DIR__ . '/alerts',
-				__DIR__ . '/exporters',
-			),
 		)
 	)
 	->withPhpVersion( PhpVersion::PHP_82 )


### PR DESCRIPTION
XWPENG-47 (sub-PR 3 of the typed-properties stack; base: `ticket/XWPENG-47-typed-props-connectors`).

Adds native `string` typed properties to the alert and export extension-point families, completing the Rector `TypedPropertyFromAssignsRector` pass for these classes. Abstract bases (`Alert_Type`, `Alert_Trigger`, `Exporter`) declare `$slug` / `$name` as `public string` with empty-string defaults so child classes can override with concrete values. All seven alert types, three alert triggers, and two exporters receive matching typed `$name` / `$slug` (and `$meta_key` / `$field_key` on triggers) properties, with redundant `@var` docblocks removed from the children. `rector.php` drops the skip rules that deferred this work to PR 3.

No runtime behavior changes — this is a static-analysis and type-safety improvement only.

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: N/A — internal typing refactor, no user-facing change.
- New: N/A.


## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).


Change `[ ]` to `[x]` to mark the items as done.