### PR TITLE
Add an outgoing webhook alert and hide IFTTT from the new-alert UI.

### DIFF
--- a/abilities/class-ability-create-alert.php
+++ b/abilities/class-ability-create-alert.php
@@ -54,7 +54,7 @@ class Ability_Create_Alert extends Ability {
 			'properties'           => array(
 				'alert_type'      => array(
 					'type'        => 'string',
-					'description' => 'Notifier slug. Built-in types are none, highlight, email, ifttt, slack. Other slugs may be registered by extensions.',
+					'description' => 'Notifier slug. Built-in types are none, highlight, email, slack, webhook. The ifttt type is deprecated and cannot be created; existing IFTTT alerts still fire. Other slugs may be registered by extensions.',
 				),
 				'trigger_author'  => array(
 					'type'        => 'string',
@@ -129,6 +129,21 @@ class Ability_Create_Alert extends Ability {
 					__( 'Unknown alert_type "%1$s". Registered types: %2$s.', 'stream' ),
 					(string) $input['alert_type'],
 					implode( ', ', $registered_types )
+				),
+				array( 'status' => 400 )
+			);
+		}
+
+		$type_objects = isset( $this->plugin->alerts->alert_types )
+			? (array) $this->plugin->alerts->alert_types
+			: array();
+		if ( isset( $type_objects[ $input['alert_type'] ] ) && empty( $type_objects[ $input['alert_type'] ]->creatable ) ) {
+			return new \WP_Error(
+				'stream_alert_type_not_creatable',
+				sprintf(
+					/* translators: %s: alert_type slug supplied by caller */
+					__( 'Alert type "%s" is deprecated and cannot be created.', 'stream' ),
+					(string) $input['alert_type']
 				),
 				array( 'status' => 400 )
 			);

--- a/alerts/class-alert-type-highlight.php
+++ b/alerts/class-alert-type-highlight.php
@@ -49,21 +49,13 @@ class Alert_Type_Highlight extends Alert_Type {
 	public $single_alert_id;
 
 	/**
-	 * The Plugin
-	 *
-	 * @var Plugin
-	 */
-	public $plugin;
-
-	/**
 	 * Class Constructor
 	 *
 	 * @param Plugin $plugin Plugin object.
 	 * @return void
 	 */
-	public function __construct( $plugin ) {
+	public function __construct( public Plugin $plugin ) {
 		parent::__construct( $plugin );
-		$this->plugin = $plugin;
 		if ( ! is_admin() ) {
 			return;
 		}

--- a/alerts/class-alert-type-ifttt.php
+++ b/alerts/class-alert-type-ifttt.php
@@ -61,6 +61,13 @@ class Alert_Type_IFTTT extends Alert_Type {
 	public string $slug = 'ifttt';
 
 	/**
+	 * Hidden from the new-alert UI; existing IFTTT alerts still fire.
+	 *
+	 * @var bool
+	 */
+	public bool $creatable = false;
+
+	/**
 	 * Class Constructor
 	 *
 	 * @param Plugin $plugin Plugin object.

--- a/alerts/class-alert-type-webhook.php
+++ b/alerts/class-alert-type-webhook.php
@@ -1,0 +1,445 @@
+<?php
+/**
+ * Outgoing Webhook Alerts.
+ *
+ * @package WP_Stream
+ */
+
+namespace WP_Stream;
+
+/**
+ * Class Alert_Type_Webhook
+ *
+ * @package WP_Stream
+ */
+class Alert_Type_Webhook extends Alert_Type {
+
+	/**
+	 * Record keys that may appear as {{field}} placeholders in the body template.
+	 */
+	const PLACEHOLDER_FIELDS = array(
+		'summary',
+		'connector',
+		'context',
+		'action',
+		'user_id',
+		'user_role',
+		'ip',
+		'object_id',
+		'blog_id',
+		'created',
+	);
+
+	/**
+	 * Allowed Content-Type header values.
+	 */
+	const ALLOWED_CONTENT_TYPES = array(
+		'application/json',
+		'application/json; charset=utf-8',
+		'text/plain',
+		'application/x-www-form-urlencoded',
+	);
+
+	/**
+	 * HTTP header names that must not be overridden by configuration.
+	 */
+	const BLOCKED_HEADER_NAMES = array(
+		'host',
+		'content-length',
+		'transfer-encoding',
+	);
+
+	/**
+	 * Alert type name
+	 *
+	 * @var string
+	 */
+	public string $name = 'Outgoing Webhook';
+
+	/**
+	 * Alert type slug
+	 *
+	 * @var string
+	 */
+	public string $slug = 'webhook';
+
+	/**
+	 * Class Constructor
+	 *
+	 * @param Plugin $plugin Plugin object.
+	 */
+	public function __construct( public Plugin $plugin ) {
+		parent::__construct( $plugin );
+
+		$this->register_hooks();
+	}
+
+	/**
+	 * Register hooks for the alert type.
+	 *
+	 * @return void
+	 */
+	private function register_hooks() {
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		add_filter(
+			'wp_stream_alerts_save_meta',
+			array( $this, 'add_alert_meta' ),
+			10,
+			2
+		);
+	}
+
+	/**
+	 * Send an HTTP request for the matching record.
+	 *
+	 * @param int   $record_id Record that triggered notification.
+	 * @param array $recordarr Record details.
+	 * @param Alert $alert     Alert options.
+	 * @return void
+	 */
+	public function alert( $record_id, $recordarr, $alert ) {
+		unset( $record_id );
+
+		$options = wp_parse_args(
+			is_object( $alert ) ? $alert->alert_meta : array(),
+			array(
+				'url'           => '',
+				'method'        => 'POST',
+				'content_type'  => 'application/json',
+				'headers'       => array(),
+				'body_template' => '',
+			)
+		);
+
+		$url = is_string( $options['url'] ) ? trim( $options['url'] ) : '';
+		if ( '' === $url || false === wp_http_validate_url( $url ) ) {
+			return;
+		}
+
+		$method = strtoupper( (string) $options['method'] );
+		if ( ! in_array( $method, array( 'POST', 'PUT' ), true ) ) {
+			$method = 'POST';
+		}
+
+		$template = is_string( $options['body_template'] ) ? $options['body_template'] : '';
+		if ( '' === trim( $template ) ) {
+			$template = self::default_body_template();
+		}
+
+		$body    = self::substitute_placeholders( $template, (array) $recordarr );
+		$headers = self::build_request_headers( $options['content_type'], $options['headers'] );
+
+		$response = wp_safe_remote_request(
+			$url,
+			array(
+				'method'  => $method,
+				'headers' => $headers,
+				'body'    => $body,
+				'timeout' => 15,
+			)
+		);
+
+		if ( is_wp_error( $response ) && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Opt-in debug only.
+			error_log( sprintf( 'Stream webhook alert request failed: %s', $response->get_error_message() ) );
+		}
+	}
+
+	/**
+	 * Compact JSON object with placeholders for every supported record field.
+	 *
+	 * @return string
+	 */
+	public static function default_body_template() {
+		$parts = array();
+		foreach ( self::PLACEHOLDER_FIELDS as $field ) {
+			$parts[] = '"' . $field . '":{{' . $field . '}}';
+		}
+
+		return '{' . implode( ',', $parts ) . '}';
+	}
+
+	/**
+	 * Replace {{field}} tokens with JSON-encoded record values.
+	 *
+	 * @param string $template  JSON body template.
+	 * @param array  $recordarr Record details.
+	 * @return string
+	 */
+	public static function substitute_placeholders( $template, $recordarr ) {
+		$replacements = array();
+		foreach ( self::PLACEHOLDER_FIELDS as $field ) {
+			$value                                = array_key_exists( $field, $recordarr ) ? $recordarr[ $field ] : '';
+			$replacements[ '{{' . $field . '}}' ] = wp_json_encode( $value );
+		}
+
+		return strtr( (string) $template, $replacements );
+	}
+
+	/**
+	 * Merge Content-Type with extra header rows; drop blocked names.
+	 *
+	 * @param string $content_type Requested Content-Type.
+	 * @param array  $header_rows  Stored header rows.
+	 * @return array
+	 */
+	public static function build_request_headers( $content_type, $header_rows ) {
+		$headers = array(
+			'Content-Type' => self::sanitize_content_type( $content_type ),
+		);
+
+		foreach ( self::normalize_header_rows( $header_rows ) as $row ) {
+			$name  = $row['name'];
+			$value = $row['value'];
+			$key   = strtolower( $name );
+			if ( in_array( $key, self::BLOCKED_HEADER_NAMES, true ) ) {
+				continue;
+			}
+			if ( 'content-type' === $key ) {
+				$headers['Content-Type'] = self::sanitize_content_type( $value );
+				continue;
+			}
+			$headers[ $name ] = $value;
+		}
+
+		return $headers;
+	}
+
+	/**
+	 * Restrict Content-Type to the allowlist.
+	 *
+	 * @param string $content_type Raw Content-Type.
+	 * @return string
+	 */
+	public static function sanitize_content_type( $content_type ) {
+		$normalized = strtolower( trim( (string) $content_type ) );
+		foreach ( self::ALLOWED_CONTENT_TYPES as $allowed ) {
+			if ( strtolower( $allowed ) === $normalized ) {
+				return $allowed;
+			}
+		}
+
+		return 'application/json';
+	}
+
+	/**
+	 * Normalize stored or posted headers into name/value rows.
+	 *
+	 * @param mixed $headers Header rows, associative map, or textarea string.
+	 * @return array<int, array{name: string, value: string}>
+	 */
+	public static function normalize_header_rows( $headers ) {
+		if ( is_string( $headers ) ) {
+			return self::parse_header_textarea( $headers );
+		}
+
+		if ( ! is_array( $headers ) ) {
+			return array();
+		}
+
+		$rows = array();
+		foreach ( $headers as $key => $entry ) {
+			if ( is_array( $entry ) && isset( $entry['name'] ) ) {
+				$name  = (string) $entry['name'];
+				$value = isset( $entry['value'] ) ? (string) $entry['value'] : '';
+			} elseif ( is_string( $key ) && ! is_numeric( $key ) ) {
+				$name  = $key;
+				$value = is_scalar( $entry ) ? (string) $entry : '';
+			} else {
+				continue;
+			}
+
+			$sanitized = self::sanitize_header_pair( $name, $value );
+			if ( null !== $sanitized ) {
+				$rows[] = $sanitized;
+			}
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Parse "Name: value" lines from the additional-headers field.
+	 *
+	 * @param string $text Textarea contents.
+	 * @return array<int, array{name: string, value: string}>
+	 */
+	public static function parse_header_textarea( $text ) {
+		$rows  = array();
+		$lines = preg_split( '/\r\n|\r|\n/', (string) $text );
+		if ( ! is_array( $lines ) ) {
+			return array();
+		}
+
+		foreach ( $lines as $line ) {
+			$line = trim( $line );
+			if ( '' === $line || false === strpos( $line, ':' ) ) {
+				continue;
+			}
+			$parts     = explode( ':', $line, 2 );
+			$sanitized = self::sanitize_header_pair( $parts[0], $parts[1] );
+			if ( null !== $sanitized ) {
+				$rows[] = $sanitized;
+			}
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Sanitize one HTTP header name/value pair.
+	 *
+	 * @param string $name  Header name.
+	 * @param string $value Header value.
+	 * @return array{name: string, value: string}|null
+	 */
+	public static function sanitize_header_pair( $name, $value ) {
+		$name  = trim( (string) $name );
+		$value = trim( str_replace( array( "\r", "\n" ), '', (string) $value ) );
+		if ( '' === $name || ! preg_match( '/^[A-Za-z0-9-]+$/', $name ) ) {
+			return null;
+		}
+		if ( in_array( strtolower( $name ), self::BLOCKED_HEADER_NAMES, true ) ) {
+			return null;
+		}
+
+		return array(
+			'name'  => $name,
+			'value' => $value,
+		);
+	}
+
+	/**
+	 * Display settings form for this alert type.
+	 *
+	 * @param Alert $alert Alert currently being worked on.
+	 * @return void
+	 */
+	public function display_fields( $alert ) {
+		$alert_meta = array();
+		if ( is_object( $alert ) ) {
+			$alert_meta = $alert->alert_meta;
+		}
+		$options = wp_parse_args(
+			$alert_meta,
+			array(
+				'url'           => '',
+				'method'        => 'POST',
+				'content_type'  => 'application/json',
+				'headers'       => array(),
+				'body_template' => self::default_body_template(),
+			)
+		);
+
+		$header_text = '';
+		foreach ( self::normalize_header_rows( $options['headers'] ) as $row ) {
+			$header_text .= $row['name'] . ': ' . $row['value'] . "\n";
+		}
+
+		$content_type_options = array();
+		foreach ( self::ALLOWED_CONTENT_TYPES as $type ) {
+			$content_type_options[ $type ] = $type;
+		}
+
+		$form = new Form_Generator();
+		echo '<span class="wp_stream_alert_type_description">' . esc_html__( 'Send an HTTP POST or PUT request to a URL with a JSON body.', 'stream' ) . '</span>';
+
+		echo '<label for="wp_stream_webhook_url"><span class="title">' . esc_html__( 'URL', 'stream' ) . '</span>';
+		echo '<span class="input-text-wrap">';
+		$form->render_field(
+			'text',
+			array(
+				'name'  => 'wp_stream_webhook_url',
+				'title' => esc_attr( __( 'URL', 'stream' ) ),
+				'value' => $options['url'],
+			)
+		);
+		echo '</span>';
+		echo '<span class="input-text-wrap">' . esc_html__( 'Must be a valid HTTP or HTTPS URL.', 'stream' ) . '</span>';
+		echo '</label>';
+
+		echo '<label for="wp_stream_webhook_method"><span class="title">' . esc_html__( 'Method', 'stream' ) . '</span>';
+		echo '<span class="input-text-wrap">';
+		$form->render_field(
+			'select',
+			array(
+				'name'    => 'wp_stream_webhook_method',
+				'value'   => in_array( $options['method'], array( 'POST', 'PUT' ), true ) ? $options['method'] : 'POST',
+				'options' => array(
+					'POST' => 'POST',
+					'PUT'  => 'PUT',
+				),
+			)
+		);
+		echo '</span></label>';
+
+		echo '<label for="wp_stream_webhook_content_type"><span class="title">' . esc_html__( 'Content-Type', 'stream' ) . '</span>';
+		echo '<span class="input-text-wrap">';
+		$form->render_field(
+			'select',
+			array(
+				'name'    => 'wp_stream_webhook_content_type',
+				'value'   => self::sanitize_content_type( $options['content_type'] ),
+				'options' => $content_type_options,
+			)
+		);
+		echo '</span></label>';
+
+		echo '<label for="wp_stream_webhook_headers"><span class="title">' . esc_html__( 'Headers', 'stream' ) . '</span>';
+		echo '<span class="input-text-wrap">';
+		printf(
+			'<textarea name="wp_stream_webhook_headers" id="wp_stream_webhook_headers" rows="3" class="large-text">%s</textarea>',
+			esc_textarea( $header_text )
+		);
+		echo '</span>';
+		echo '<span class="input-text-wrap">' . esc_html__( 'Optional extra headers, one per line as Name: value. Host cannot be overridden.', 'stream' ) . '</span>';
+		echo '</label>';
+
+		echo '<label for="wp_stream_webhook_body_template"><span class="title">' . esc_html__( 'Body template', 'stream' ) . '</span>';
+		echo '<span class="input-text-wrap">';
+		printf(
+			'<textarea name="wp_stream_webhook_body_template" id="wp_stream_webhook_body_template" rows="5" class="large-text code">%s</textarea>',
+			esc_textarea( $options['body_template'] )
+		);
+		echo '</span>';
+		echo '<span class="input-text-wrap">' . esc_html__( 'JSON with {{summary}}, {{connector}}, {{context}}, {{action}}, {{user_id}}, {{user_role}}, {{ip}}, {{object_id}}, {{blog_id}}, {{created}}. Values are JSON-encoded.', 'stream' ) . '</span>';
+		echo '</label>';
+	}
+
+	/**
+	 * Add webhook fields when this alert type is saved.
+	 *
+	 * @param array  $alert_meta The metadata to be inserted for this alert.
+	 * @param string $alert_type The type of alert being added or updated.
+	 *
+	 * @return array
+	 */
+	public function add_alert_meta( $alert_meta, $alert_type ) {
+		if ( 'webhook' !== $alert_type ) {
+			return $alert_meta;
+		}
+
+		$url = wp_stream_filter_input( INPUT_POST, 'wp_stream_webhook_url' );
+		if ( ! empty( $url ) ) {
+			$alert_meta['url'] = esc_url_raw( $url );
+		}
+
+		$method               = wp_stream_filter_input( INPUT_POST, 'wp_stream_webhook_method' );
+		$method               = is_string( $method ) ? strtoupper( $method ) : 'POST';
+		$alert_meta['method'] = in_array( $method, array( 'POST', 'PUT' ), true ) ? $method : 'POST';
+
+		$content_type               = wp_stream_filter_input( INPUT_POST, 'wp_stream_webhook_content_type' );
+		$alert_meta['content_type'] = self::sanitize_content_type( (string) $content_type );
+
+		$headers_raw           = wp_stream_filter_input( INPUT_POST, 'wp_stream_webhook_headers' );
+		$alert_meta['headers'] = self::normalize_header_rows( is_string( $headers_raw ) ? $headers_raw : '' );
+
+		$body_template               = wp_stream_filter_input( INPUT_POST, 'wp_stream_webhook_body_template' );
+		$alert_meta['body_template'] = is_string( $body_template ) ? $body_template : '';
+
+		return $alert_meta;
+	}
+}

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@
 
 - Raise the minimum PHP version from 7.2 to **8.2**. Sites running PHP below 8.2 see an admin notice (for users who can activate plugins) and Stream remains inactive — no fatal error. PHP 7.2–8.1 are no longer supported ([XWPENG-46](https://xwp-co.atlassian.net/browse/XWPENG-46)).
 
+### Enhancements
+
+- Add an Outgoing Webhook alert (HTTP POST or PUT, optional headers, JSON body with record-field placeholders). IFTTT is no longer offered when creating a new alert; existing IFTTT alerts still fire. To keep using Maker, configure a webhook whose URL is `https://maker.ifttt.com/trigger/{event}/with/key/{key}`.
+
 ### Development
 
 - Align Composer (`require.php` `^8.2`), plugin headers, `readme.txt`, PHPCS `testVersion`, contributing docs, and CI matrix (PHP 8.2 / 8.3 / 8.4) at the new floor ([XWPENG-46](https://xwp-co.atlassian.net/browse/XWPENG-46)).

--- a/classes/class-ability.php
+++ b/classes/class-ability.php
@@ -137,6 +137,8 @@ abstract class Ability {
 	const SECRET_ALERT_META_KEYS = array(
 		'webhook',
 		'maker_key',
+		'url',
+		'headers',
 	);
 
 	/**

--- a/classes/class-alert-type.php
+++ b/classes/class-alert-type.php
@@ -24,11 +24,20 @@ abstract class Alert_Type {
 	public string $slug = '';
 
 	/**
+	 * Whether this type can be selected when creating a new alert.
+	 *
+	 * Existing alerts of a non-creatable type still fire and remain editable.
+	 *
+	 * @var bool
+	 */
+	public bool $creatable = true;
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param Plugin $plugin Plugin object.
 	 */
-	public function __construct( public $plugin ) {
+	public function __construct( public Plugin $plugin ) {
 	}
 
 	/**

--- a/classes/class-alerts-admin-ui.php
+++ b/classes/class-alerts-admin-ui.php
@@ -183,11 +183,12 @@ class Alerts_Admin_UI {
 	/**
 	 * Display Alert Type Meta Box
 	 *
-	 * @param \WP_Post|array $post Post object for current alert.
+	 * @param \WP_Post|array $post            Post object for current alert.
+	 * @param bool           $creatable_only  When false, include deprecated types (inline edit).
 	 *
 	 * @return void
 	 */
-	public function display_notification_box( $post = array() ) {
+	public function display_notification_box( $post = array(), $creatable_only = true ) {
 		$alert      = null;
 		$alert_type = 'none';
 		if ( is_object( $post ) ) {
@@ -205,7 +206,7 @@ class Alerts_Admin_UI {
 				'id'          => 'wp_stream_alert_type',
 				'name'        => 'wp_stream_alert_type',
 				'value'       => $alert_type,
-				'options'     => $this->get_notification_values(),
+				'options'     => $this->get_notification_values( $alert_type, $creatable_only ),
 				'placeholder' => __( 'No Alert', 'stream' ),
 				'title'       => 'Alert Type:',
 			)
@@ -254,6 +255,15 @@ class Alerts_Admin_UI {
 			$alert_type = 'none';
 		}
 		if ( ! array_key_exists( $alert_type, $this->plugin->alerts->alert_types ) ) {
+			wp_send_json_error(
+				array(
+					'message' => 'Could not find alert type.',
+				)
+			);
+		}
+
+		$type_obj = $this->plugin->alerts->alert_types[ $alert_type ];
+		if ( empty( $type_obj?->creatable ) && ( empty( $post_id ) || 'new' === $post_id ) ) {
 			wp_send_json_error(
 				array(
 					'message' => 'Could not find alert type.',
@@ -401,15 +411,26 @@ class Alerts_Admin_UI {
 	}
 
 	/**
-	 * Return all notification values
+	 * Return notification type labels for the alert-type dropdown.
 	 *
+	 * Non-creatable types are omitted from the new-alert UI unless
+	 * `$include_slug` is that type, or `$creatable_only` is false (inline edit).
+	 *
+	 * @param string $include_slug    Optional type slug to keep even when not creatable.
+	 * @param bool   $creatable_only  Whether to hide non-creatable types.
 	 * @return array
 	 */
-	public function get_notification_values() {
+	public function get_notification_values( $include_slug = '', $creatable_only = true ) {
 		$result = array();
-		$names  = wp_list_pluck( $this->plugin->alerts->alert_types, 'name', 'slug' );
-		foreach ( $names as $slug => $name ) {
-			$result[ $slug ] = $name;
+		foreach ( $this->plugin->alerts->alert_types as $slug => $type ) {
+			$creatable = $type->creatable;
+			if ( $creatable_only && ! $creatable && $slug !== $include_slug ) {
+				continue;
+			}
+			if ( empty( $type->name ) ) {
+				continue;
+			}
+			$result[ $slug ] = $type->name;
 		}
 
 		return $result;
@@ -477,6 +498,15 @@ class Alerts_Admin_UI {
 		$trigger_action = wp_stream_filter_input( INPUT_POST, 'wp_stream_trigger_action' );
 		$alert_type     = wp_stream_filter_input( INPUT_POST, 'wp_stream_alert_type' );
 		$alert_status   = wp_stream_filter_input( INPUT_POST, 'wp_stream_alert_status' );
+
+		$registered_types = $this->plugin->alerts->alert_types;
+		if ( ! $registered_types[ $alert_type ]?->creatable ) {
+			wp_send_json_error(
+				array(
+					'message' => 'Alert type is not creatable.',
+				)
+			);
+		}
 
 		// Insert the post into the database.
 		$item    = (object) array(

--- a/classes/class-alerts-list.php
+++ b/classes/class-alerts-list.php
@@ -199,6 +199,38 @@ class Alerts_List {
 					<input type="hidden" name="wp_stream_slack_icon" value="<?php echo esc_attr( $alert->alert_meta['slack_icon'] ); ?>" />
 					<?php
 				}
+				if ( ! empty( $alert->alert_meta['url'] ) ) {
+					?>
+					<input type="hidden" name="wp_stream_webhook_url" value="<?php echo esc_attr( $alert->alert_meta['url'] ); ?>" />
+					<?php
+				}
+				if ( ! empty( $alert->alert_meta['method'] ) ) {
+					?>
+					<input type="hidden" name="wp_stream_webhook_method" value="<?php echo esc_attr( $alert->alert_meta['method'] ); ?>" />
+					<?php
+				}
+				if ( ! empty( $alert->alert_meta['content_type'] ) ) {
+					?>
+					<input type="hidden" name="wp_stream_webhook_content_type" value="<?php echo esc_attr( $alert->alert_meta['content_type'] ); ?>" />
+					<?php
+				}
+				if ( ! empty( $alert->alert_meta['headers'] ) && is_array( $alert->alert_meta['headers'] ) ) {
+					$header_lines = array();
+					foreach ( $alert->alert_meta['headers'] as $header_row ) {
+						if ( is_array( $header_row ) && ! empty( $header_row['name'] ) ) {
+							$header_value   = isset( $header_row['value'] ) ? $header_row['value'] : '';
+							$header_lines[] = $header_row['name'] . ': ' . $header_value;
+						}
+					}
+					?>
+					<input type="hidden" name="wp_stream_webhook_headers" value="<?php echo esc_attr( implode( "\n", $header_lines ) ); ?>" />
+					<?php
+				}
+				if ( ! empty( $alert->alert_meta['body_template'] ) ) {
+					?>
+					<input type="hidden" name="wp_stream_webhook_body_template" value="<?php echo esc_attr( $alert->alert_meta['body_template'] ); ?>" />
+					<?php
+				}
 				break;
 			case 'alert_status':
 				$post_status_object = get_post_status_object( get_post_status( $post_id ) );
@@ -312,7 +344,11 @@ class Alerts_List {
 				<?php
 				$function_name = 'display_' . $type . '_box';
 				$the_post      = get_post();
-				call_user_func( array( $this->plugin->alerts->admin_ui, $function_name ), $the_post );
+				$args          = array( $the_post );
+				if ( 'notification' === $type ) {
+					$args[] = false;
+				}
+				call_user_func_array( array( $this->plugin->alerts->admin_ui, $function_name ), $args );
 				?>
 			</fieldset>
 			<?php

--- a/classes/class-alerts.php
+++ b/classes/class-alerts.php
@@ -106,6 +106,7 @@ class Alerts {
 			'email',
 			'ifttt',
 			'slack',
+			'webhook',
 		);
 
 		$classes = array();

--- a/tests/e2e/admin-ui-smoke.spec.js
+++ b/tests/e2e/admin-ui-smoke.spec.js
@@ -112,4 +112,14 @@ test.describe( 'Admin UI smoke', () => {
 		const empty = page.locator( '.no-items, .post-state' );
 		await expect( list.or( empty ).first() ).toBeVisible();
 	} );
+
+	test( 'new alert type list includes webhook and omits IFTTT', async () => {
+		await page.goto( '/wp-admin/edit.php?post_type=wp_stream_alerts' );
+		await page.locator( 'a.page-title-action' ).click();
+		const form = page.locator( '#add-new-alert' );
+		await expect( form ).toBeVisible();
+		const typeSelect = form.locator( '#wp_stream_alert_type' );
+		await expect( typeSelect.locator( 'option[value="webhook"]' ) ).toHaveCount( 1 );
+		await expect( typeSelect.locator( 'option[value="ifttt"]' ) ).toHaveCount( 0 );
+	} );
 } );

--- a/tests/e2e/alert-create.spec.js
+++ b/tests/e2e/alert-create.spec.js
@@ -21,10 +21,12 @@ test.describe.configure( { mode: 'serial' } );
 
 /** List-table row id (`post-{ID}`) of the alert this spec created. */
 let createdAlertRowId = '';
+let createdWebhookRowId = '';
 
 test.afterAll( async ( { browser } ) => {
 	const page = await newAuthedPage( browser );
-	await trashCreatedAlert( page );
+	await trashCreatedAlert( page, createdAlertRowId );
+	await trashCreatedAlert( page, createdWebhookRowId );
 	await page.context().close();
 } );
 
@@ -66,6 +68,38 @@ test.describe( 'Alert create', () => {
 			page.locator( '#the-list tr.highlight-yellow' ).first(),
 		).toBeVisible();
 	} );
+
+	test( 'creates an outgoing webhook alert', async ( { page } ) => {
+		await page.goto( '/wp-admin/edit.php?post_type=wp_stream_alerts' );
+		const existingIds = await listAlertRowIds( page );
+
+		await page.locator( 'a.page-title-action' ).click();
+		const form = page.locator( '#add-new-alert' );
+		await expect( form ).toBeVisible();
+		await expect( form.locator( '#wp_stream_alert_type option[value="ifttt"]' ) ).toHaveCount(
+			0,
+		);
+
+		await form.locator( '#wp_stream_alert_type' ).selectOption( 'webhook' );
+		await expect( form.locator( '#wp_stream_webhook_url' ) ).toBeVisible();
+		await form.locator( '#wp_stream_webhook_url' ).fill( 'https://example.com/stream-hook' );
+		await form.locator( '#wp_stream_webhook_method' ).selectOption( 'POST' );
+
+		await form.locator( 'button.button-primary.save' ).click( {
+			noWaitAfter: true,
+		} );
+		await expect( page.locator( '#add-new-alert' ) ).toHaveCount( 0, {
+			timeout: 20_000,
+		} );
+
+		const afterIds = await listAlertRowIds( page );
+		createdWebhookRowId =
+			afterIds.find( ( id ) => ! existingIds.includes( id ) ) || '';
+		expect( createdWebhookRowId, 'Webhook alert row should appear after save' ).toBeTruthy();
+		await expect(
+			page.locator( `#the-list tr#${ createdWebhookRowId }` ),
+		).toContainText( /Outgoing Webhook/ );
+	} );
 } );
 
 /**
@@ -81,17 +115,17 @@ async function listAlertRowIds( wpPage ) {
 }
 
 /**
- * Trash only the alert this spec created so leftover "any event" highlight
- * rules do not paint every subsequent record.
+ * Trash an alert created by this spec so leftover rules do not affect later tests.
  *
  * @param {import('@playwright/test').Page} wpPage Page.
+ * @param {string}                          rowId  `post-{ID}` value.
  */
-async function trashCreatedAlert( wpPage ) {
-	if ( ! createdAlertRowId ) {
+async function trashCreatedAlert( wpPage, rowId ) {
+	if ( ! rowId ) {
 		return;
 	}
 	await wpPage.goto( '/wp-admin/edit.php?post_type=wp_stream_alerts' );
-	const row = wpPage.locator( `#the-list tr#${ createdAlertRowId }` );
+	const row = wpPage.locator( `#the-list tr#${ rowId }` );
 	if ( ! ( await row.isVisible().catch( () => false ) ) ) {
 		return;
 	}

--- a/tests/phpunit/Alerts_Test.php
+++ b/tests/phpunit/Alerts_Test.php
@@ -33,6 +33,8 @@ class Alerts_Test extends WP_StreamTestCase {
 		$this->assertArrayHasKey( 'none', $alerts->alert_types );
 		$this->assertArrayHasKey( 'highlight', $alerts->alert_types );
 		$this->assertArrayHasKey( 'email', $alerts->alert_types );
+		$this->assertArrayHasKey( 'webhook', $alerts->alert_types );
+		$this->assertArrayHasKey( 'ifttt', $alerts->alert_types );
 
 		$this->assertEquals( 1, $action->get_call_count() );
 	}
@@ -342,9 +344,10 @@ class Alerts_Test extends WP_StreamTestCase {
 	public function test_get_notification_values() {
 		$alerts = new Alerts( $this->plugin );
 
-		$count  = count( $alerts->alert_types );
 		$output = $alerts->admin_ui->get_notification_values();
-		$this->assertEquals( $count, count( $output ) );
+		$this->assertArrayHasKey( 'webhook', $output );
+		$this->assertArrayNotHasKey( 'ifttt', $output );
+		$this->assertSame( count( $alerts->alert_types ) - 1, count( $output ) );
 	}
 
 	public function test_get_actions() {

--- a/tests/phpunit/abilities/Ability_Create_Alert_Test.php
+++ b/tests/phpunit/abilities/Ability_Create_Alert_Test.php
@@ -147,6 +147,23 @@ class Ability_Create_Alert_Test extends Abilities_TestCase {
 		$this->assertEmpty( $alerts );
 	}
 
+	public function test_rejects_ifttt_as_not_creatable() {
+		wp_set_current_user( $this->admin_user_id );
+
+		$result = $this->ability->execute(
+			array(
+				'alert_type'      => 'ifttt',
+				'trigger_author'  => 'any',
+				'trigger_context' => 'posts',
+				'trigger_action'  => 'updated',
+			)
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'stream_alert_type_not_creatable', $result->get_error_code() );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+	}
+
 	public function test_respects_disabled_status() {
 		wp_set_current_user( $this->admin_user_id );
 

--- a/tests/phpunit/abilities/Ability_Get_Alerts_Test.php
+++ b/tests/phpunit/abilities/Ability_Get_Alerts_Test.php
@@ -211,6 +211,35 @@ class Ability_Get_Alerts_Test extends Abilities_TestCase {
 		$this->assertStringNotContainsString( $maker_key, (string) wp_json_encode( $row ) );
 	}
 
+	public function test_webhook_url_is_redacted() {
+		wp_set_current_user( $this->admin_user_id );
+
+		$url = 'https://example.test/outgoing-webhook/secret-path';
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'   => Alerts::POST_TYPE,
+				'post_status' => 'wp_stream_enabled',
+				'post_title'  => 'Outgoing webhook alert',
+			)
+		);
+		update_post_meta( $post_id, 'alert_type', 'webhook' );
+		update_post_meta(
+			$post_id,
+			'alert_meta',
+			array(
+				'url'    => $url,
+				'method' => 'POST',
+			)
+		);
+
+		$row = $this->find_alert_row( $this->ability->execute( array( 'status' => 'any' ) ), $post_id );
+
+		$this->assertArrayNotHasKey( 'url', (array) $row['alert_meta'] );
+		$this->assertTrue( ( (array) $row['alert_meta'] )['url_configured'] );
+		$this->assertStringNotContainsString( $url, (string) wp_json_encode( $row ) );
+	}
+
 	/**
 	 * An unconfigured secret reports false rather than being reported as
 	 * present, so the marker is meaningful either way.

--- a/tests/phpunit/alerts/Alert_Type_Webhook_Test.php
+++ b/tests/phpunit/alerts/Alert_Type_Webhook_Test.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Integration tests for Alert_Type_Webhook.
+ *
+ * @package WP_Stream
+ */
+
+namespace WP_Stream;
+
+/**
+ * Class Alert_Type_Webhook_Test
+ *
+ * @package WP_Stream
+ * @group alerts
+ */
+class Alert_Type_Webhook_Test extends WP_StreamTestCase {
+
+	/**
+	 * Captured HTTP request from pre_http_request.
+	 *
+	 * @var array|null
+	 */
+	protected static $captured_http;
+
+	public function set_up(): void {
+		parent::set_up();
+		self::$captured_http = null;
+		add_filter( 'pre_http_request', array( self::class, 'capture_pre_http_request' ), 10, 3 );
+	}
+
+	public function tear_down(): void {
+		remove_filter( 'pre_http_request', array( self::class, 'capture_pre_http_request' ), 10 );
+		parent::tear_down();
+	}
+
+	/**
+	 * Short-circuit HTTP and record the request.
+	 *
+	 * @param false|array|\WP_Error $preempt Whether to short-circuit.
+	 * @param array                 $args    Request arguments.
+	 * @param string                $url     Request URL.
+	 * @return array
+	 */
+	public static function capture_pre_http_request( $preempt, $args, $url ) {
+		unset( $preempt );
+		self::$captured_http = array(
+			'url'  => $url,
+			'args' => $args,
+		);
+
+		return array(
+			'headers'  => array(),
+			'body'     => 'ok',
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'cookies'  => array(),
+			'filename' => null,
+		);
+	}
+
+	public function test_webhook_type_is_registered_and_creatable() {
+		$alerts = new Alerts( $this->plugin );
+
+		$this->assertArrayHasKey( 'webhook', $alerts->alert_types );
+		$this->assertInstanceOf( Alert_Type_Webhook::class, $alerts->alert_types['webhook'] );
+		$this->assertTrue( $alerts->alert_types['webhook']->creatable );
+		$this->assertFalse( $alerts->alert_types['ifttt']->creatable );
+	}
+
+	public function test_new_notification_values_include_webhook_not_ifttt() {
+		$alerts = new Alerts( $this->plugin );
+		$values = $alerts->admin_ui->get_notification_values();
+
+		$this->assertArrayHasKey( 'webhook', $values );
+		$this->assertSame( 'Outgoing Webhook', $values['webhook'] );
+		$this->assertArrayNotHasKey( 'ifttt', $values );
+		$this->assertArrayHasKey( 'ifttt', $alerts->admin_ui->get_notification_values( 'ifttt' ) );
+		$this->assertArrayHasKey( 'ifttt', $alerts->admin_ui->get_notification_values( '', false ) );
+	}
+
+	public function test_alert_posts_via_pre_http_request() {
+		$type              = new Alert_Type_Webhook( $this->plugin );
+		$alert             = new \stdClass();
+		$alert->alert_meta = array(
+			'url'           => 'https://example.com/stream-hook',
+			'method'        => 'POST',
+			'body_template' => '{"summary":{{summary}}}',
+		);
+
+		$type->alert(
+			1,
+			array(
+				'summary'   => 'Hello',
+				'connector' => 'posts',
+				'context'   => 'post',
+				'action'    => 'updated',
+				'user_id'   => 1,
+				'user_role' => 'administrator',
+				'ip'        => '127.0.0.1',
+				'object_id' => 1,
+				'blog_id'   => 1,
+				'created'   => '2026-09-07 12:00:00',
+			),
+			$alert
+		);
+
+		$this->assertNotNull( self::$captured_http );
+		$this->assertSame( 'https://example.com/stream-hook', self::$captured_http['url'] );
+		$this->assertSame( 'POST', self::$captured_http['args']['method'] );
+		$decoded = json_decode( self::$captured_http['args']['body'], true );
+		$this->assertSame( 'Hello', $decoded['summary'] );
+	}
+
+	public function test_alert_skips_invalid_url_without_http() {
+		$type              = new Alert_Type_Webhook( $this->plugin );
+		$alert             = new \stdClass();
+		$alert->alert_meta = array(
+			'url' => 'ftp://example.com/nope',
+		);
+
+		$type->alert( 1, array( 'summary' => 'Hello' ), $alert );
+
+		$this->assertNull( self::$captured_http );
+	}
+}

--- a/tests/phpunit/unit/Alert_Type_Webhook_Unit_Test.php
+++ b/tests/phpunit/unit/Alert_Type_Webhook_Unit_Test.php
@@ -1,0 +1,224 @@
+<?php
+namespace WP_Stream;
+
+use Brain\Monkey\Functions;
+use Mockery;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+
+class Alert_Type_Webhook_Unit_Test extends TestCase {
+
+	/**
+	 * Last arguments passed to wp_safe_remote_request.
+	 *
+	 * @var array|null
+	 */
+	protected static $last_request;
+
+	/**
+	 * Type under test.
+	 *
+	 * @var Alert_Type_Webhook
+	 */
+	protected $type;
+
+	protected function set_up() {
+		parent::set_up();
+		self::$last_request = null;
+		Functions\when( 'is_admin' )->justReturn( false );
+		Functions\when( 'wp_parse_args' )->alias( array( self::class, 'wp_parse_args_stub' ) );
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+		Functions\when( 'is_wp_error' )->justReturn( false );
+
+		require_once dirname( __DIR__, 3 ) . '/alerts/class-alert-type-webhook.php';
+
+		$plugin     = Mockery::mock( Plugin::class );
+		$this->type = new Alert_Type_Webhook( $plugin );
+	}
+
+	/**
+	 * Merge defaults like wp_parse_args.
+	 *
+	 * @param array $args     Incoming args.
+	 * @param array $defaults Defaults.
+	 * @return array
+	 */
+	public static function wp_parse_args_stub( $args, $defaults = array() ) {
+		return array_merge( $defaults, (array) $args );
+	}
+
+	/**
+	 * Treat non-empty http(s) URLs as valid.
+	 *
+	 * @param string $url URL.
+	 * @return string|false
+	 */
+	public static function validate_url_stub( $url ) {
+		if ( 0 === strpos( (string) $url, 'https://' ) || 0 === strpos( (string) $url, 'http://' ) ) {
+			return $url;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Capture wp_safe_remote_request arguments.
+	 *
+	 * @param string $url  Request URL.
+	 * @param array  $args Request args.
+	 * @return array
+	 */
+	public static function capture_remote_request( $url, $args ) {
+		self::$last_request = array(
+			'url'  => $url,
+			'args' => $args,
+		);
+
+		return array(
+			'body'     => 'ok',
+			'response' => array(
+				'code' => 200,
+			),
+		);
+	}
+
+	/**
+	 * Sample record used by placeholder tests.
+	 *
+	 * @return array
+	 */
+	protected function sample_record() {
+		return array(
+			'summary'   => 'Updated "Hello"',
+			'connector' => 'posts',
+			'context'   => 'post',
+			'action'    => 'updated',
+			'user_id'   => 7,
+			'user_role' => 'administrator',
+			'ip'        => '203.0.113.10',
+			'object_id' => 42,
+			'blog_id'   => 1,
+			'created'   => '2026-09-07 12:00:00',
+		);
+	}
+
+	public function test_substitute_placeholders_json_encodes_values() {
+		$template = '{"summary":{{summary}},"connector":{{connector}}}';
+		$body     = Alert_Type_Webhook::substitute_placeholders( $template, $this->sample_record() );
+		$decoded  = json_decode( $body, true );
+
+		$this->assertIsArray( $decoded );
+		$this->assertSame( 'Updated "Hello"', $decoded['summary'] );
+		$this->assertSame( 'posts', $decoded['connector'] );
+	}
+
+	public function test_missing_placeholder_fields_become_empty_strings() {
+		$body    = Alert_Type_Webhook::substitute_placeholders( '{"ip":{{ip}}}', array() );
+		$decoded = json_decode( $body, true );
+
+		$this->assertSame( '', $decoded['ip'] );
+	}
+
+	/**
+	 * Host and other blocked header names are dropped.
+	 *
+	 * @param string $name Header name.
+	 *
+	 * @dataProvider data_blocked_header_names
+	 */
+	#[DataProvider( 'data_blocked_header_names' )]
+	public function test_blocked_headers_are_omitted( $name ) {
+		$headers = Alert_Type_Webhook::build_request_headers(
+			'application/json',
+			array(
+				array(
+					'name'  => $name,
+					'value' => 'evil.example',
+				),
+				array(
+					'name'  => 'X-Stream-Token',
+					'value' => 'abc',
+				),
+			)
+		);
+
+		$this->assertArrayNotHasKey( $name, $headers );
+		$this->assertSame( 'abc', $headers['X-Stream-Token'] );
+		$this->assertSame( 'application/json', $headers['Content-Type'] );
+	}
+
+	/**
+	 * Blocked HTTP header names.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public static function data_blocked_header_names() {
+		return array(
+			'host'              => array( 'Host' ),
+			'content_length'    => array( 'Content-Length' ),
+			'transfer_encoding' => array( 'Transfer-Encoding' ),
+		);
+	}
+
+	public function test_unknown_content_type_falls_back_to_json() {
+		$this->assertSame( 'application/json', Alert_Type_Webhook::sanitize_content_type( 'text/html' ) );
+	}
+
+	public function test_alert_skips_request_when_url_invalid() {
+		Functions\when( 'wp_http_validate_url' )->justReturn( false );
+		Functions\expect( 'wp_safe_remote_request' )->never();
+
+		$alert              = new \stdClass();
+		$alert->alert_meta  = array(
+			'url'    => 'not-a-url',
+			'method' => 'POST',
+		);
+
+		$this->type->alert( 1, $this->sample_record(), $alert );
+		$this->assertNull( self::$last_request );
+	}
+
+	public function test_alert_skips_request_when_url_empty() {
+		Functions\when( 'wp_http_validate_url' )->justReturn( false );
+		Functions\expect( 'wp_safe_remote_request' )->never();
+
+		$alert             = new \stdClass();
+		$alert->alert_meta = array(
+			'url' => '',
+		);
+
+		$this->type->alert( 1, $this->sample_record(), $alert );
+	}
+
+	public function test_alert_sends_put_with_substituted_body() {
+		Functions\when( 'wp_http_validate_url' )->alias( array( self::class, 'validate_url_stub' ) );
+		Functions\expect( 'wp_safe_remote_request' )
+			->once()
+			->andReturnUsing( array( self::class, 'capture_remote_request' ) );
+
+		$alert             = new \stdClass();
+		$alert->alert_meta = array(
+			'url'           => 'https://example.com/hooks/stream',
+			'method'        => 'PUT',
+			'content_type'  => 'application/json',
+			'headers'       => array(
+				array(
+					'name'  => 'X-Stream-Token',
+					'value' => 'secret',
+				),
+			),
+			'body_template' => '{"summary":{{summary}},"action":{{action}}}',
+		);
+
+		$this->type->alert( 9, $this->sample_record(), $alert );
+
+		$this->assertSame( 'https://example.com/hooks/stream', self::$last_request['url'] );
+		$this->assertSame( 'PUT', self::$last_request['args']['method'] );
+		$this->assertSame( 15, self::$last_request['args']['timeout'] );
+		$this->assertSame( 'secret', self::$last_request['args']['headers']['X-Stream-Token'] );
+
+		$decoded = json_decode( self::$last_request['args']['body'], true );
+		$this->assertSame( 'Updated "Hello"', $decoded['summary'] );
+		$this->assertSame( 'updated', $decoded['action'] );
+	}
+}

--- a/tests/phpunit/unit/Alerts_Admin_UI_Unit_Test.php
+++ b/tests/phpunit/unit/Alerts_Admin_UI_Unit_Test.php
@@ -104,20 +104,33 @@ class Alerts_Admin_UI_Unit_Test extends TestCase {
 	 * @return array<string, object>
 	 */
 	protected function sample_alert_types() {
-		$none            = new \stdClass();
-		$none->slug      = 'none';
-		$none->name      = 'Do Nothing';
-		$highlight       = new \stdClass();
-		$highlight->slug = 'highlight';
-		$highlight->name = 'Highlight';
-		$email           = new \stdClass();
-		$email->slug     = 'email';
-		$email->name     = 'Email';
+		$none                 = new \stdClass();
+		$none->slug           = 'none';
+		$none->name           = 'Do Nothing';
+		$none->creatable      = true;
+		$highlight            = new \stdClass();
+		$highlight->slug      = 'highlight';
+		$highlight->name      = 'Highlight';
+		$highlight->creatable = true;
+		$email                = new \stdClass();
+		$email->slug          = 'email';
+		$email->name          = 'Email';
+		$email->creatable     = true;
+		$ifttt                = new \stdClass();
+		$ifttt->slug          = 'ifttt';
+		$ifttt->name          = 'IFTTT';
+		$ifttt->creatable     = false;
+		$webhook              = new \stdClass();
+		$webhook->slug        = 'webhook';
+		$webhook->name        = 'Outgoing Webhook';
+		$webhook->creatable   = true;
 
 		return array(
 			'none'      => $none,
 			'highlight' => $highlight,
 			'email'     => $email,
+			'ifttt'     => $ifttt,
+			'webhook'   => $webhook,
 		);
 	}
 
@@ -148,10 +161,13 @@ class Alerts_Admin_UI_Unit_Test extends TestCase {
 		);
 	}
 
-	public function test_get_notification_values_count_matches_alert_types() {
+	public function test_get_notification_values_omits_non_creatable_types() {
 		$values = $this->admin_ui->get_notification_values();
 
-		$this->assertCount( count( $this->plugin->alerts->alert_types ), $values );
+		$this->assertArrayHasKey( 'webhook', $values );
+		$this->assertArrayNotHasKey( 'ifttt', $values );
+		$this->assertArrayHasKey( 'ifttt', $this->admin_ui->get_notification_values( 'ifttt' ) );
+		$this->assertArrayHasKey( 'ifttt', $this->admin_ui->get_notification_values( '', false ) );
 	}
 
 	public function test_display_status_box_outputs_enabled_and_disabled() {


### PR DESCRIPTION
Fixes XWPENG-56.

Adds a generic Outgoing Webhook alert (URL, POST or PUT, optional headers, JSON body with record-field placeholders). IFTTT is not offered when creating a new alert; existing IFTTT alerts still fire and remain editable. Maker recipes can be migrated by pointing a webhook at `https://maker.ifttt.com/trigger/{event}/with/key/{key}`.

Stacked on #1995.

## Test plan

- [ ] New-alert type list includes Outgoing Webhook and omits IFTTT.
- [ ] Saving a webhook alert stores URL and method and shows “Outgoing Webhook” in the list.
- [ ] An existing IFTTT alert still shows Maker fields on inline edit.
- [ ] Ability create rejects `ifttt`; `stream/get-alerts` redacts webhook `url` and `headers`.