### PR TITLE
Split List_Table query and column rendering into collaborators.

### DIFF
--- a/classes/class-list-table-column-renderer.php
+++ b/classes/class-list-table-column-renderer.php
@@ -1,0 +1,262 @@
+<?php
+/**
+ * Renders Stream list-table cell HTML for a record column.
+ *
+ * @package WP_Stream
+ */
+
+namespace WP_Stream;
+
+/**
+ * Class - List_Table_Column_Renderer
+ */
+class List_Table_Column_Renderer {
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param Plugin $plugin Plugin instance.
+	 */
+	public function __construct( private Plugin $plugin ) {
+	}
+
+	/**
+	 * Return HTML for a list-table cell.
+	 *
+	 * Callers (List_Table) apply `wp_kses` and echo the result.
+	 *
+	 * @param object|array $item        Record data.
+	 * @param string       $column_name Column name.
+	 * @return string
+	 */
+	public function render( $item, $column_name ) {
+		$out    = '';
+		$record = new Record( $item );
+
+		switch ( $column_name ) {
+			case 'date':
+				$created     = gmdate( 'Y-m-d H:i:s', strtotime( $record->created ) );
+				$date_string = sprintf(
+					'<time datetime="%s" class="relative-time record-created">%s</time>',
+					wp_stream_get_iso_8601_extended_date( strtotime( $record->created ) ),
+					get_date_from_gmt( $created, 'Y/m/d' )
+				);
+				$out         = $this->column_link( $date_string, 'date', get_date_from_gmt( $created, 'Y/m/d' ) );
+				$out        .= '<br />';
+				$out        .= get_date_from_gmt( $created, 'h:i:s A T' );
+				break;
+
+			case 'summary':
+				$out          = $record->summary;
+				$object_title = $record->get_object_title();
+				/* translators: %s: the title of any object, like a Post (e.g. "Hello World") */
+				$view_all_text = $object_title ? sprintf( esc_html__( 'View all activity for "%s"', 'stream' ), esc_attr( $object_title ) ) : esc_html__( 'View all activity for this object', 'stream' );
+
+				if ( $record->object_id ) {
+					$out .= $this->column_link(
+						'<span class="dashicons dashicons-search stream-filter-object-id"></span>',
+						array(
+							'object_id' => $record->object_id,
+							'context'   => $record->context,
+						),
+						null,
+						esc_attr( $view_all_text )
+					);
+				}
+				$out .= $this->get_action_links( $record );
+				break;
+
+			case 'user_id':
+				$user = new Author( (int) $record->user_id, (array) $record->user_meta );
+
+				$filtered_records_url = add_query_arg(
+					array(
+						'page'    => $this->plugin->admin->records_page_slug,
+						'user_id' => absint( $user->id ),
+					),
+					self_admin_url( $this->plugin->admin->admin_parent_page )
+				);
+
+				$out = sprintf(
+					'<a href="%s">%s <span>%s</span></a>%s%s%s',
+					$filtered_records_url,
+					$user->get_avatar_img( 80 ),
+					$user->get_display_name(),
+					$user->is_deleted() ? sprintf( '<br /><small class="deleted">%s</small>', esc_html__( 'Deleted User', 'stream' ) ) : '',
+					sprintf( '<br /><small>%s</small>', $user->get_role() ),
+					sprintf( '<br /><small>%s</small>', $user->get_agent_label( $user->get_agent() ) )
+				);
+				break;
+
+			case 'context':
+				$connector_title = $this->get_term_title( $record->{'connector'}, 'connector' );
+				$context_title   = $this->get_term_title( $record->{'context'}, 'context' );
+
+				$out  = $this->column_link( $connector_title, 'connector', $item->{'connector'} );
+				$out .= '<br />&#8627;&nbsp;';
+				$out .= $this->column_link(
+					$context_title,
+					array(
+						'connector' => $record->{'connector'},
+						'context'   => $record->{'context'},
+					)
+				);
+				break;
+
+			case 'action':
+				$out = $this->column_link( $this->get_term_title( $record->{$column_name}, $column_name ), $column_name, $record->{$column_name} );
+				break;
+
+			case 'blog_id':
+				$blog = ( $record->blog_id && is_multisite() ) ? get_blog_details( $record->blog_id ) : $this->plugin->admin->network->get_network_blog();
+				$out  = $this->column_link( $blog->blogname, 'blog_id', $blog->blog_id );
+				break;
+
+			case 'ip':
+				$out = $this->column_link( $record->{$column_name}, 'ip', $record->{$column_name} );
+				break;
+
+			default:
+				/**
+				 * Registers new Columns to be inserted into the table. The cell contents of this column is set
+				 * below with 'wp_stream_insert_column_default_'
+				 *
+				 * @since      3.5.1
+				 * @deprecated 4.0.1 Use the {@see 'wp_stream_list_table_columns'} filter instead.
+				 *
+				 * @param array $new_columns Columns injected in the table.
+				 *
+				 * @return array
+				 */
+				apply_filters_deprecated(
+					'wp_stream_register_column_defaults',
+					array( array() ),
+					/* translators: %s is the Stream version number. It is part of a filter deprecation notice and is preceded by: "{hook_name} is deprecated since version %s of Stream". */
+					sprintf( __( '%s of Stream', 'stream' ), '4.0.1' ),
+					'wp_stream_list_table_columns',
+					__( 'This filter is being deprecated as it is redundant. You can define custom column names and titles using the `wp_stream_list_table_columns` filter then provide the value for the custom columns using the `wp_stream_insert_column_default_{$column_name}` filter.', 'stream' )
+				);
+
+				/**
+				 * Allows for the addition of content under a specified column.
+				 *
+				 * @param string $out         Column content.
+				 * @param object $record      Record with row content.
+				 * @param string $column_name Column name.
+				 *
+				 * @return string
+				 */
+				$out = (string) apply_filters( "wp_stream_insert_column_default_{$column_name}", $out, $record, $column_name );
+				break;
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Returns the actions links for the provided record. (Eg. Edit, View)
+	 *
+	 * @param Record $record Record.
+	 * @return string
+	 */
+	public function get_action_links( $record ) {
+		$out = '';
+
+		/**
+		 * Filter allows modification of action links for a specific connector
+		 *
+		 * @param array
+		 * @param Record
+		 *
+		 * @return array Action links for this connector
+		 */
+		$action_links = apply_filters( 'wp_stream_action_links_' . $record->connector, array(), $record );
+
+		/**
+		 * Filter allows addition of custom links for a specific connector
+		 *
+		 * @param array
+		 * @param Record
+		 *
+		 * @return array Custom links for this connector
+		 */
+		$custom_links = apply_filters( 'wp_stream_custom_action_links_' . $record->connector, array(), $record );
+
+		if ( $action_links || $custom_links ) {
+			$out .= '<div class="row-actions">';
+		}
+
+		$links = array();
+		if ( $action_links && is_array( $action_links ) ) {
+			foreach ( $action_links as $al_title => $al_href ) {
+				$links[] = sprintf(
+					'<span><a href="%s" class="action-link">%s</a></span>',
+					$al_href,
+					$al_title
+				);
+			}
+		}
+
+		if ( $custom_links && is_array( $custom_links ) ) {
+			foreach ( $custom_links as $key => $link ) {
+				$links[] = $link;
+			}
+		}
+
+		$out .= implode( ' | ', $links );
+
+		if ( $action_links || $custom_links ) {
+			$out .= '</div>';
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Returns a link to be displayed in the table.
+	 *
+	 * @param string       $display Text to be displayed in link.
+	 * @param string|array $key     Query string variable(s).
+	 * @param string       $value   Single query string value.
+	 * @param string       $title   Tooltip value.
+	 * @return string
+	 */
+	public function column_link( $display, $key, $value = null, $title = null ) {
+		$url = add_query_arg(
+			array(
+				'page' => $this->plugin->admin->records_page_slug,
+			),
+			self_admin_url( $this->plugin->admin->admin_parent_page )
+		);
+
+		$args = ! is_array( $key ) ? array(
+			$key => $value,
+		) : $key;
+
+		foreach ( $args as $k => $v ) {
+			$url = add_query_arg( $k, $v, $url );
+		}
+
+		return sprintf(
+			'<a href="%s" title="%s">%s</a>',
+			esc_url( $url ),
+			esc_attr( $title ),
+			$display
+		);
+	}
+
+	/**
+	 * Returns the label for a connector term.
+	 *
+	 * @param string $term Connector label type.
+	 * @param string $type Connector term.
+	 * @return string
+	 */
+	public function get_term_title( $term, $type ) {
+		if ( ! isset( $this->plugin->connectors->term_labels[ 'stream_' . $type ][ $term ] ) ) {
+			return $term;
+		}
+
+		return $this->plugin->connectors->term_labels[ 'stream_' . $type ][ $term ];
+	}
+}

--- a/classes/class-list-table-query-builder.php
+++ b/classes/class-list-table-query-builder.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Builds DB::get_records() argument arrays from list-table filter input.
+ *
+ * @package WP_Stream
+ */
+
+namespace WP_Stream;
+
+/**
+ * Class - List_Table_Query_Builder
+ */
+class List_Table_Query_Builder {
+
+	/**
+	 * Scalar filter params copied when non-empty.
+	 *
+	 * @var array<int, string>
+	 */
+	private const SCALAR_PARAMS = array(
+		'search',
+		'date',
+		'date_from',
+		'date_to',
+		'date_after',
+		'date_before',
+	);
+
+	/**
+	 * Record property filters, including `__in` / `__not_in` variants.
+	 *
+	 * @var array<int, string>
+	 */
+	private const PROPERTY_PARAMS = array(
+		'record',
+		'site_id',
+		'blog_id',
+		'object_id',
+		'user_id',
+		'user_role',
+		'ip',
+		'connector',
+		'context',
+		'action',
+	);
+
+	/**
+	 * Build query args for DB::get_records() from sanitized filter input.
+	 *
+	 * List_Table maps `wp_stream_filter_input` (and pagination) into `$input`.
+	 * This method does not read the request or call the DB.
+	 *
+	 * @param array $input Sanitized request values plus pagination keys
+	 *                     (`paged`, `records_per_page`).
+	 * @return array Arguments for DB::get_records().
+	 */
+	public function build_args( array $input ): array {
+		$args = array();
+
+		if ( ! empty( $input['order'] ) ) {
+			$args['order'] = $input['order'];
+		}
+
+		if ( ! empty( $input['orderby'] ) ) {
+			$args['orderby'] = $input['orderby'];
+		}
+
+		foreach ( self::SCALAR_PARAMS as $param ) {
+			if ( ! empty( $input[ $param ] ) ) {
+				$args[ $param ] = $input[ $param ];
+			}
+		}
+
+		foreach ( self::PROPERTY_PARAMS as $property ) {
+			$this->apply_property_filter( $args, $input, $property );
+		}
+
+		if ( isset( $input['paged'] ) ) {
+			$args['paged'] = $input['paged'];
+		}
+
+		if ( isset( $args['context'] ) && 0 === strpos( (string) $args['context'], 'group-' ) ) {
+			$args['connector'] = str_replace( 'group-', '', $args['context'] );
+			$args['context']   = '';
+		}
+
+		if ( ! isset( $args['records_per_page'] ) ) {
+			$args['records_per_page'] = $input['records_per_page'] ?? 20;
+		}
+
+		$args['records_per_page'] = apply_filters( 'stream_records_per_page', $args['records_per_page'] );
+
+		return $args;
+	}
+
+	/**
+	 * Apply a scalar property and its `__in` / `__not_in` list variants.
+	 *
+	 * @param array  $args     Args bag (by reference).
+	 * @param array  $input    Sanitized input.
+	 * @param string $property Property name.
+	 * @return void
+	 */
+	private function apply_property_filter( array &$args, array $input, string $property ): void {
+		$value = $input[ $property ] ?? null;
+
+		// Allow 0 values.
+		if ( isset( $value ) && '' !== $value && false !== $value ) {
+			$args[ $property ] = $value;
+		}
+
+		$value_in = $input[ $property . '__in' ] ?? null;
+
+		if ( $value_in ) {
+			$args[ $property . '__in' ] = is_array( $value_in ) ? $value_in : explode( ',', $value_in );
+		}
+
+		$value_not_in = $input[ $property . '__not_in' ] ?? null;
+
+		if ( $value_not_in ) {
+			$args[ $property . '__not_in' ] = is_array( $value_not_in )
+				? $value_not_in
+				: explode( ',', $value_not_in );
+		}
+	}
+}

--- a/classes/class-list-table.php
+++ b/classes/class-list-table.php
@@ -13,6 +13,20 @@ namespace WP_Stream;
 class List_Table extends \WP_List_Table {
 
 	/**
+	 * Builds DB::get_records() args from filter input.
+	 *
+	 * @var List_Table_Query_Builder
+	 */
+	private List_Table_Query_Builder $query_builder;
+
+	/**
+	 * Renders record cell HTML.
+	 *
+	 * @var List_Table_Column_Renderer
+	 */
+	private List_Table_Column_Renderer $column_renderer;
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param Plugin $plugin Instance of plugin object.
@@ -35,6 +49,9 @@ class List_Table extends \WP_List_Table {
 				'screen'    => $screen_id,
 			)
 		);
+
+		$this->query_builder   = new List_Table_Query_Builder();
+		$this->column_renderer = new List_Table_Column_Renderer( $this->plugin );
 
 		add_screen_option(
 			'per_page',
@@ -191,6 +208,21 @@ class List_Table extends \WP_List_Table {
 	 * @return array
 	 */
 	public function get_records() {
+		$args                     = $this->collect_filter_input();
+		$args['paged']            = $this->get_pagenum();
+		$args['records_per_page'] = $this->get_items_per_page( 'edit_stream_per_page', 20 );
+
+		$args = $this->query_builder->build_args( $args );
+
+		return $this->plugin->db->get_records( $args );
+	}
+
+	/**
+	 * Map request query vars into a sanitized args bag for the query builder.
+	 *
+	 * @return array
+	 */
+	private function collect_filter_input(): array {
 		$args = array();
 
 		// Parse sorting params.
@@ -247,31 +279,17 @@ class List_Table extends \WP_List_Table {
 			$value_in = wp_stream_filter_input( INPUT_GET, $property . '__in' );
 
 			if ( $value_in ) {
-				$args[ $property . '__in' ] = explode( ',', $value_in );
+				$args[ $property . '__in' ] = $value_in;
 			}
 
 			$value_not_in = wp_stream_filter_input( INPUT_GET, $property . '__not_in' );
 
 			if ( $value_not_in ) {
-				$args[ $property . '__not_in' ] = explode( ',', $value_not_in );
+				$args[ $property . '__not_in' ] = $value_not_in;
 			}
 		}
 
-		$args['paged'] = $this->get_pagenum();
-
-		if ( isset( $args['context'] ) && 0 === strpos( $args['context'], 'group-' ) ) {
-			$args['connector'] = str_replace( 'group-', '', $args['context'] );
-			$args['context']   = '';
-		}
-
-		if ( ! isset( $args['records_per_page'] ) ) {
-			$args['records_per_page'] = $this->get_items_per_page( 'edit_stream_per_page', 20 );
-		}
-		$args['records_per_page'] = apply_filters( 'stream_records_per_page', $args['records_per_page'] );
-
-		$items = $this->plugin->db->get_records( $args );
-
-		return $items;
+		return $args;
 	}
 
 	/**
@@ -291,125 +309,7 @@ class List_Table extends \WP_List_Table {
 	 * @return void
 	 */
 	public function column_default( $item, $column_name ) {
-		$out    = '';
-		$record = new Record( $item );
-
-		switch ( $column_name ) {
-			case 'date':
-				$created     = gmdate( 'Y-m-d H:i:s', strtotime( $record->created ) );
-				$date_string = sprintf(
-					'<time datetime="%s" class="relative-time record-created">%s</time>',
-					wp_stream_get_iso_8601_extended_date( strtotime( $record->created ) ),
-					get_date_from_gmt( $created, 'Y/m/d' )
-				);
-				$out         = $this->column_link( $date_string, 'date', get_date_from_gmt( $created, 'Y/m/d' ) );
-				$out        .= '<br />';
-				$out        .= get_date_from_gmt( $created, 'h:i:s A T' );
-				break;
-
-			case 'summary':
-				$out          = $record->summary;
-				$object_title = $record->get_object_title();
-				/* translators: %s: the title of any object, like a Post (e.g. "Hello World") */
-				$view_all_text = $object_title ? sprintf( esc_html__( 'View all activity for "%s"', 'stream' ), esc_attr( $object_title ) ) : esc_html__( 'View all activity for this object', 'stream' );
-
-				if ( $record->object_id ) {
-					$out .= $this->column_link(
-						'<span class="dashicons dashicons-search stream-filter-object-id"></span>',
-						array(
-							'object_id' => $record->object_id,
-							'context'   => $record->context,
-						),
-						null,
-						esc_attr( $view_all_text )
-					);
-				}
-				$out .= $this->get_action_links( $record );
-				break;
-
-			case 'user_id':
-				$user = new Author( (int) $record->user_id, (array) $record->user_meta );
-
-				$filtered_records_url = add_query_arg(
-					array(
-						'page'    => $this->plugin->admin->records_page_slug,
-						'user_id' => absint( $user->id ),
-					),
-					self_admin_url( $this->plugin->admin->admin_parent_page )
-				);
-
-				$out = sprintf(
-					'<a href="%s">%s <span>%s</span></a>%s%s%s',
-					$filtered_records_url,
-					$user->get_avatar_img( 80 ),
-					$user->get_display_name(),
-					$user->is_deleted() ? sprintf( '<br /><small class="deleted">%s</small>', esc_html__( 'Deleted User', 'stream' ) ) : '',
-					sprintf( '<br /><small>%s</small>', $user->get_role() ),
-					sprintf( '<br /><small>%s</small>', $user->get_agent_label( $user->get_agent() ) )
-				);
-				break;
-
-			case 'context':
-				$connector_title = $this->get_term_title( $record->{'connector'}, 'connector' );
-				$context_title   = $this->get_term_title( $record->{'context'}, 'context' );
-
-				$out  = $this->column_link( $connector_title, 'connector', $item->{'connector'} );
-				$out .= '<br />&#8627;&nbsp;';
-				$out .= $this->column_link(
-					$context_title,
-					array(
-						'connector' => $record->{'connector'},
-						'context'   => $record->{'context'},
-					)
-				);
-				break;
-
-			case 'action':
-				$out = $this->column_link( $this->get_term_title( $record->{$column_name}, $column_name ), $column_name, $record->{$column_name} );
-				break;
-
-			case 'blog_id':
-				$blog = ( $record->blog_id && is_multisite() ) ? get_blog_details( $record->blog_id ) : $this->plugin->admin->network->get_network_blog();
-				$out  = $this->column_link( $blog->blogname, 'blog_id', $blog->blog_id );
-				break;
-
-			case 'ip':
-				$out = $this->column_link( $record->{$column_name}, 'ip', $record->{$column_name} );
-				break;
-
-			default:
-				/**
-				 * Registers new Columns to be inserted into the table. The cell contents of this column is set
-				 * below with 'wp_stream_insert_column_default_'
-				 *
-				 * @since      3.5.1
-				 * @deprecated 4.0.1 Use the {@see 'wp_stream_list_table_columns'} filter instead.
-				 *
-				 * @param array $new_columns Columns injected in the table.
-				 *
-				 * @return array
-				 */
-				apply_filters_deprecated(
-					'wp_stream_register_column_defaults',
-					array( array() ),
-					/* translators: %s is the Stream version number. It is part of a filter deprecation notice and is preceded by: "{hook_name} is deprecated since version %s of Stream". */
-					sprintf( __( '%s of Stream', 'stream' ), '4.0.1' ),
-					'wp_stream_list_table_columns',
-					__( 'This filter is being deprecated as it is redundant. You can define custom column names and titles using the `wp_stream_list_table_columns` filter then provide the value for the custom columns using the `wp_stream_insert_column_default_{$column_name}` filter.', 'stream' )
-				);
-
-				/**
-				 * Allows for the addition of content under a specified column.
-				 *
-				 * @param string $out         Column content.
-				 * @param object $record      Record with row content.
-				 * @param string $column_name Column name.
-				 *
-				 * @return string
-				 */
-				$out = (string) apply_filters( "wp_stream_insert_column_default_{$column_name}", $out, $record, $column_name );
-				break;
-		}
+		$out = $this->column_renderer->render( $item, $column_name );
 
 		$allowed_tags                  = wp_kses_allowed_html( 'post' );
 		$allowed_tags['time']          = array(
@@ -419,113 +319,6 @@ class List_Table extends \WP_List_Table {
 		$allowed_tags['img']['srcset'] = true;
 
 		echo wp_kses( $out, $allowed_tags );
-	}
-
-	/**
-	 * Returns the actions links for the provided record. (Eg. Edit, View)
-	 *
-	 * @param Record $record  Record.
-	 * @return string
-	 */
-	public function get_action_links( $record ) {
-		$out = '';
-
-		/**
-		 * Filter allows modification of action links for a specific connector
-		 *
-		 * @param array
-		 * @param Record
-		 *
-		 * @return array Action links for this connector
-		 */
-		$action_links = apply_filters( 'wp_stream_action_links_' . $record->connector, array(), $record );
-
-		/**
-		 * Filter allows addition of custom links for a specific connector
-		 *
-		 * @param array
-		 * @param Record
-		 *
-		 * @return array Custom links for this connector
-		 */
-		$custom_links = apply_filters( 'wp_stream_custom_action_links_' . $record->connector, array(), $record );
-
-		if ( $action_links || $custom_links ) {
-			$out .= '<div class="row-actions">';
-		}
-
-		$links = array();
-		if ( $action_links && is_array( $action_links ) ) {
-			foreach ( $action_links as $al_title => $al_href ) {
-				$links[] = sprintf(
-					'<span><a href="%s" class="action-link">%s</a></span>',
-					$al_href,
-					$al_title
-				);
-			}
-		}
-
-		if ( $custom_links && is_array( $custom_links ) ) {
-			foreach ( $custom_links as $key => $link ) {
-				$links[] = $link;
-			}
-		}
-
-		$out .= implode( ' | ', $links );
-
-		if ( $action_links || $custom_links ) {
-			$out .= '</div>';
-		}
-
-		return $out;
-	}
-
-	/**
-	 * Returns a link to be display in the table.
-	 *
-	 * @param string       $display  Text to be displayed in link.
-	 * @param string|array $key      Query string variable(s).
-	 * @param string       $value    Single query string value.
-	 * @param string       $title    Tooltip value.
-	 * @return string
-	 */
-	public function column_link( $display, $key, $value = null, $title = null ) {
-		$url = add_query_arg(
-			array(
-				'page' => $this->plugin->admin->records_page_slug,
-			),
-			self_admin_url( $this->plugin->admin->admin_parent_page )
-		);
-
-		$args = ! is_array( $key ) ? array(
-			$key => $value,
-		) : $key;
-
-		foreach ( $args as $k => $v ) {
-			$url = add_query_arg( $k, $v, $url );
-		}
-
-		return sprintf(
-			'<a href="%s" title="%s">%s</a>',
-			esc_url( $url ),
-			esc_attr( $title ),
-			$display
-		);
-	}
-
-	/**
-	 * Returns the label for a connector term.
-	 *
-	 * @param string $term  Connector label type.
-	 * @param string $type  Connector term.
-	 * @return string
-	 */
-	public function get_term_title( $term, $type ) {
-		if ( ! isset( $this->plugin->connectors->term_labels[ 'stream_' . $type ][ $term ] ) ) {
-			return $term;
-		}
-
-		return $this->plugin->connectors->term_labels[ 'stream_' . $type ][ $term ];
 	}
 
 	/**

--- a/tests/phpunit/unit/List_Table_Column_Renderer_Unit_Test.php
+++ b/tests/phpunit/unit/List_Table_Column_Renderer_Unit_Test.php
@@ -1,0 +1,285 @@
+<?php
+namespace WP_Stream;
+
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+use Mockery;
+use PHPUnit\Framework\Attributes\DataProvider;
+use stdClass;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+
+class List_Table_Column_Renderer_Unit_Test extends TestCase {
+	/**
+	 * Renderer under test.
+	 *
+	 * @var List_Table_Column_Renderer
+	 */
+	protected $renderer;
+
+	/**
+	 * Plugin mock with admin + connectors stubs.
+	 *
+	 * @var Plugin
+	 */
+	protected $plugin;
+
+	protected function set_up() {
+		parent::set_up();
+		$this->stubTranslationFunctions();
+		$this->stubEscapeFunctions();
+
+		$this->plugin             = Mockery::mock( Plugin::class );
+		$this->plugin->admin      = Mockery::mock( Admin::class );
+		$this->plugin->connectors = Mockery::mock( Connectors::class );
+
+		$this->plugin->admin->records_page_slug = 'wp_stream';
+		$this->plugin->admin->admin_parent_page = 'admin.php';
+
+		$this->plugin->connectors->term_labels = array(
+			'stream_action'    => array(
+				'updated' => 'Updated',
+			),
+			'stream_connector' => array(
+				'posts' => 'Posts',
+			),
+			'stream_context'   => array(
+				'post' => 'Posts',
+			),
+		);
+
+		Functions\when( 'self_admin_url' )->justReturn( 'http://example.com/wp-admin/admin.php' );
+		Functions\when( 'add_query_arg' )->alias( array( self::class, 'add_query_arg_stub' ) );
+		Functions\when( 'wp_stream_get_iso_8601_extended_date' )->justReturn( '2020-01-15T12:00:00+00:00' );
+		Functions\when( 'get_date_from_gmt' )->alias( array( self::class, 'get_date_from_gmt_stub' ) );
+		Functions\when( 'apply_filters_deprecated' )->justReturn( array() );
+
+		$this->renderer = new List_Table_Column_Renderer( $this->plugin );
+	}
+
+	/**
+	 * Minimal add_query_arg stand-in that appends query keys.
+	 *
+	 * @param mixed ...$args add_query_arg argument list.
+	 * @return string
+	 */
+	public static function add_query_arg_stub( ...$args ) {
+		if ( 1 === count( $args ) && is_array( $args[0] ) ) {
+			return 'http://example.com/wp-admin/admin.php?' . http_build_query( $args[0] );
+		}
+
+		if ( 2 === count( $args ) && is_array( $args[0] ) ) {
+			$url   = (string) $args[1];
+			$query = http_build_query( $args[0] );
+			return false === strpos( $url, '?' ) ? $url . '?' . $query : $url . '&' . $query;
+		}
+
+		if ( 3 === count( $args ) ) {
+			$key   = (string) $args[0];
+			$value = (string) $args[1];
+			$url   = (string) $args[2];
+			$pair  = rawurlencode( $key ) . '=' . rawurlencode( $value );
+			return false === strpos( $url, '?' ) ? $url . '?' . $pair : $url . '&' . $pair;
+		}
+
+		return 'http://example.com/wp-admin/admin.php';
+	}
+
+	/**
+	 * get_date_from_gmt stand-in keyed off the requested format.
+	 *
+	 * @param string $date   GMT date string (unused; fixture is fixed).
+	 * @param string $format PHP date format.
+	 * @return string
+	 */
+	public static function get_date_from_gmt_stub( $date, $format = '' ) {
+		unset( $date );
+
+		if ( 'Y/m/d' === $format ) {
+			return '2020/01/15';
+		}
+
+		if ( 'h:i:s A T' === $format ) {
+			return '12:00:00 PM UTC';
+		}
+
+		return '';
+	}
+
+	/**
+	 * Build a minimal record object for the renderer.
+	 *
+	 * @param array $overrides Property overrides.
+	 * @return stdClass
+	 */
+	private function make_item( array $overrides = array() ) {
+		return (object) array_merge(
+			array(
+				'ID'        => 1,
+				'created'   => '2020-01-15 12:00:00',
+				'site_id'   => 1,
+				'blog_id'   => 1,
+				'object_id' => 0,
+				'user_id'   => 1,
+				'user_role' => 'administrator',
+				'summary'   => 'Updated "Hello World"',
+				'connector' => 'posts',
+				'context'   => 'post',
+				'action'    => 'updated',
+				'ip'        => '127.0.0.1',
+				'meta'      => array(),
+			),
+			$overrides
+		);
+	}
+
+	/**
+	 * Test get_term_title returns label when present and falls back to term.
+	 */
+	public function test_get_term_title_label_and_fallback() {
+		$this->assertSame( 'Updated', $this->renderer->get_term_title( 'updated', 'action' ) );
+		$this->assertSame( 'missing', $this->renderer->get_term_title( 'missing', 'action' ) );
+	}
+
+	/**
+	 * Test column_link builds a filter URL with page and key/value.
+	 */
+	public function test_column_link_builds_filter_url() {
+		$html = $this->renderer->column_link( '127.0.0.1', 'ip', '127.0.0.1', 'Filter by IP' );
+
+		$this->assertStringContainsString( 'page=wp_stream', $html );
+		$this->assertStringContainsString( 'ip=127.0.0.1', $html );
+		$this->assertStringContainsString( 'title="Filter by IP"', $html );
+		$this->assertStringContainsString( '>127.0.0.1</a>', $html );
+	}
+
+	/**
+	 * Test action column returns labeled filter link HTML.
+	 */
+	public function test_render_action_column_returns_labeled_link() {
+		$html = $this->renderer->render( $this->make_item(), 'action' );
+
+		$this->assertStringContainsString( 'Updated', $html );
+		$this->assertStringContainsString( 'action=updated', $html );
+		$this->assertStringContainsString( '<a href=', $html );
+	}
+
+	/**
+	 * Test IP column returns a filter link for the IP value.
+	 */
+	public function test_render_ip_column_returns_filter_link() {
+		$html = $this->renderer->render( $this->make_item(), 'ip' );
+
+		$this->assertStringContainsString( '127.0.0.1', $html );
+		$this->assertStringContainsString( 'ip=127.0.0.1', $html );
+	}
+
+	/**
+	 * Test get_action_links wraps connector action links in row-actions markup.
+	 */
+	public function test_get_action_links_wraps_row_actions() {
+		$record = new Record( $this->make_item() );
+
+		Filters\expectApplied( 'wp_stream_action_links_posts' )
+			->once()
+			->andReturn( array( 'Edit' => 'http://example.com/edit' ) );
+		Filters\expectApplied( 'wp_stream_custom_action_links_posts' )
+			->once()
+			->andReturn( array() );
+
+		$html = $this->renderer->get_action_links( $record );
+
+		$this->assertStringContainsString( 'row-actions', $html );
+		$this->assertStringContainsString( 'action-link', $html );
+		$this->assertStringContainsString( 'Edit', $html );
+		$this->assertStringContainsString( 'http://example.com/edit', $html );
+	}
+
+	/**
+	 * Test summary column with and without an object_id filter link.
+	 *
+	 * @param array $overrides Item property overrides.
+	 * @param bool  $expect_object_filter Whether the object-id dashicon link is expected.
+	 */
+	#[DataProvider( 'data_render_summary_column' )]
+	public function test_render_summary_column( $overrides, $expect_object_filter ) {
+		$html = $this->renderer->render( $this->make_item( $overrides ), 'summary' );
+
+		$this->assertStringContainsString( 'Updated "Hello World"', $html );
+
+		if ( $expect_object_filter ) {
+			$this->assertStringContainsString( 'stream-filter-object-id', $html );
+			$this->assertStringContainsString( 'object_id=42', $html );
+			$this->assertStringContainsString( 'context=post', $html );
+		} else {
+			$this->assertStringNotContainsString( 'stream-filter-object-id', $html );
+		}
+	}
+
+	/**
+	 * Data provider for summary column object_id branches.
+	 *
+	 * @return array<string, array{0: array, 1: bool}>
+	 */
+	public static function data_render_summary_column() {
+		return array(
+			'without_object_id' => array(
+				array(),
+				false,
+			),
+			'with_object_id'    => array(
+				array(
+					'object_id' => 42,
+					'context'   => 'post',
+				),
+				true,
+			),
+		);
+	}
+
+	/**
+	 * Test date column emits time element, filter link, and local time line.
+	 */
+	public function test_render_date_column_outputs_time_and_filter_link() {
+		$html = $this->renderer->render( $this->make_item(), 'date' );
+
+		$this->assertStringContainsString( '<time', $html );
+		$this->assertStringContainsString( 'datetime="2020-01-15T12:00:00+00:00"', $html );
+		$this->assertStringContainsString( 'relative-time record-created', $html );
+		$this->assertTrue(
+			false !== strpos( $html, 'date=2020/01/15' ) || false !== strpos( $html, 'date=2020%2F01%2F15' ),
+			'Date filter URL should include date=2020/01/15 (raw or encoded)'
+		);
+		$this->assertStringContainsString( '<br />', $html );
+		$this->assertStringContainsString( '12:00:00 PM UTC', $html );
+	}
+
+	/**
+	 * Test context column nests connector and context filter links.
+	 */
+	public function test_render_context_column_nests_connector_and_context_links() {
+		$html = $this->renderer->render( $this->make_item(), 'context' );
+
+		$this->assertStringContainsString( 'Posts', $html );
+		$this->assertStringContainsString( 'connector=posts', $html );
+		$this->assertStringContainsString( 'context=post', $html );
+		$this->assertTrue(
+			false !== strpos( $html, '&#8627;' ) || false !== strpos( $html, '↳' ),
+			'Context column should include the nested arrow marker'
+		);
+	}
+
+	/**
+	 * Test default column applies the insert-column filter for custom columns.
+	 */
+	public function test_render_default_column_applies_insert_filter() {
+		$custom = '<span class="custom">x</span>';
+
+		Filters\expectApplied( 'wp_stream_insert_column_default_custom_col' )
+			->once()
+			->andReturn( $custom );
+
+		$html = $this->renderer->render( $this->make_item(), 'custom_col' );
+
+		$this->assertSame( $custom, $html );
+	}
+}

--- a/tests/phpunit/unit/List_Table_Query_Builder_Unit_Test.php
+++ b/tests/phpunit/unit/List_Table_Query_Builder_Unit_Test.php
@@ -1,0 +1,221 @@
+<?php
+namespace WP_Stream;
+
+use Brain\Monkey\Filters;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+
+class List_Table_Query_Builder_Unit_Test extends TestCase {
+	/**
+	 * Builder under test.
+	 *
+	 * @var List_Table_Query_Builder
+	 */
+	protected $builder;
+
+	protected function set_up() {
+		parent::set_up();
+		$this->builder = new List_Table_Query_Builder();
+	}
+
+	/**
+	 * Test order, orderby, search, and date scalar passthrough.
+	 */
+	public function test_build_args_passes_order_search_and_dates() {
+		$args = $this->builder->build_args(
+			array(
+				'order'            => 'asc',
+				'orderby'          => 'created',
+				'search'           => 'hello',
+				'date'             => '2020-01-01',
+				'date_from'        => '2019-01-01',
+				'date_to'          => '2019-12-31',
+				'date_after'       => '2020-06-15',
+				'date_before'      => '2020-06-16',
+				'paged'            => 2,
+				'records_per_page' => 10,
+			)
+		);
+
+		$this->assertSame( 'asc', $args['order'] );
+		$this->assertSame( 'created', $args['orderby'] );
+		$this->assertSame( 'hello', $args['search'] );
+		$this->assertSame( '2020-01-01', $args['date'] );
+		$this->assertSame( '2019-01-01', $args['date_from'] );
+		$this->assertSame( '2019-12-31', $args['date_to'] );
+		$this->assertSame( '2020-06-15', $args['date_after'] );
+		$this->assertSame( '2020-06-16', $args['date_before'] );
+		$this->assertSame( 2, $args['paged'] );
+		$this->assertSame( 10, $args['records_per_page'] );
+	}
+
+	/**
+	 * Test scalar property filters, including user_id = 0.
+	 *
+	 * @param array $input    Input bag.
+	 * @param array $expected Expected subset of args.
+	 */
+	#[DataProvider( 'data_property_filters' )]
+	public function test_build_args_property_filters( $input, $expected ) {
+		$args = $this->builder->build_args( $input );
+
+		foreach ( $expected as $key => $value ) {
+			$this->assertSame( $value, $args[ $key ], "Failed asserting args[{$key}]" );
+		}
+	}
+
+	/**
+	 * Data provider for property filter cases.
+	 *
+	 * @return array<string, array{0: array, 1: array}>
+	 */
+	public static function data_property_filters() {
+		return array(
+			'user_id_zero'   => array(
+				array(
+					'user_id'          => 0,
+					'records_per_page' => 20,
+				),
+				array( 'user_id' => 0 ),
+			),
+			'scalar_filters' => array(
+				array(
+					'connector'        => 'posts',
+					'context'          => 'post',
+					'action'           => 'updated',
+					'ip'               => '127.0.0.1',
+					'records_per_page' => 20,
+				),
+				array(
+					'connector' => 'posts',
+					'context'   => 'post',
+					'action'    => 'updated',
+					'ip'        => '127.0.0.1',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Empty-string property filters are omitted from args.
+	 */
+	public function test_build_args_skips_empty_string_property() {
+		$args = $this->builder->build_args(
+			array(
+				'user_role'        => '',
+				'records_per_page' => 20,
+			)
+		);
+
+		$this->assertArrayNotHasKey( 'user_role', $args );
+	}
+
+	/**
+	 * Test __in / __not_in comma-list explosion and array passthrough.
+	 */
+	public function test_build_args_explodes_in_and_not_in_lists() {
+		$args = $this->builder->build_args(
+			array(
+				'connector__in'    => 'posts,users',
+				'user_id__not_in'  => '1,2',
+				'action__in'       => array( 'updated', 'created' ),
+				'records_per_page' => 20,
+			)
+		);
+
+		$this->assertSame( array( 'posts', 'users' ), $args['connector__in'] );
+		$this->assertSame( array( '1', '2' ), $args['user_id__not_in'] );
+		$this->assertSame( array( 'updated', 'created' ), $args['action__in'] );
+	}
+
+	/**
+	 * Test group-{connector} context remaps to connector with empty context.
+	 */
+	public function test_build_args_remaps_group_context_to_connector() {
+		$args = $this->builder->build_args(
+			array(
+				'context'          => 'group-posts',
+				'records_per_page' => 20,
+			)
+		);
+
+		$this->assertSame( 'posts', $args['connector'] );
+		$this->assertSame( '', $args['context'] );
+	}
+
+	/**
+	 * Test stream_records_per_page filter is applied.
+	 */
+	public function test_build_args_applies_stream_records_per_page_filter() {
+		Filters\expectApplied( 'stream_records_per_page' )
+			->once()
+			->with( 20 )
+			->andReturn( 50 );
+
+		$args = $this->builder->build_args(
+			array(
+				'records_per_page' => 20,
+			)
+		);
+
+		$this->assertSame( 50, $args['records_per_page'] );
+	}
+
+	/**
+	 * Test default records_per_page when omitted from input.
+	 */
+	public function test_build_args_defaults_records_per_page() {
+		Filters\expectApplied( 'stream_records_per_page' )
+			->once()
+			->andReturn( 20 );
+
+		$args = $this->builder->build_args( array() );
+
+		$this->assertSame( 20, $args['records_per_page'] );
+	}
+
+	/**
+	 * Test paged=0 is preserved via isset, and omitted paged stays absent.
+	 *
+	 * @param array $input           Input bag.
+	 * @param bool  $expect_paged_key Whether args should contain paged.
+	 * @param mixed $expected_paged  Expected paged value when present.
+	 */
+	#[DataProvider( 'data_paged_preservation' )]
+	public function test_build_args_paged_preservation( $input, $expect_paged_key, $expected_paged ) {
+		$args = $this->builder->build_args( $input );
+
+		if ( $expect_paged_key ) {
+			$this->assertArrayHasKey( 'paged', $args );
+			$this->assertSame( $expected_paged, $args['paged'] );
+			$this->assertSame( 20, $args['records_per_page'] );
+		} else {
+			$this->assertArrayNotHasKey( 'paged', $args );
+		}
+	}
+
+	/**
+	 * Data provider for paged isset vs empty() contract.
+	 *
+	 * @return array<string, array{0: array, 1: bool, 2: mixed}>
+	 */
+	public static function data_paged_preservation() {
+		return array(
+			'paged_zero' => array(
+				array(
+					'paged'            => 0,
+					'records_per_page' => 20,
+				),
+				true,
+				0,
+			),
+			'omit_paged' => array(
+				array(
+					'records_per_page' => 20,
+				),
+				false,
+				null,
+			),
+		);
+	}
+}


### PR DESCRIPTION
Fixes XWPENG-50.

Continues the admin god-class decomposition by extracting query construction and column HTML from `List_Table` into two collaborators. `List_Table` keeps WordPress list-table responsibilities (screen options, pagination, `wp_kses` output); filter-to-DB mapping and cell rendering move into testable, WordPress-free classes.

## Summary

- **`List_Table_Query_Builder`** — Maps sanitized filter input to `DB::get_records()` args: order/search/date scalars, property filters (including `__in` / `__not_in` comma lists), `group-{connector}` context remapping, pagination, and the `stream_records_per_page` filter.
- **`List_Table_Column_Renderer`** — Renders record cell HTML for built-in columns (date, summary, user, context, action, blog, IP) plus custom columns via `wp_stream_insert_column_default_{$column}`; includes `column_link()`, `get_action_links()`, and `get_term_title()` moved from `List_Table`.
- **`List_Table`** — `get_records()` now calls private `collect_filter_input()` (reads `wp_stream_filter_input` + pagination), delegates arg building to the query builder, then queries the DB. `column_default()` delegates HTML generation to the column renderer and still applies `wp_kses` before echo.
- **Unit tests** — `List_Table_Query_Builder_Unit_Test` and `List_Table_Column_Renderer_Unit_Test` cover filter mapping, group-context remap, pagination edge cases (`paged = 0`), and representative column output (Brain Monkey; no WordPress bootstrap).

## Stack context

Stacks on [#1992](https://github.com/xwp/stream/pull/1992) (`ticket/XWPENG-49-admin-split`).

No user-facing behavior change — internal refactor only.

## Test plan

- [x] CI: Lint and Test + E2E (PHP 8.2 / 8.3 / 8.4) pass
- [x] `composer lint` and `composer lint-tests` pass locally
- [ ] Reviewer: spot-check Stream records list filters (connector/context group, user, date) and column links in wp-admin

# Checklist

- [ ] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [x] I have added phpunit tests.


## Release Changelog

- Fix: N/A — internal refactor, no user-facing change.
- New: N/A.


## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).


Change `[ ]` to `[x]` to mark the items as done.