### PR TITLE
Convert two switch statements to match expressions.

### DIFF
--- a/abilities/class-ability-get-alerts.php
+++ b/abilities/class-ability-get-alerts.php
@@ -99,16 +99,11 @@ class Ability_Get_Alerts extends Ability {
 	public function execute( $input = null ) {
 		$requested = isset( $input['status'] ) ? $input['status'] : 'any';
 
-		switch ( $requested ) {
-			case 'enabled':
-				$statuses = array( Alerts::STATUS_ENABLED );
-				break;
-			case 'disabled':
-				$statuses = array( Alerts::STATUS_DISABLED );
-				break;
-			default:
-				$statuses = array( Alerts::STATUS_ENABLED, Alerts::STATUS_DISABLED );
-		}
+		$statuses = match ( $requested ) {
+			'enabled' => array( Alerts::STATUS_ENABLED ),
+			'disabled' => array( Alerts::STATUS_DISABLED ),
+			default => array( Alerts::STATUS_ENABLED, Alerts::STATUS_DISABLED ),
+		};
 
 		$alerts = $this->plugin->alerts->get_alerts( $statuses );
 

--- a/classes/class-list-table.php
+++ b/classes/class-list-table.php
@@ -1167,25 +1167,14 @@ class List_Table extends \WP_List_Table {
 	 * @return string setting name for that column
 	 */
 	public function get_column_excluded_setting_key( $column ) {
-		switch ( $column ) {
-			case 'connector':
-				$output = 'connectors';
-				break;
-			case 'context':
-				$output = 'contexts';
-				break;
-			case 'action':
-				$output = 'action';
-				break;
-			case 'ip':
-				$output = 'ip_addresses';
-				break;
-			case 'user_id':
-				$output = 'users';
-				break;
-			default:
-				$output = false;
-		}
+		$output = match ( $column ) {
+			'connector' => 'connectors',
+			'context' => 'contexts',
+			'action' => 'action',
+			'ip' => 'ip_addresses',
+			'user_id' => 'users',
+			default => false,
+		};
 
 		return $output;
 	}

--- a/rector.php
+++ b/rector.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
 use Rector\ValueObject\PhpVersion;
 
@@ -41,7 +42,7 @@ return RectorConfig::configure()
 	)
 	->withPhpVersion( PhpVersion::PHP_82 )
 	->withCache( __DIR__ . '/artifacts/rector' )
-	->withRules( array() )
+	->withRules( array( ChangeSwitchToMatchRector::class ) )
 	->withConfiguredRule(
 		TypedPropertyFromAssignsRector::class,
 		array( TypedPropertyFromAssignsRector::INLINE_PUBLIC => true )


### PR DESCRIPTION
Fixes XWPENG-47.

Part of the XWPENG-47 Rector modernization stack. This PR targets `ticket/XWPENG-47-constructor-promotion` and converts the two remaining eligible `switch` statements in the Rector scan paths to PHP 8.0 `match` expressions. Behavior is unchanged; the refactor uses expression-style branching that is easier to read and aligns with the PHP 8.2 baseline.

## Summary

- **`Ability_Get_Alerts::execute()`** — maps the `status` input (`enabled`, `disabled`, or default/`any`) to the alert status filter array via `match`.
- **`List_Table::get_column_excluded_setting_key()`** — maps list-table column slugs to their exclusion-setting keys via `match`.
- **`rector.php`** — registers `ChangeSwitchToMatchRector` so `composer lint-rector` reflects the transformations present in this branch.

No new PHPUnit coverage is required: both methods preserve identical return values for every branch.

# Checklist

- [x] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: N/A — no user-facing bug fix in this stacked refactor.
- New: N/A — no new feature in this stacked refactor.


## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).