### PR TITLE
Track Gravity Forms logging (debug/error) setting changes

### DIFF
--- a/connectors.md
+++ b/connectors.md
@@ -357,6 +357,8 @@
 				'label' => esc_html_x( 'reCAPTCHA Private Key', 'gravityforms', 'stream' ),
 			),
 			'rg_gforms_key'                 => null,
+			'gform_enable_logging'          => null,
+			'gravityformsaddon_gravityformslogging_settings' => null,
 		);
 	}
 ```

--- a/connectors/class-connector-gravityforms.php
+++ b/connectors/class-connector-gravityforms.php
@@ -74,6 +74,14 @@ class Connector_GravityForms extends Connector {
 	public $options_override = array();
 
 	/**
+	 * Whether the main logging toggle was just changed, so the resulting
+	 * per-add-on cascade isn't also reported
+	 *
+	 * @var bool
+	 */
+	private $logging_main_toggle_in_progress = false;
+
+	/**
 	 * Check if plugin dependencies are satisfied and add an admin notice if not
 	 *
 	 * @return bool
@@ -211,6 +219,8 @@ class Connector_GravityForms extends Connector {
 				'label' => esc_html_x( 'reCAPTCHA Private Key', 'gravityforms', 'stream' ),
 			),
 			'rg_gforms_key'                 => null,
+			'gform_enable_logging'          => null,
+			'gravityformsaddon_gravityformslogging_settings' => null,
 		);
 	}
 
@@ -556,6 +566,112 @@ class Connector_GravityForms extends Connector {
 			'settings',
 			$is_update ? 'updated' : 'deleted'
 		);
+	}
+
+	/**
+	 * Log the main "Enable Logging" setting change
+	 *
+	 * @param bool|null $old_value  Previous state.
+	 * @param bool      $new_value  Updated state.
+	 * @return void
+	 */
+	public function check_gform_enable_logging( $old_value, $new_value ) {
+		$this->logging_main_toggle_in_progress = true;
+
+		$this->log(
+			sprintf(
+				/* translators: %s: a status (e.g. "enabled") */
+				__( 'Gravity Forms logging %s', 'stream' ),
+				$this->get_status_for_message(
+					$new_value,
+					esc_html__( 'enabled', 'stream' ),
+					esc_html__( 'disabled', 'stream' )
+				)
+			),
+			compact( 'old_value', 'new_value' ),
+			null,
+			'settings',
+			$new_value ? 'activated' : 'deactivated'
+		);
+	}
+
+	/**
+	 * Log Gravity Forms logging setting changes for Core and each add-on
+	 *
+	 * @param array|null $old_value  Previous logging settings, keyed by plugin slug.
+	 * @param array|null $new_value  Updated logging settings, keyed by plugin slug.
+	 * @return void
+	 */
+	public function check_gravityformsaddon_gravityformslogging_settings( $old_value, $new_value ) {
+		/*
+		 * The main toggle already reports that logging was enabled; skip the
+		 * add-on cascade it triggers as a side effect, since that's just
+		 * redundant noise for the same action.
+		 */
+		if ( $this->logging_main_toggle_in_progress ) {
+			$this->logging_main_toggle_in_progress = false;
+			return;
+		}
+
+		if ( is_null( $old_value ) && is_null( $new_value ) ) {
+			$this->log(
+				__( 'Gravity Forms logging configuration deleted', 'stream' ),
+				array(),
+				null,
+				'settings',
+				'deleted'
+			);
+			return;
+		}
+
+		$old_value = is_array( $old_value ) ? $old_value : array();
+		$new_value = is_array( $new_value ) ? $new_value : array();
+
+		$plugin_slugs      = $this->get_changed_keys( $old_value, $new_value );
+		$supported_plugins = class_exists( '\GFLogging' ) ? \GFLogging::get_instance()->get_supported_plugins() : array();
+
+		foreach ( $plugin_slugs as $plugin_slug ) {
+			$old_enabled = ! empty( $old_value[ $plugin_slug ]['enable'] );
+			$new_enabled = ! empty( $new_value[ $plugin_slug ]['enable'] );
+
+			if ( $old_enabled === $new_enabled ) {
+				continue;
+			}
+
+			$plugin_label = $this->get_logging_plugin_label( $plugin_slug, $supported_plugins );
+
+			$this->log(
+				sprintf(
+					/* translators: 1: a status (e.g. "enabled"), 2: a plugin name (e.g. "Gravity Forms Core") */
+					__( 'Gravity Forms logging %1$s for "%2$s"', 'stream' ),
+					$this->get_status_for_message(
+						$new_enabled,
+						esc_html__( 'enabled', 'stream' ),
+						esc_html__( 'disabled', 'stream' )
+					),
+					$plugin_label
+				),
+				compact( 'plugin_slug', 'old_enabled', 'new_enabled' ),
+				null,
+				'settings',
+				$new_enabled ? 'activated' : 'deactivated'
+			);
+		}
+	}
+
+	/**
+	 * Get the display label for a Gravity Forms logging-tracked plugin slug
+	 *
+	 * @param string $plugin_slug        Plugin slug as stored in the logging settings.
+	 * @param array  $supported_plugins  Slug-to-label map, from GFLogging::get_supported_plugins().
+	 * @return string
+	 */
+	private function get_logging_plugin_label( $plugin_slug, $supported_plugins ) {
+		if ( isset( $supported_plugins[ $plugin_slug ] ) ) {
+			return $this->escape_percentages( $supported_plugins[ $plugin_slug ] );
+		}
+
+		return $this->escape_percentages( $plugin_slug );
 	}
 
 	/**

--- a/tests/phpunit/connectors/test-class-connector-gravityforms.php
+++ b/tests/phpunit/connectors/test-class-connector-gravityforms.php
@@ -1,6 +1,8 @@
 <?php
 namespace WP_Stream;
 
+require_once __DIR__ . '/../fake-gflogging.php';
+
 /**
  * Tests for the Gravity Forms connector.
  *
@@ -35,6 +37,10 @@ class Test_Connector_GravityForms extends WP_StreamTestCase {
 		// Populates $options, which check() consults. Safe without the plugin
 		// present: register() only builds that array.
 		$this->mock->register();
+
+		// Empty by default, so get_logging_plugin_label() falls back to the
+		// raw slug in every test except the one that populates this.
+		\GFLogging::$supported_plugins = array();
 	}
 
 	/**
@@ -139,5 +145,249 @@ class Test_Connector_GravityForms extends WP_StreamTestCase {
 		$this->mock->check_rg_gforms_key( 'old-license', '' );
 
 		$this->assertStringContainsString( 'deleted', $message );
+	}
+
+	/**
+	 * Toggling the main "Enable Logging" setting must be reported, so an
+	 * audit log user can tell who enabled it and when.
+	 */
+	public function test_logging_main_toggle_is_reported() {
+		$action = '';
+		$this->mock->expects( $this->once() )
+			->method( 'log' )
+			->willReturnCallback(
+				function ( $message, $args, $object_id, $context, $logged_action ) use ( &$action ) {
+					$action = $logged_action;
+					return true;
+				}
+			);
+
+		$this->mock->check_gform_enable_logging( false, true );
+
+		$this->assertSame( 'activated', $action );
+	}
+
+	/**
+	 * Gravity Forms enables every add-on's logger as a side effect of the
+	 * main toggle, in the same request. That cascade must not also be
+	 * reported, or one user action would produce a confusing pile of
+	 * per-add-on records alongside the single main-toggle record.
+	 */
+	public function test_addon_cascade_from_main_toggle_is_not_reported() {
+		$this->mock->expects( $this->once() )->method( 'log' );
+
+		$this->mock->check_gform_enable_logging( false, true );
+
+		$this->mock->check_gravityformsaddon_gravityformslogging_settings(
+			array(
+				'gravityforms'       => array( 'enable' => '0' ),
+				'gravityformsstripe' => array( 'enable' => '0' ),
+			),
+			array(
+				'gravityforms'       => array( 'enable' => '1' ),
+				'gravityformsstripe' => array( 'enable' => '1' ),
+			)
+		);
+	}
+
+	/**
+	 * Enabling logging for one add-on must be reported as 'activated'.
+	 */
+	public function test_addon_logging_enabled_is_reported() {
+		$action = '';
+		$this->mock->expects( $this->once() )
+			->method( 'log' )
+			->willReturnCallback(
+				function ( $message, $args, $object_id, $context, $logged_action ) use ( &$action ) {
+					$action = $logged_action;
+					return true;
+				}
+			);
+
+		$this->mock->check_gravityformsaddon_gravityformslogging_settings(
+			array( 'gravityforms' => array( 'enable' => '0' ) ),
+			array( 'gravityforms' => array( 'enable' => '1' ) )
+		);
+
+		$this->assertSame( 'activated', $action );
+	}
+
+	/**
+	 * Disabling logging for one add-on must be reported as 'deactivated'.
+	 */
+	public function test_addon_logging_disabled_is_reported() {
+		$action = '';
+		$this->mock->expects( $this->once() )
+			->method( 'log' )
+			->willReturnCallback(
+				function ( $message, $args, $object_id, $context, $logged_action ) use ( &$action ) {
+					$action = $logged_action;
+					return true;
+				}
+			);
+
+		$this->mock->check_gravityformsaddon_gravityformslogging_settings(
+			array( 'gravityforms' => array( 'enable' => '1' ) ),
+			array( 'gravityforms' => array( 'enable' => '0' ) )
+		);
+
+		$this->assertSame( 'deactivated', $action );
+	}
+
+	/**
+	 * An unchanged add-on entry must not produce a record, or resubmitting
+	 * the whole settings form would spam the log for every untouched add-on.
+	 */
+	public function test_addon_logging_unchanged_is_not_reported() {
+		$this->mock->expects( $this->never() )->method( 'log' );
+
+		$this->mock->check_gravityformsaddon_gravityformslogging_settings(
+			array( 'gravityforms' => array( 'enable' => '1' ) ),
+			array( 'gravityforms' => array( 'enable' => '1' ) )
+		);
+	}
+
+	/**
+	 * Each changed add-on must be its own record, since the whole settings
+	 * form (Core plus every add-on) saves together in one option update.
+	 */
+	public function test_addon_logging_multiple_changes_are_reported_separately() {
+		$this->mock->expects( $this->exactly( 2 ) )->method( 'log' );
+
+		$this->mock->check_gravityformsaddon_gravityformslogging_settings(
+			array(
+				'gravityforms'       => array( 'enable' => '0' ),
+				'gravityformsstripe' => array( 'enable' => '0' ),
+			),
+			array(
+				'gravityforms'       => array( 'enable' => '1' ),
+				'gravityformsstripe' => array( 'enable' => '1' ),
+			)
+		);
+	}
+
+	/**
+	 * The option's first-ever save (add_option, so the old value is entirely
+	 * absent) must still be reported, without a PHP notice from the missing
+	 * old entry.
+	 */
+	public function test_addon_logging_first_save_is_reported_without_notice() {
+		$this->mock->expects( $this->once() )->method( 'log' );
+
+		$this->mock->check_gravityformsaddon_gravityformslogging_settings(
+			null,
+			array( 'gravityforms' => array( 'enable' => '1' ) )
+		);
+	}
+
+	/**
+	 * The suppression flag must only skip the write right after a
+	 * main-toggle change, not a later unrelated one in the same process.
+	 */
+	public function test_addon_logging_suppression_is_consumed_once() {
+		$this->mock->expects( $this->exactly( 2 ) )->method( 'log' );
+
+		$this->mock->check_gform_enable_logging( false, true );
+
+		$this->mock->check_gravityformsaddon_gravityformslogging_settings(
+			array( 'gravityforms' => array( 'enable' => '0' ) ),
+			array( 'gravityforms' => array( 'enable' => '1' ) )
+		);
+
+		$this->mock->check_gravityformsaddon_gravityformslogging_settings(
+			array( 'gravityformsstripe' => array( 'enable' => '1' ) ),
+			array( 'gravityformsstripe' => array( 'enable' => '0' ) )
+		);
+	}
+
+	/**
+	 * Deleting the whole logging configuration must still be reported.
+	 */
+	public function test_addon_logging_deletion_is_reported() {
+		$action = '';
+		$this->mock->expects( $this->once() )
+			->method( 'log' )
+			->willReturnCallback(
+				function ( $message, $args, $object_id, $context, $logged_action ) use ( &$action ) {
+					$action = $logged_action;
+					return true;
+				}
+			);
+
+		$this->mock->check_gravityformsaddon_gravityformslogging_settings( null, null );
+
+		$this->assertSame( 'deleted', $action );
+	}
+
+	/**
+	 * An unmapped slug must fall back to the raw slug.
+	 */
+	public function test_addon_logging_label_falls_back_to_slug_when_unmapped() {
+		$message = '';
+		$this->mock->expects( $this->once() )
+			->method( 'log' )
+			->willReturnCallback(
+				function ( $msg ) use ( &$message ) {
+					$message = $msg;
+					return true;
+				}
+			);
+
+		$this->mock->check_gravityformsaddon_gravityformslogging_settings(
+			array( 'gravityformsstripe' => array( 'enable' => '0' ) ),
+			array( 'gravityformsstripe' => array( 'enable' => '1' ) )
+		);
+
+		$this->assertStringContainsString( 'gravityformsstripe', $message );
+	}
+
+	/**
+	 * A mapped slug must be reported by its real name, not the raw slug.
+	 */
+	public function test_addon_logging_label_uses_supported_plugin_name() {
+		\GFLogging::$supported_plugins = array( 'gravityformsstripe' => 'Gravity Forms Stripe Add-On' );
+
+		$message = '';
+		$this->mock->expects( $this->once() )
+			->method( 'log' )
+			->willReturnCallback(
+				function ( $msg ) use ( &$message ) {
+					$message = $msg;
+					return true;
+				}
+			);
+
+		$this->mock->check_gravityformsaddon_gravityformslogging_settings(
+			array( 'gravityformsstripe' => array( 'enable' => '0' ) ),
+			array( 'gravityformsstripe' => array( 'enable' => '1' ) )
+		);
+
+		$this->assertStringContainsString( 'Gravity Forms Stripe Add-On', $message );
+		$this->assertStringNotContainsString( 'gravityformsstripe', $message );
+	}
+
+	/**
+	 * A plugin name containing "%" must reach the message escaped.
+	 */
+	public function test_addon_logging_label_is_escaped() {
+		\GFLogging::$supported_plugins = array( 'gravityformsstripe' => 'Stripe 50% Off Add-On' );
+
+		$message = '';
+		$this->mock->expects( $this->once() )
+			->method( 'log' )
+			->willReturnCallback(
+				function ( $msg ) use ( &$message ) {
+					$message = $msg;
+					return true;
+				}
+			);
+
+		$this->mock->check_gravityformsaddon_gravityformslogging_settings(
+			array( 'gravityformsstripe' => array( 'enable' => '0' ) ),
+			array( 'gravityformsstripe' => array( 'enable' => '1' ) )
+		);
+
+		$this->assertStringContainsString( 'Stripe 50%% Off Add-On', $message );
+		$this->assertStringNotContainsString( 'Stripe 50% Off', $message );
 	}
 }

--- a/tests/phpunit/fake-gflogging.php
+++ b/tests/phpunit/fake-gflogging.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Minimal stand-in for Gravity Forms' GFLogging class.
+ *
+ * Deliberately unnamespaced, so it satisfies class_exists( '\GFLogging' )
+ * like the real (uninstalled here) class would.
+ *
+ * @package WP_Stream
+ */
+
+/**
+ * Class - GFLogging
+ */
+class GFLogging {
+
+	/**
+	 * Slug-to-label map returned by get_supported_plugins()
+	 *
+	 * @var array
+	 */
+	public static $supported_plugins = array();
+
+	/**
+	 * Fake singleton accessor
+	 *
+	 * @return self
+	 */
+	public static function get_instance() {
+		return new self();
+	}
+
+	/**
+	 * Fake supported-plugins lookup
+	 *
+	 * @return array
+	 */
+	public function get_supported_plugins() {
+		return self::$supported_plugins;
+	}
+}


### PR DESCRIPTION
Fixes #1996.

Adds tracking for Gravity Forms' logging settings to the Gravity Forms connector, following the existing `rg_gforms_key` pattern (a `null` entry in `$this->options` plus a matching `check_*` method):

- The main "Enable Logging" toggle (`gform_enable_logging`) is reported as a single enabled/disabled record.
- Each add-on's own logging toggle (`gravityformsaddon_gravityformslogging_settings`, one entry per plugin slug, e.g. `gravityforms` for Core or `gravityformsstripe` for the Stripe add-on) is reported individually when changed on its own.
- Gravity Forms force-enables every add-on's logger as a side effect of the main toggle (`enable_all_loggers()`). A request-scoped flag skips reporting that cascade separately, so flipping the main toggle produces one record, not one per add-on.
- Deleting the logging option entirely (e.g. uninstalling the Gravity Forms Logging add-on) is reported as a single record, since WordPress's `delete_option` hook carries no prior value to diff per add-on against.

# Checklist

- [x] Project documentation has been updated to reflect the changes in this pull request, if applicable.
- [x] I have tested the changes in the local development environment (see `contributing.md`).
- [x] I have added phpunit tests.


## Release Changelog

- New: Track when Gravity Forms logging (the main toggle and each add-on) is enabled or disabled.
