### PR TITLE
Replace Select2 with native selects on the records filter screen.

### DIFF
--- a/classes/class-admin-assets.php
+++ b/classes/class-admin-assets.php
@@ -44,7 +44,6 @@ class Admin_Assets {
 			$this->admin->plugin->enqueue_asset(
 				'admin',
 				array(
-					$this->admin->plugin->with_select2(),
 					$this->admin->plugin->with_jquery_timeago(),
 				),
 				array(

--- a/classes/class-list-table.php
+++ b/classes/class-list-table.php
@@ -337,23 +337,6 @@ class List_Table extends \WP_List_Table {
 		if ( 'user_id' === $column ) {
 			$all_records = array();
 
-			// If the number of users exceeds the max users constant value then return an empty array and use AJAX instead.
-			$user_count  = count_users();
-			$total_users = $user_count['total_users'];
-
-			if ( $total_users > $this->plugin->admin->preload_users_max ) {
-				$selected_user = wp_stream_filter_input( INPUT_GET, 'user_id' );
-				if ( $selected_user ) {
-					$user = new Author( $selected_user );
-
-					return array(
-						$selected_user => $user->get_display_name(),
-					);
-				} else {
-					return array();
-				}
-			}
-
 			$users = array_map(
 				function ( $user_id ) {
 					return new Author( $user_id );
@@ -599,22 +582,30 @@ class List_Table extends \WP_List_Table {
 	 * @return void
 	 */
 	public function filter_select( $name, $title, $items, $ajax = false ) {
-		$selected = wp_stream_filter_input( INPUT_GET, $name );
+		$selected    = wp_stream_filter_input( INPUT_GET, $name );
+		$placeholder = sprintf(
+			/* translators: %s: the title of the dropdown menu (e.g. "users") */
+			__( 'Show all %s', 'stream' ),
+			$title
+		);
+		$select_id = 'stream-filter-' . $name;
+
+		echo '<div class="stream-filter-control">';
 
 		printf(
-			'<select name="%1$s" class="chosen-select" data-placeholder="%2$s">',
-			esc_attr( $name ),
-			esc_attr(
-				sprintf(
-					/* translators: %s: the title of the dropdown menu (e.g. "users") */
-					__( 'Show all %s', 'stream' ),
-					$title
-				)
-			)
+			'<label class="screen-reader-text" for="%1$s">%2$s</label>',
+			esc_attr( $select_id ),
+			esc_html( $placeholder )
 		);
 
-		// First option should be empty.
-		echo '<option value=""></option>';
+		printf(
+			'<select name="%1$s" id="%2$s" class="chosen-select" data-placeholder="%3$s">',
+			esc_attr( $name ),
+			esc_attr( $select_id ),
+			esc_attr( $placeholder )
+		);
+
+		printf( '<option value="">%s</option>', esc_html( $placeholder ) );
 
 		foreach ( $items as $key => $item ) {
 			$value       = isset( $item['children'] ) ? 'group-' . $key : $key;
@@ -648,6 +639,7 @@ class List_Table extends \WP_List_Table {
 		}
 
 		echo '</select>';
+		echo '</div>';
 	}
 
 	/**
@@ -784,7 +776,6 @@ class List_Table extends \WP_List_Table {
 		}
 		echo '</select></div>';
 		wp_nonce_field( 'stream_record_actions_nonce', 'stream_record_actions_nonce' );
-		wp_nonce_field( 'stream_filters_user_search_nonce', 'stream_filters_user_search_nonce' );
 
 		printf( '<input type="hidden" name="page" value="%s">', esc_attr( wp_stream_filter_input( INPUT_GET, 'page' ) ) );
 		printf( '<input type="hidden" name="date_predefined" value="%s">', esc_attr( wp_stream_filter_input( INPUT_GET, 'date_predefined' ) ) );

--- a/src/css/admin.scss
+++ b/src/css/admin.scss
@@ -221,13 +221,16 @@ more custom columns squeezes the summary column to a narrow strip.
 	display: inline;
 }
 
-.toplevel_page_wp_stream .select2-container {
+.toplevel_page_wp_stream .stream-filter-control {
+	display: inline-block;
 	margin-right: 6px;
 	margin-bottom: 6px;
+	vertical-align: top;
 }
 
-.toplevel_page_wp_stream .select2-container.select2-allowclear .select2-choice abbr {
-	margin-top: -2px;
+.toplevel_page_wp_stream .stream-filter-control select {
+	max-width: 165px;
+	vertical-align: middle;
 }
 
 

--- a/src/js/admin.js
+++ b/src/js/admin.js
@@ -22,100 +22,20 @@ if ( 'en' === window[ 'wp-stream-admin' ].locale && 'undefined' !== typeof $.tim
 
 $( 'li.toplevel_page_wp_stream ul li.wp-first-item.current' ).parent().parent().find( '.update-plugins' ).remove();
 
-$( '.toplevel_page_wp_stream :input.chosen-select' ).each(
-	function( i, el ) {
-		let args = {};
-		function templateResult( record ) {
-			const $result = $( '<span>' );
-			const $elem = $( record.element );
-			let icon = '';
-
-			if ( '- ' === record.text.substring( 0, 2 ) ) {
-				record.text = record.text.substring( 2 );
-			}
-
-			if ( 'undefined' !== typeof record.id && 'string' === typeof record.id ) {
-				if ( record.id.indexOf( 'group-' ) === 0 ) {
-					$result.addClass( 'parent' );
-				} else if ( $elem.hasClass( 'level-2' ) ) {
-					$result.addClass( 'child' );
-				}
-			}
-
-			if ( undefined !== record.icon ) {
-				icon = record.icon;
-			} else if ( undefined !== $elem && '' !== $elem.data( 'icon' ) ) {
-				icon = $elem.data( 'icon' );
-			}
-
-			if ( icon ) {
-				$result.html( '<img src="' + icon + '" class="wp-stream-select2-icon">' );
-			}
-			$result.append( record.text );
-
-			return $result;
-		}
-		function templateSelection( record ) {
-			if ( '- ' === record.text.substring( 0, 2 ) ) {
-				record.text = record.text.substring( 2 );
-			}
-			return record.text;
-		}
-
-		if ( $( el ).find( 'option' ).not( ':selected' ).not( ':empty' ).length > 0 ) {
-			args = {
-				minimumResultsForSearch: 10,
-				templateResult,
-				templateSelection,
-				allowClear: true,
-				width: '165px',
-			};
-		} else {
-			args = {
-				minimumInputLength: 3,
-				allowClear: true,
-				width: '165px',
-				ajax: {
-					url: window.ajaxurl,
-					delay: 500,
-					dataType: 'json',
-					quietMillis: 100,
-					data( term ) {
-						return {
-							action: 'wp_stream_filters',
-							nonce: $( '#stream_filters_user_search_nonce' ).val(),
-							filter: $( el ).attr( 'name' ),
-							q: term.term,
-						};
-					},
-					processResults( data ) {
-						const results = [];
-						$.each(
-							data, function( index, item ) {
-								results.push(
-									{
-										id: item.id,
-										text: item.label,
-									},
-								);
-							},
-						);
-						return {
-							results,
-						};
-					},
-				},
-				templateResult,
-				templateSelection,
-			};
-		}
-
-		$( el ).select2( args );
-	},
-);
+/**
+ * Filter control wrapper (or the select itself) for screen-option visibility.
+ *
+ * @param {string} name Filter field name.
+ * @return {Object} Control to show or hide.
+ */
+function getRecordsFilterControl( name ) {
+	const $named = $( '.alignleft.actions [name="' + name + '"]' ).first();
+	const $control = $named.closest( '.stream-filter-control' );
+	return $control.length ? $control : $named;
+}
 
 const $queryVars = getQueryVars();
-const $contextInput = $( '.toplevel_page_wp_stream select.chosen-select[name="context"]' );
+const $contextInput = $( '#record-filter-form select.chosen-select[name="context"]' );
 
 if ( ( 'undefined' === typeof $queryVars.context || '' === $queryVars.context ) && 'undefined' !== typeof $queryVars.connector ) {
 	$contextInput.val( 'group-' + $queryVars.connector );
@@ -131,9 +51,9 @@ $( 'input[type=submit]', '#record-filter-form' ).click(
 
 $( '#record-filter-form' ).submit(
 	function() {
-		const	$context = $( '.toplevel_page_wp_stream :input.chosen-select[name="context"]' ),
+		const	$context = $( '#record-filter-form select.chosen-select[name="context"]' ),
 			$option = $context.find( 'option:selected' ),
-			$connector = $context.parent().find( '.record-filter-connector' ),
+			$connector = $( '#record-filter-form .record-filter-connector' ),
 			optionConnector = $option.data( 'group' ),
 			optionClass = $option.prop( 'class' ),
 			$recordAction = $( '.recordactions select' );
@@ -269,11 +189,14 @@ $( document ).ready(
 				all_hidden = false;
 			}
 
-			const divs = $( 'div.alignleft.actions div.select2-container' );
-
-			divs.each(
+			$( 'div.alignleft.actions select.chosen-select' ).each(
 				function() {
-					if ( ! $( this ).is( ':hidden' ) ) {
+					const name = $( this ).prop( 'name' );
+					if ( 'date_predefined' === name ) {
+						return;
+					}
+					const $control = getRecordsFilterControl( name );
+					if ( $control.length && ! $control.is( ':hidden' ) ) {
 						all_hidden = false;
 						return false;
 					}
@@ -298,11 +221,15 @@ $( document ).ready(
 		$( 'div.actions select.chosen-select' ).each(
 			function() {
 				const name = $( this ).prop( 'name' );
+				if ( 'date_predefined' === name ) {
+					return;
+				}
+				const $control = getRecordsFilterControl( name );
 
 				if ( $( 'div.metabox-prefs [name="' + name + '-hide"]' ).is( ':checked' ) ) {
-					$( this ).prev( '.select2-container' ).show();
+					$control.show();
 				} else {
-					$( this ).prev( '.select2-container' ).hide();
+					$control.hide();
 				}
 			},
 		);
@@ -321,11 +248,12 @@ $( document ).ready(
 					}
 				} else {
 					id = id.replace( '-hide', '' );
+					const $control = getRecordsFilterControl( id );
 
 					if ( $( this ).is( ':checked' ) ) {
-						$( '[name="' + id + '"]' ).prev( '.select2-container' ).show();
+						$control.show();
 					} else {
-						$( '[name="' + id + '"]' ).prev( '.select2-container' ).hide();
+						$control.hide();
 					}
 				}
 
@@ -407,12 +335,6 @@ const intervals = {
 					datepickers.datepicker( 'widget' ).addClass( 'stream-datepicker' );
 				}
 
-				predefined.select2(
-					{
-						allowClear: true,
-					},
-				);
-
 				if ( '' !== from.val() ) {
 					from_remove.show();
 				}
@@ -442,9 +364,6 @@ const intervals = {
 							if ( $.datepicker && datepickers.datepicker( 'widget' ).is( ':visible' ) ) {
 								datepickers.datepicker( 'refresh' ).datepicker( 'hide' );
 							}
-						},
-						'select2-removed'() {
-							predefined.val( '' ).trigger( 'change' );
 						},
 						check_options() {
 							if ( '' !== to.val() && '' !== from.val() ) {

--- a/tests/e2e/admin-ui-smoke.spec.js
+++ b/tests/e2e/admin-ui-smoke.spec.js
@@ -11,11 +11,11 @@ import { newAuthedPage } from './helpers/stream-plugin';
 /**
  * Admin UI smoke test for the Stream plugin.
  *
- * Loads the main Stream admin screens and asserts that core
- * jQuery-dependent widgets render and that no uncaught JS errors
- * are emitted. Intended to catch regressions from upstream jQuery,
- * jQuery UI, or select2 version bumps that the unit / integration
- * suites do not exercise.
+ * Loads the main Stream admin screens and asserts that the records-screen
+ * native selects and the jQuery UI datepicker render, and that no uncaught
+ * JS errors are emitted. Intended to catch regressions from upstream jQuery
+ * or jQuery UI version bumps that the unit / integration suites do not
+ * exercise.
  */
 
 test.describe.configure( { mode: 'serial' } );
@@ -75,9 +75,6 @@ test.describe( 'Admin UI smoke', () => {
 		await page.goto( '/wp-admin/admin.php?page=wp_stream' );
 
 		// The date inputs are revealed only when the "Custom" range is selected.
-		// The visible UI is a select2 widget on top of the real <select>, so set
-		// the value on the native element and dispatch the change event jQuery
-		// listens for.
 		await page.evaluate( () => {
 			const select = document.querySelector(
 				'select[name="date_predefined"]',
@@ -92,13 +89,13 @@ test.describe( 'Admin UI smoke', () => {
 		await expect( page.locator( '#ui-datepicker-div' ) ).toBeVisible();
 	} );
 
-	test( 'opens a select2 dropdown', async () => {
+	test( 'uses native selects on the records filters', async () => {
 		await page.goto( '/wp-admin/admin.php?page=wp_stream' );
-		const select2 = page.locator( '.select2-selection' ).first();
-		await expect( select2 ).toBeVisible();
-		await select2.click();
-		await expect( page.locator( '.select2-dropdown' ) ).toBeVisible();
-		await page.keyboard.press( 'Escape' );
+		await expect(
+			page.locator( '#record-filter-form select[name="context"]' ),
+		).toBeVisible();
+		await expect( page.locator( '.select2-dropdown' ) ).toHaveCount( 0 );
+		await expect( page.locator( '.select2-container' ) ).toHaveCount( 0 );
 	} );
 
 	test( 'loads the Settings tab', async () => {

--- a/tests/phpunit/Admin_Assets_Test.php
+++ b/tests/phpunit/Admin_Assets_Test.php
@@ -66,6 +66,9 @@ class Admin_Assets_Test extends WP_StreamTestCase {
 
 		$this->assertTrue( wp_style_is( 'wp-stream-admin' ), 'wp-stream-admin style is enqueued' );
 
+		// select2 remains enqueued via the admin-exclude bundle dependency until
+		// that screen migrates off it; the records screen itself no longer runs
+		// any select2 initialization (see the e2e native-selects assertions).
 		$this->assertTrue( wp_script_is( 'wp-stream-select2' ), 'wp-stream-select2 script is enqueued' );
 		$this->assertTrue( wp_script_is( 'wp-stream-select2-en' ), 'wp-stream-select2-en script is enqueued' );
 		$this->assertTrue( wp_script_is( 'wp-stream-jquery-timeago' ), 'wp-stream-jquery-timeago script is enqueued' );


### PR DESCRIPTION
Fixes XWPENG-54.

The records screen filter bar now uses the native `<select>` elements the server already renders, with no Select2 initialization. Each control gets a screen-reader label, a visible placeholder option, and a stable ID; screen-option visibility targets the select wrapper instead of Select2 DOM.

The user filter lists every user (all users + super-admins + WP-CLI). Sites with many users see a larger `<select>` until the Ajax combobox in #2011. The unused user-search nonce field and the admin bundle's select2 dependency are dropped (still enqueued via admin-exclude until #2010). Other Select2 screens are unchanged.

Stacked on #2000.

## Test plan

- [ ] Records filter bar uses native selects (no Select2 containers).
- [ ] Each filter has an accessible label and a visible placeholder option.
- [ ] Screen-option toggles still show/hide the matching filter.
- [ ] Filtering by user, connector, context, and action still works.
- [ ] Settings and alert-config Select2 screens are unchanged.