### PR TITLE
Stop tracking Jetpack modules that no longer exist.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 ### Enhancements
 
 - Add an Outgoing Webhook alert (HTTP POST or PUT, optional headers, JSON body with record-field placeholders). IFTTT is no longer offered when creating a new alert; existing IFTTT alerts still fire. To keep using Maker, configure a webhook whose URL is `https://maker.ifttt.com/trigger/{event}/with/key/{key}`.
+- Stop tracking Jetpack modules that no longer exist (Google+ authorship, Mobile theme, Custom CSS). Remaining Jetpack module logging was audited against Jetpack 15.5 on 2026-09-07.
 
 ### Development
 

--- a/connectors/class-connector-jetpack.php
+++ b/connectors/class-connector-jetpack.php
@@ -1,6 +1,14 @@
 <?php
 /**
- * Connector for Jetpack
+ * Connector for Jetpack.
+ *
+ * Tracks Jetpack modules that still exist on disk as of 2026-09-07 (Jetpack 15.5):
+ * carousel, comments, infinite-scroll, likes, monitor, post-by-email, protect,
+ * publicize, related-posts, sharedaddy, sso, stats, subscriptions, tiled-gallery,
+ * verification-tools, videopress.
+ *
+ * Context labels for modules Jetpack no longer ships (custom-css, gplus-authorship,
+ * minileven) stay so existing Stream records still show a translated name.
  *
  * @package WP_Stream
  */
@@ -97,18 +105,21 @@ class Connector_Jetpack extends Connector {
 	/**
 	 * Return translated context labels
 	 *
+	 * Labels for modules Jetpack no longer ships remain so historical records
+	 * do not fall back to the raw context slug.
+	 *
 	 * @return array Context label translations
 	 */
 	public function get_context_labels() {
 		return array(
 			'blogs'              => esc_html_x( 'Blogs', 'jetpack', 'stream' ),
 			'carousel'           => esc_html_x( 'Carousel', 'jetpack', 'stream' ),
-			'custom-css'         => esc_html_x( 'Custom CSS', 'jetpack', 'stream' ),
-			'gplus-authorship'   => esc_html_x( 'Google+ Profile', 'jetpack', 'stream' ),
+			'custom-css'         => esc_html_x( 'Custom CSS', 'jetpack', 'stream' ), // DEPRECATED.
+			'gplus-authorship'   => esc_html_x( 'Google+ Profile', 'jetpack', 'stream' ), // DEPRECATED.
 			'infinite-scroll'    => esc_html_x( 'Infinite Scroll', 'jetpack', 'stream' ),
 			'jetpack-comments'   => esc_html_x( 'Comments', 'jetpack', 'stream' ),
 			'likes'              => esc_html_x( 'Likes', 'jetpack', 'stream' ),
-			'minileven'          => esc_html_x( 'Mobile', 'jetpack', 'stream' ),
+			'minileven'          => esc_html_x( 'Mobile', 'jetpack', 'stream' ), // DEPRECATED.
 			'modules'            => esc_html_x( 'Modules', 'jetpack', 'stream' ),
 			'monitor'            => esc_html_x( 'Monitor', 'jetpack', 'stream' ),
 			'options'            => esc_html_x( 'Options', 'jetpack', 'stream' ),
@@ -197,8 +208,6 @@ class Connector_Jetpack extends Connector {
 		$this->options = array(
 			'jetpack_options'                   => null,
 			// Sharing module.
-			'hide_gplus'                        => null,
-			'gplus_authors'                     => null,
 			'sharing-options'                   => array(
 				'label'   => esc_html__( 'Sharing options', 'stream' ),
 				'context' => 'sharedaddy',
@@ -222,15 +231,6 @@ class Connector_Jetpack extends Connector {
 			'disabled_likes'                    => array(
 				'label'   => esc_html__( 'WP.com Site-wide Likes', 'stream' ),
 				'context' => 'likes',
-			),
-			// Mobile.
-			'wp_mobile_excerpt'                 => array(
-				'label'   => esc_html__( 'Excerpts appearance', 'stream' ),
-				'context' => 'minileven',
-			),
-			'wp_mobile_app_promos'              => array(
-				'label'   => esc_html__( 'App promos', 'stream' ),
-				'context' => 'minileven',
 			),
 		);
 
@@ -665,59 +665,6 @@ class Connector_Jetpack extends Connector {
 	}
 
 	/**
-	 * Logs Google+ profile display status
-	 *
-	 * @param string $old_value  Old status.
-	 * @param string $new_value  New status.
-	 * @return null|bool
-	 */
-	public function check_hide_gplus( $old_value, $new_value ) {
-		$status = ! is_null( $new_value );
-
-		if ( $status && $old_value ) {
-			return false;
-		}
-
-		$this->log(
-			/* translators: Placeholder refers to a status (e.g. "enabled") */
-			__( 'G+ profile display %s', 'stream' ),
-			array(
-				'action' => $status ? esc_html__( 'enabled', 'stream' ) : esc_html__( 'disabled', 'stream' ),
-			),
-			null,
-			'gplus-authorship',
-			'updated'
-		);
-	}
-
-	/**
-	 * Logs if current user's Google+ account connection status
-	 *
-	 * @param string $old_value  Old status.
-	 * @param string $new_value  New status.
-	 * @return void
-	 */
-	public function check_gplus_authors( $old_value, $new_value ) {
-		unset( $old_value );
-
-		$user      = wp_get_current_user();
-		$connected = is_array( $new_value ) && array_key_exists( $user->ID, $new_value );
-
-		$this->log(
-			/* translators: %1$s: a user display name, %2$s: a status (e.g. "Jane Doe", "connected") */
-			__( '%1$s\'s Google+ account %2$s', 'stream' ),
-			array(
-				'display_name' => $user->display_name,
-				'action'       => $connected ? esc_html__( 'connected', 'stream' ) : esc_html__( 'disconnected', 'stream' ),
-				'user_id'      => $user->ID,
-			),
-			$user->ID,
-			'gplus-authorship',
-			'updated'
-		);
-	}
-
-	/**
 	 * Logs sharedaddy resource status.
 	 *
 	 * @param string $old_value  Old status.
@@ -767,18 +714,6 @@ class Connector_Jetpack extends Connector {
 				$data['context']         = $overrides['context'];
 				$data['connector']       = $this->name;
 			}
-		} elseif ( 'posts' === $data['connector'] && 'safecss' === $data['context'] ) {
-			$data = array_merge(
-				$data,
-				array(
-					'connector' => $this->name,
-					'message'   => esc_html__( 'Custom CSS updated', 'stream' ),
-					'args'      => array(),
-					'object_id' => null,
-					'context'   => 'custom-css',
-					'action'    => 'updated',
-				)
-			);
 		}
 
 		return $data;

--- a/tests/phpunit/connectors/Connector_Jetpack_Test.php
+++ b/tests/phpunit/connectors/Connector_Jetpack_Test.php
@@ -44,6 +44,35 @@ class Connector_Jetpack_Test extends WP_StreamTestCase {
 		$this->assertTrue( class_exists( 'Jetpack', 'Jetpack is inactive' ) );
 	}
 
+	/**
+	 * Dead modules are not tracked. Their context labels stay for historical records.
+	 */
+	public function test_removed_modules_are_not_tracked() {
+		$labels = $this->mock->get_context_labels();
+
+		$this->assertArrayHasKey( 'gplus-authorship', $labels );
+		$this->assertArrayHasKey( 'minileven', $labels );
+		$this->assertArrayHasKey( 'custom-css', $labels );
+
+		$this->assertArrayHasKey( 'carousel', $labels );
+		$this->assertArrayHasKey( 'sharedaddy', $labels );
+		$this->assertArrayHasKey( 'videopress', $labels );
+
+		$this->assertArrayNotHasKey( 'hide_gplus', $this->mock->options );
+		$this->assertArrayNotHasKey( 'gplus_authors', $this->mock->options );
+		$this->assertArrayNotHasKey( 'wp_mobile_excerpt', $this->mock->options );
+		$this->assertArrayNotHasKey( 'wp_mobile_app_promos', $this->mock->options );
+
+		$safecss = array(
+			'connector' => 'posts',
+			'context'   => 'safecss',
+			'message'   => 'Post updated',
+			'args'      => array( 'option' => 'unused' ),
+		);
+
+		$this->assertSame( $safecss, $this->mock->log_override( $safecss ) );
+	}
+
 	public function test_callback_jetpack_log_entry_activate() {
 		$this->mock->expects( $this->once() )
 			->method( 'log' )


### PR DESCRIPTION
Fixes XWPENG-57.

Stops logging Jetpack modules that no longer exist on disk as of Jetpack 15.5 (Google+ authorship, Mobile theme, Custom CSS). Context labels for those modules remain so historical Stream records still display a translated name.

Stacked on #1999.

## Test plan

- [ ] Remaining Jetpack modules still produce Stream records.
- [ ] Option changes for the removed modules are not logged.
- [ ] Historical records with those contexts still show Custom CSS, Google+ Profile, and Mobile.