### PR TITLE
Skip malformed entries when iterating over WooCommerce settings pages

### DIFF
--- a/connectors/class-connector-woocommerce.php
+++ b/connectors/class-connector-woocommerce.php
@@ -775,6 +775,16 @@ class Connector_Woocommerce extends Connector {
 
 			foreach ( \WC_Admin_Settings::get_settings_pages() as $page ) {
 				/**
+				 * Skip malformed entries. Third-party plugins can hook the
+				 * `woocommerce_get_settings_pages` filter and (due to bugs of
+				 * their own) push non-object values onto the array; we
+				 * shouldn't fatal on data we don't control.
+				 */
+				if ( ! is_object( $page ) || ! method_exists( $page, 'add_settings_page' ) ) {
+					continue;
+				}
+
+				/**
 				 * Get ID / Label of the page, since they're protected, by hacking into
 				 * the callback filter for 'woocommerce_settings_tabs_array'.
 				 */


### PR DESCRIPTION
Add safety check to skip malformed entries when iterating over WooCommerce settings pages

`get_woocommerce_settings_fields()` iterates over the array returned by
`WC_Admin_Settings::get_settings_pages()` (which is built from the
third-party-extensible `woocommerce_get_settings_pages` filter) and calls
`add_settings_page()` on each entry, assuming every entry is a
`WC_Settings_Page` instance.

If a third-party plugin has a bug that hooks that filter and pushes a
non-object (e.g. an int) into the array, Stream calls a method on that
non-object and throws an uncaught fatal error, taking down all of wp-admin —
not just Stream's own settings-indexing logic.

This PR adds a guard at the top of the loop that skips any entry that isn't
an object exposing `add_settings_page()`, so malformed data from other
plugins is silently ignored instead of crashing the site. This is defensive
only — it doesn't change behavior for any well-formed settings page.


# Checklist

- [x] Project documentation has been updated to reflect the changes in this pull request, if applicable. (Not applicable)
- [x] I have tested the changes in the local development environment (see `contributing.md`). (Tested on a live site.)
- [ ] I have added phpunit tests.


## Release Changelog

- Fix: Prevent a fatal error in `Connector_Woocommerce::get_woocommerce_settings_fields()` when a third-party plugin adds a malformed (non-object) entry to the `woocommerce_get_settings_pages` filter.


## Release Checklist

- [ ] This pull request is to the `master` branch.
- [ ] Release version follows [semantic versioning](https://semver.org). Does it include breaking changes?
- [ ] Update changelog in `readme.txt`.
- [ ] Bump version in `stream.php`.
- [ ] Bump `Stable tag` in `readme.txt`.
- [ ] Bump version in `classes/class-plugin.php`.
- [ ] Draft a release [on GitHub](https://github.com/xwp/stream/releases/new).


Change `[ ]` to `[x]` to mark the items as done.
