### PR TITLE
Apply constructor property promotion via Rector.

### DIFF
--- a/classes/class-abilities.php
+++ b/classes/class-abilities.php
@@ -34,11 +34,6 @@ class Abilities {
 	const SETTING_NAME = 'enable_abilities_api';
 
 	/**
-	 * Holds instance of plugin object.
-	 */
-	public Plugin $plugin;
-
-	/**
 	 * Registered ability objects keyed by namespaced name.
 	 *
 	 * @var array<string, Ability>
@@ -50,9 +45,7 @@ class Abilities {
 	 *
 	 * @param Plugin $plugin Instance of plugin object.
 	 */
-	public function __construct( Plugin $plugin ) {
-		$this->plugin = $plugin;
-
+	public function __construct( public Plugin $plugin ) {
 		if ( ! $this->is_available() ) {
 			return;
 		}

--- a/classes/class-ability.php
+++ b/classes/class-ability.php
@@ -18,17 +18,11 @@ namespace WP_Stream;
 abstract class Ability {
 
 	/**
-	 * Holds instance of plugin object.
-	 */
-	protected Plugin $plugin;
-
-	/**
 	 * Class constructor.
 	 *
 	 * @param Plugin $plugin Instance of plugin object.
 	 */
-	public function __construct( Plugin $plugin ) {
-		$this->plugin = $plugin;
+	public function __construct( protected Plugin $plugin ) {
 	}
 
 	/**

--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -77,13 +77,6 @@ class Admin {
 	const LARGE_TABLE_CRON_NOTICE_OPTION = 'wp_stream_large_table_cron_notice';
 
 	/**
-	 * Holds Instance of plugin object
-	 *
-	 * @var Plugin
-	 */
-	public $plugin;
-
-	/**
 	 * Holds Network class
 	 */
 	public ?Network $network = null;
@@ -158,9 +151,7 @@ class Admin {
 	 *
 	 * @param Plugin $plugin Instance of plugin object.
 	 */
-	public function __construct( $plugin ) {
-		$this->plugin = $plugin;
-
+	public function __construct( public $plugin ) {
 		add_action( 'init', array( $this, 'init' ) );
 
 		// Ensure function used in various methods is pre-loaded.

--- a/classes/class-alert-trigger.php
+++ b/classes/class-alert-trigger.php
@@ -15,13 +15,6 @@ namespace WP_Stream;
 abstract class Alert_Trigger {
 
 	/**
-	 * Holds instance of plugin object
-	 *
-	 * @var Plugin
-	 */
-	public $plugin;
-
-	/**
 	 * Unique identifier
 	 *
 	 * @var string
@@ -33,9 +26,7 @@ abstract class Alert_Trigger {
 	 *
 	 * @param Plugin $plugin Instance of plugin object.
 	 */
-	public function __construct( $plugin ) {
-		$this->plugin = $plugin;
-
+	public function __construct( public $plugin ) {
 		add_action( 'wp_stream_alert_trigger_form_display', array( $this, 'add_fields' ), 10, 2 );
 		add_action( 'wp_stream_alert_trigger_form_save', array( $this, 'save_fields' ), 10, 1 );
 		add_filter( 'wp_stream_alert_trigger_check', array( $this, 'check_record' ), 10, 4 );

--- a/classes/class-alert-type.php
+++ b/classes/class-alert-type.php
@@ -17,13 +17,6 @@ namespace WP_Stream;
 abstract class Alert_Type {
 
 	/**
-	 * Holds instance of plugin object
-	 *
-	 * @var Plugin
-	 */
-	public $plugin;
-
-	/**
 	 * Unique identifier.
 	 *
 	 * @var string
@@ -35,8 +28,7 @@ abstract class Alert_Type {
 	 *
 	 * @param Plugin $plugin Plugin object.
 	 */
-	public function __construct( $plugin ) {
-		$this->plugin = $plugin;
+	public function __construct( public $plugin ) {
 	}
 
 	/**

--- a/classes/class-alert.php
+++ b/classes/class-alert.php
@@ -57,13 +57,6 @@ class Alert {
 	public $alert_meta;
 
 	/**
-	 * Holds instance of plugin object
-	 *
-	 * @var Plugin
-	 */
-	public $plugin;
-
-	/**
 	 * Class constructor
 	 *
 	 * @param ?object $item   Alert data.
@@ -71,9 +64,7 @@ class Alert {
 	 *
 	 * @return void
 	 */
-	public function __construct( $item, $plugin ) {
-		$this->plugin = $plugin;
-
+	public function __construct( $item, public $plugin ) {
 		$this->ID     = isset( $item->ID ) ? $item->ID : null;
 		$this->status = isset( $item->status ) ? $item->status : 'wp_stream_disabled';
 		$this->date   = isset( $item->date ) ? $item->date : null;

--- a/classes/class-alerts-list.php
+++ b/classes/class-alerts-list.php
@@ -14,20 +14,11 @@ namespace WP_Stream;
  */
 class Alerts_List {
 	/**
-	 * Holds instance of plugin object
-	 *
-	 * @var Plugin
-	 */
-	public $plugin;
-
-	/**
 	 * Class constructor.
 	 *
 	 * @param Plugin $plugin Instance of plugin object.
 	 */
-	public function __construct( $plugin ) {
-		$this->plugin = $plugin;
-
+	public function __construct( public $plugin ) {
 		add_filter( 'bulk_actions-edit-wp_stream_alerts', array( $this, 'suppress_bulk_actions' ), 10, 1 );
 		add_filter( 'disable_months_dropdown', array( $this, 'suppress_months_dropdown' ), 10, 2 );
 		add_filter( 'post_row_actions', array( $this, 'suppress_quick_edit' ), 10, 1 );

--- a/classes/class-alerts.php
+++ b/classes/class-alerts.php
@@ -40,13 +40,6 @@ class Alerts {
 	const CAPABILITY = WP_STREAM_SETTINGS_CAPABILITY;
 
 	/**
-	 * Holds Instance of plugin object
-	 *
-	 * @var Plugin
-	 */
-	public $plugin;
-
-	/**
 	 * Post meta prefix
 	 */
 	public string $meta_prefix = 'wp_stream';
@@ -70,9 +63,7 @@ class Alerts {
 	 *
 	 * @param Plugin $plugin Instance of plugin object.
 	 */
-	public function __construct( $plugin ) {
-		$this->plugin = $plugin;
-
+	public function __construct( public $plugin ) {
 		// Register custom post type.
 		add_action( 'init', array( $this, 'register_post_type' ) );
 

--- a/classes/class-connectors.php
+++ b/classes/class-connectors.php
@@ -45,13 +45,6 @@ class Connectors {
 		'wordpress-seo',
 	);
 
-	/**
-	 * Holds instance of plugin object
-	 *
-	 * @var Plugin
-	 */
-	public $plugin;
-
 
 	/**
 	 * Fully-qualified builtin connector class names after files are included.
@@ -98,8 +91,7 @@ class Connectors {
 	 *
 	 * @param Plugin $plugin Instance of plugin object.
 	 */
-	public function __construct( $plugin ) {
-		$this->plugin = $plugin;
+	public function __construct( public $plugin ) {
 		$this->load_connectors();
 	}
 

--- a/classes/class-db.php
+++ b/classes/class-db.php
@@ -12,13 +12,6 @@ namespace WP_Stream;
  */
 class DB {
 	/**
-	 * Holds the driver instance
-	 *
-	 * @var DB_Driver
-	 */
-	public $driver;
-
-	/**
 	 * Number of records in last request
 	 *
 	 * @var int
@@ -30,8 +23,7 @@ class DB {
 	 *
 	 * @param DB_Driver $driver Driver we want to use.
 	 */
-	public function __construct( $driver ) {
-		$this->driver = $driver;
+	public function __construct( public $driver ) {
 	}
 
 	/**

--- a/classes/class-export.php
+++ b/classes/class-export.php
@@ -12,13 +12,6 @@ namespace WP_Stream;
  */
 class Export {
 	/**
-	 * Holds instance of plugin object
-	 *
-	 * @var Plugin
-	 */
-	public $plugin;
-
-	/**
 	 * Hold registered exporters
 	 *
 	 * @var array
@@ -30,9 +23,7 @@ class Export {
 	 *
 	 * @param Plugin $plugin The plugin object.
 	 */
-	public function __construct( $plugin ) {
-		$this->plugin = $plugin;
-
+	public function __construct( public $plugin ) {
 		if ( 'wp_stream' === wp_stream_filter_input( INPUT_GET, 'page' ) ) {
 			add_action( 'admin_init', array( $this, 'render_download' ) );
 			add_action( 'wp_stream_record_actions_menu', array( $this, 'actions_menu_export_items' ) );

--- a/classes/class-install.php
+++ b/classes/class-install.php
@@ -12,13 +12,6 @@ namespace WP_Stream;
  */
 class Install {
 	/**
-	 * Holds Instance of plugin object
-	 *
-	 * @var Plugin
-	 */
-	public $plugin;
-
-	/**
 	 * Option key to store database version
 	 */
 	public string $option_key = 'wp_stream_db';
@@ -61,9 +54,7 @@ class Install {
 	 *
 	 * @param Plugin $plugin  Instance of plugin object.
 	 */
-	public function __construct( $plugin ) {
-		$this->plugin = $plugin;
-
+	public function __construct( public $plugin ) {
 		$this->db_version = $this->get_db_version();
 		$this->stream_url = self_admin_url( $this->plugin->admin->admin_parent_page . '&page=' . $this->plugin->admin->settings_page_slug );
 

--- a/classes/class-list-table.php
+++ b/classes/class-list-table.php
@@ -13,21 +13,12 @@ namespace WP_Stream;
 class List_Table extends \WP_List_Table {
 
 	/**
-	 * Holds Instance of plugin object
-	 *
-	 * @var Plugin
-	 */
-	public $plugin;
-
-	/**
 	 * Class constructor.
 	 *
 	 * @param Plugin $plugin Instance of plugin object.
 	 * @param array  $args   Argument to filter rows by.
 	 */
-	public function __construct( $plugin, $args = array() ) {
-		$this->plugin = $plugin;
-
+	public function __construct( public $plugin, $args = array() ) {
 		$screen_id = isset( $args['screen'] ) ? $args['screen'] : null;
 
 		/**

--- a/classes/class-live-update.php
+++ b/classes/class-live-update.php
@@ -12,13 +12,6 @@ namespace WP_Stream;
  */
 class Live_Update {
 	/**
-	 * Holds instance of plugin object
-	 *
-	 * @var Plugin
-	 */
-	public $plugin;
-
-	/**
 	 * User meta key/identifier
 	 */
 	public string $user_meta_key = 'stream_live_update_records';
@@ -33,9 +26,7 @@ class Live_Update {
 	 *
 	 * @param Plugin $plugin Instance of plugin object.
 	 */
-	public function __construct( $plugin ) {
-		$this->plugin = $plugin;
-
+	public function __construct( public $plugin ) {
 		// Heartbeat live update.
 		add_filter( 'heartbeat_received', array( $this, 'heartbeat_received' ), 10, 2 );
 

--- a/classes/class-log.php
+++ b/classes/class-log.php
@@ -13,13 +13,6 @@ namespace WP_Stream;
 class Log {
 
 	/**
-	 * Holds Instance of plugin object
-	 *
-	 * @var Plugin
-	 */
-	public $plugin;
-
-	/**
 	 * Previous Stream record ID, used for chaining same-session records
 	 *
 	 * @var int
@@ -31,9 +24,7 @@ class Log {
 	 *
 	 * @param Plugin $plugin Instance of plugin object.
 	 */
-	public function __construct( $plugin ) {
-		$this->plugin = $plugin;
-
+	public function __construct( public $plugin ) {
 		// Ensure function used in various methods is pre-loaded.
 		if ( ! function_exists( 'is_plugin_active_for_network' ) ) {
 			require_once ABSPATH . '/wp-admin/includes/plugin.php';

--- a/classes/class-network.php
+++ b/classes/class-network.php
@@ -13,13 +13,6 @@ namespace WP_Stream;
  */
 class Network {
 	/**
-	 * Holds instance of plugin object
-	 *
-	 * @var Plugin
-	 */
-	public $plugin;
-
-	/**
 	 * Network page slug
 	 */
 	public string $network_settings_page_slug = 'wp_stream_network_settings';
@@ -34,9 +27,7 @@ class Network {
 	 *
 	 * @param Plugin $plugin  Instance of plugin object.
 	 */
-	public function __construct( $plugin ) {
-		$this->plugin = $plugin;
-
+	public function __construct( public $plugin ) {
 		// Always add default site_id/blog_id params when multisite.
 		if ( is_multisite() ) {
 			add_filter( 'wp_stream_query_args', array( $this, 'network_query_args' ) );

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -17,13 +17,6 @@ use WP_User_Query;
 class Settings {
 
 	/**
-	 * Holds instance of plugin object
-	 *
-	 * @var Plugin
-	 */
-	public $plugin;
-
-	/**
 	 * Settings key/identifier
 	 *
 	 * @var string
@@ -54,9 +47,7 @@ class Settings {
 	 *
 	 * @param Plugin $plugin Instance of plugin object.
 	 */
-	public function __construct( $plugin ) {
-		$this->plugin = $plugin;
-
+	public function __construct( public $plugin ) {
 		$this->option_key = $this->get_option_key();
 		$this->options    = $this->get_options();
 

--- a/rector.php
+++ b/rector.php
@@ -12,6 +12,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
 use Rector\ValueObject\PhpVersion;
 
@@ -44,4 +45,8 @@ return RectorConfig::configure()
 	->withConfiguredRule(
 		TypedPropertyFromAssignsRector::class,
 		array( TypedPropertyFromAssignsRector::INLINE_PUBLIC => true )
+	)
+	->withConfiguredRule(
+		ClassPropertyAssignToConstructorPromotionRector::class,
+		array( ClassPropertyAssignToConstructorPromotionRector::RENAME_PROPERTY => false )
 	);


### PR DESCRIPTION
XWPENG-47 (sub-PR 4 of the typed-properties stack; base: `ticket/XWPENG-47-typed-props-alerts`).

Applies PHP 8 constructor property promotion to seventeen core service classes via Rector's `ClassPropertyAssignToConstructorPromotionRector`. Each class that previously declared a property and assigned it in `__construct()` now promotes the parameter directly — for example `public function __construct( public Plugin $plugin )` — removing redundant property declarations and `$this->prop = $prop` boilerplate.

**Classes updated:** `Abilities`, `Ability` (`protected`), `Admin`, `Alert`, `Alerts`, `Alerts_List`, `Alert_Trigger`, `Alert_Type`, `Connectors`, `DB`, `Export`, `Install`, `List_Table`, `Live_Update`, `Log`, `Network`, `Settings`.

`rector.php` registers the promotion rule with `RENAME_PROPERTY => false` so existing property names are preserved.

No runtime behavior changes — this is a readability and modernization refactor only.

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: N/A — internal refactor, no user-facing change.
- New: N/A.


## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).


Change `[ ]` to `[x]` to mark the items as done.